### PR TITLE
docs: improve README examples with Maven test command and Spock explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,12 +122,18 @@ ID,NAME,EMAIL
 ### 3. Run Test
 
 ```bash
+# Gradle
 ./gradlew test
+
+# Maven
+./mvnw test
 ```
 
 ## Usage Examples
 
 ### JUnit with Spring Boot
+
+Requires `@ExtendWith(SpringBootDatabaseTestExtension.class)` to enable the extension. The DataSource is automatically discovered from the Spring ApplicationContext.
 
 ```java
 @SpringBootTest
@@ -148,15 +154,26 @@ class UserRepositoryTest {
 
 ### Spock
 
+No explicit extension annotation required. The extension is automatically registered via Spock's global extension mechanism (`IGlobalExtension`). You only need to provide a `getDbTesterRegistry()` property accessor.
+
 ```groovy
 class UserRepositorySpec extends Specification {
 
     @Shared
-    DataSourceRegistry dbTesterRegistry
+    DataSource dataSource
+
+    @Shared
+    DataSourceRegistry registry
+
+    // Property accessor required by the framework
+    DataSourceRegistry getDbTesterRegistry() {
+        return registry
+    }
 
     def setupSpec() {
-        dbTesterRegistry = new DataSourceRegistry()
-        dbTesterRegistry.registerDefault(createDataSource())
+        dataSource = createDataSource()
+        registry = new DataSourceRegistry()
+        registry.registerDefault(dataSource)
     }
 
     @Preparation


### PR DESCRIPTION
## Summary

Improve README documentation with clearer examples and explanations.

## Changes

### Run Test Section
- Add Maven test command example alongside Gradle

### JUnit with Spring Boot
- Add explanation that `@ExtendWith(SpringBootDatabaseTestExtension.class)` is required
- Note that DataSource is automatically discovered from Spring ApplicationContext

### Spock
- Fix example code to use correct `getDbTesterRegistry()` property accessor pattern
- Add explanation that no explicit extension annotation is required
- Explain that extension is automatically registered via Spock's `IGlobalExtension` mechanism