### PR TITLE
docs: add Japanese documentation with VitePress i18n support

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -7,7 +7,6 @@ export default withMermaid({
   base: '/db-tester/',
 
   srcDir: 'specs',
-  lang: 'en-US',
   lastUpdated: true,
   cleanUrls: true,
 
@@ -22,30 +21,85 @@ export default withMermaid({
     ['link', { rel: 'icon', type: 'image/svg+xml', href: '/db-tester/favicon.svg' }],
   ],
 
+  locales: {
+    root: {
+      label: 'English',
+      lang: 'en-US',
+      themeConfig: {
+        nav: [
+          { text: 'Home', link: '/' },
+          { text: 'Overview', link: '/01-overview' },
+        ],
+        sidebar: [
+          {
+            text: 'Specifications',
+            items: [
+              { text: 'Overview', link: '/01-overview' },
+              { text: 'Architecture', link: '/02-architecture' },
+              { text: 'Public API', link: '/03-public-api' },
+              { text: 'Configuration', link: '/04-configuration' },
+              { text: 'Data Formats', link: '/05-data-formats' },
+              { text: 'Database Operations', link: '/06-database-operations' },
+              { text: 'Test Frameworks', link: '/07-test-frameworks' },
+              { text: 'SPI', link: '/08-spi' },
+              { text: 'Error Handling', link: '/09-error-handling' },
+            ],
+          },
+        ],
+        editLink: {
+          pattern: 'https://github.com/seijikohara/db-tester/edit/main/docs/specs/:path',
+          text: 'Edit this page on GitHub',
+        },
+      },
+    },
+    ja: {
+      label: '日本語',
+      lang: 'ja-JP',
+      themeConfig: {
+        nav: [
+          { text: 'ホーム', link: '/ja/' },
+          { text: '概要', link: '/ja/01-overview' },
+        ],
+        sidebar: [
+          {
+            text: '仕様',
+            items: [
+              { text: '概要', link: '/ja/01-overview' },
+              { text: 'アーキテクチャ', link: '/ja/02-architecture' },
+              { text: 'パブリックAPI', link: '/ja/03-public-api' },
+              { text: '設定', link: '/ja/04-configuration' },
+              { text: 'データフォーマット', link: '/ja/05-data-formats' },
+              { text: 'データベース操作', link: '/ja/06-database-operations' },
+              { text: 'テストフレームワーク', link: '/ja/07-test-frameworks' },
+              { text: 'SPI', link: '/ja/08-spi' },
+              { text: 'エラーハンドリング', link: '/ja/09-error-handling' },
+            ],
+          },
+        ],
+        outline: { label: '目次', level: [2, 3] },
+        docFooter: {
+          prev: '前のページ',
+          next: '次のページ',
+        },
+        lastUpdated: { text: '最終更新' },
+        editLink: {
+          pattern: 'https://github.com/seijikohara/db-tester/edit/main/docs/specs/:path',
+          text: 'GitHubで編集',
+        },
+        returnToTopLabel: 'トップに戻る',
+        sidebarMenuLabel: 'メニュー',
+        darkModeSwitchLabel: 'テーマ',
+        lightModeSwitchTitle: 'ライトモードに切り替え',
+        darkModeSwitchTitle: 'ダークモードに切り替え',
+        langMenuLabel: '言語',
+        skipToContentLabel: 'コンテンツへスキップ',
+      },
+    },
+  },
+
   themeConfig: {
     logo: '/favicon.svg',
-
-    nav: [
-      { text: 'Home', link: '/' },
-      { text: 'Overview', link: '/01-overview' },
-    ],
-
-    sidebar: [
-      {
-        text: 'Specifications',
-        items: [
-          { text: 'Overview', link: '/01-overview' },
-          { text: 'Architecture', link: '/02-architecture' },
-          { text: 'Public API', link: '/03-public-api' },
-          { text: 'Configuration', link: '/04-configuration' },
-          { text: 'Data Formats', link: '/05-data-formats' },
-          { text: 'Database Operations', link: '/06-database-operations' },
-          { text: 'Test Frameworks', link: '/07-test-frameworks' },
-          { text: 'SPI', link: '/08-spi' },
-          { text: 'Error Handling', link: '/09-error-handling' },
-        ],
-      },
-    ],
+    externalLinkIcon: true,
 
     socialLinks: [
       { icon: 'github', link: 'https://github.com/seijikohara/db-tester' },
@@ -58,11 +112,29 @@ export default withMermaid({
 
     search: {
       provider: 'local',
-    },
-
-    editLink: {
-      pattern: 'https://github.com/seijikohara/db-tester/edit/main/docs/specs/:path',
-      text: 'Edit this page on GitHub',
+      options: {
+        locales: {
+          ja: {
+            translations: {
+              button: {
+                buttonText: '検索',
+                buttonAriaLabel: '検索',
+              },
+              modal: {
+                displayDetails: '詳細を表示',
+                resetButtonTitle: 'リセット',
+                backButtonTitle: '戻る',
+                noResultsText: '検索結果が見つかりません',
+                footer: {
+                  selectText: '選択',
+                  navigateText: '移動',
+                  closeText: '閉じる',
+                },
+              },
+            },
+          },
+        },
+      },
     },
   },
 

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,0 +1,114 @@
+/**
+ * Custom styles for VitePress home layout.
+ *
+ * The home layout does not apply the `.vp-doc` class to markdown content,
+ * so code blocks lack syntax highlighting styles. This file extends the
+ * default VitePress styles to the home layout content.
+ */
+
+/* Apply vp-doc styles to home layout markdown content */
+.VPHome .vp-doc,
+.VPHomeContent > div {
+  max-width: 784px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* Ensure code blocks in home layout have proper styling */
+.VPHomeContent div[class*="language-"],
+.VPHomeContent .vp-code-group {
+  margin: 16px 0;
+  border-radius: 8px;
+}
+
+/* Code group tabs in home layout */
+.VPHomeContent .vp-code-group .tabs {
+  background-color: var(--vp-code-tab-bg);
+}
+
+/* Apply syntax highlighting styles to home layout code blocks */
+.VPHomeContent pre {
+  background-color: var(--vp-code-block-bg);
+  border-radius: 8px;
+  padding: 20px 24px;
+  overflow-x: auto;
+}
+
+.VPHomeContent code {
+  font-family: var(--vp-font-family-mono);
+  font-size: var(--vp-code-font-size);
+}
+
+/* Inline code styling for home layout */
+.VPHomeContent :not(pre) > code {
+  background-color: var(--vp-code-bg);
+  border-radius: 4px;
+  padding: 3px 6px;
+}
+
+/* Custom container styles for home layout */
+.VPHomeContent .custom-block {
+  margin: 16px 0;
+  padding: 16px 16px 8px;
+  border-radius: 8px;
+}
+
+.VPHomeContent .custom-block.tip {
+  background-color: var(--vp-custom-block-tip-bg);
+  border-color: var(--vp-custom-block-tip-border);
+}
+
+.VPHomeContent .custom-block.info {
+  background-color: var(--vp-custom-block-info-bg);
+  border-color: var(--vp-custom-block-info-border);
+}
+
+.VPHomeContent .custom-block.warning {
+  background-color: var(--vp-custom-block-warning-bg);
+  border-color: var(--vp-custom-block-warning-border);
+}
+
+.VPHomeContent .custom-block.danger {
+  background-color: var(--vp-custom-block-danger-bg);
+  border-color: var(--vp-custom-block-danger-border);
+}
+
+/* Heading styles for home layout markdown content */
+.VPHomeContent h2 {
+  margin-top: 48px;
+  margin-bottom: 16px;
+  padding-top: 24px;
+  border-top: 1px solid var(--vp-c-divider);
+  letter-spacing: -0.02em;
+  line-height: 32px;
+  font-size: 24px;
+}
+
+.VPHomeContent h2:first-child {
+  margin-top: 24px;
+  border-top: none;
+  padding-top: 0;
+}
+
+.VPHomeContent h3 {
+  margin-top: 32px;
+  margin-bottom: 16px;
+  font-size: 20px;
+  line-height: 28px;
+}
+
+/* Paragraph and list styles */
+.VPHomeContent p {
+  margin: 16px 0;
+  line-height: 28px;
+}
+
+.VPHomeContent ul,
+.VPHomeContent ol {
+  margin: 16px 0;
+  padding-left: 1.25rem;
+}
+
+.VPHomeContent li {
+  margin: 8px 0;
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,4 +1,5 @@
 import DefaultTheme from 'vitepress/theme'
 import '@catppuccin/vitepress/theme/mocha/mauve.css'
+import './custom.css'
 
 export default DefaultTheme

--- a/docs/specs/ja/01-overview.md
+++ b/docs/specs/ja/01-overview.md
@@ -1,0 +1,141 @@
+# DB Tester仕様 - 概要
+
+DB Testerフレームワークの概要を説明します。
+
+## 目的
+
+DB Testerは、JUnitおよびSpock Framework向けのデータベーステストフレームワークです。CSV/TSVベースのテストデータファイルを使用し、アノテーション駆動型のデータ準備と状態検証を提供します。
+
+本フレームワークは、データベーステストにおける以下の課題を解決します。
+
+| 課題 | 解決策 |
+|------|--------|
+| テストデータ管理 | 構造化されたディレクトリ内のファイルベースのデータセット |
+| 反復的なセットアップコード | 宣言的な`@Preparation`および`@Expectation`アノテーション |
+| 複数データベースのテスト | 明示的なバインディングを持つ名前付き`DataSource`レジストリ |
+| テストの分離 | `CLEAN_INSERT`操作による自動クリーンアップ |
+| データフォーマットの柔軟性 | CSVおよびTSVフォーマットのサポート |
+
+## 主要概念
+
+### 準備フェーズ
+
+準備フェーズは、各テストメソッドの実行前に実行されます。以下の処理を行います。
+
+1. テストクラスとメソッド名に基づいてデータセットファイルを解決
+2. 必要に応じてシナリオマーカーで行をフィルタリング
+3. 設定されたデータベース操作を適用（デフォルト: `CLEAN_INSERT`）
+
+### 検証フェーズ
+
+検証フェーズは、各テストメソッドの実行後に実行されます。以下の処理を行います。
+
+1. 指定されたディレクトリ（デフォルト: `expected/`サブディレクトリ）から期待データセットを読み込み
+2. データベースから実際のデータを読み取り
+3. 設定可能な比較戦略を使用して期待値と実際の状態を比較
+
+### 規約ベースの検出
+
+データセットの場所は自動的に解決されます。
+
+```
+src/test/resources/
+└── {package}/{TestClassName}/
+    ├── TABLE_NAME.csv           # 準備データ
+    └── expected/
+        └── TABLE_NAME.csv       # 検証データ
+```
+
+### シナリオフィルタリング
+
+複数のテストメソッドでシナリオマーカーを使用してデータセットファイルを共有できます。
+
+| [Scenario] | id | name |
+|------------|----|------|
+| testCreate | 1  | Alice |
+| testUpdate | 2  | Bob |
+
+現在のテストメソッド名に基づいて行がフィルタリングされます。
+
+## 設計思想
+
+### 設定より規約
+
+適切なデフォルトを確立することで明示的な設定を最小限に抑えます。
+
+- データセットの場所はテストクラスのパッケージと名前から導出
+- 検証サフィックスはデフォルトで`/expected`
+- シナリオマーカーカラムはデフォルトで`[Scenario]`
+- データフォーマットはデフォルトでCSV
+
+### APIと実装の分離
+
+パブリックAPIと内部実装は明確に分離されています。
+
+| レイヤー | 可視性 | 目的 |
+|----------|--------|------|
+| `db-tester-api` | パブリック | アノテーション、設定、SPIインターフェース |
+| `db-tester-core` | 内部 | JDBC操作、フォーマット解析、SPI実装 |
+
+テストフレームワークモジュール（`db-tester-junit`、`db-tester-spock`）は、コンパイル時にAPIモジュールのみに依存します。coreモジュールはJava ServiceLoader経由でランタイム時に読み込まれます。
+
+### イミュータビリティ
+
+すべてのパブリックAPIクラスはイミュータブルです。
+
+- 設定レコードはJavaの`record`型を使用
+- 値オブジェクト（TableName、ColumnName、CellValue）はfinalでイミュータブル
+- 返されるコレクションは変更不可
+
+### Nullセーフティ
+
+nullセーフティのためにJSpecifyアノテーションを使用します。
+
+- すべてのパッケージは`package-info.java`で`@NullMarked`を宣言
+- nullableなパラメータと戻り値の型は`@Nullable`アノテーションを使用
+- NullAwayがコンパイル時にnullセーフティを強制
+
+## 技術要件
+
+| コンポーネント | バージョン | 備考 |
+|----------------|------------|------|
+| Java | 21以降 | JPMS module-info.javaサポート |
+| Groovy | 5以降 | Spockモジュール用 |
+| JUnit | 6以降 | JUnit Jupiter拡張モデル |
+| Spock Framework | 2以降 | アノテーション駆動型拡張モデル |
+| Spring Boot | 4以降 | Spring Boot Starterモジュール用 |
+
+### データベース互換性
+
+標準のJDBC操作を使用し、JDBC準拠のすべてのデータベースをサポートします。
+
+- H2
+- MySQL
+- PostgreSQL
+- Derby
+- HSQLDB
+- MS SQL Server
+- Oracle
+
+## モジュール概要
+
+| モジュール | 説明 | ドキュメント |
+|------------|------|--------------|
+| `db-tester-api` | パブリックAPIモジュール | [アーキテクチャ](02-architecture) |
+| `db-tester-core` | 内部実装 | [アーキテクチャ](02-architecture) |
+| `db-tester-junit` | JUnit Jupiter拡張 | [テストフレームワーク](07-test-frameworks) |
+| `db-tester-spock` | Spock Framework拡張 | [テストフレームワーク](07-test-frameworks) |
+| `db-tester-junit-spring-boot-starter` | JUnit用Spring Boot統合 | [テストフレームワーク](07-test-frameworks) |
+| `db-tester-spock-spring-boot-starter` | Spock用Spring Boot統合 | [テストフレームワーク](07-test-frameworks) |
+| `db-tester-bom` | 依存関係管理のためのBill of Materials | - |
+
+## 関連仕様
+
+- [アーキテクチャ](02-architecture) - モジュール構造と依存関係
+- [パブリックAPI](03-public-api) - アノテーションと設定クラス
+- [設定](04-configuration) - 設定オプションと規約
+- [データフォーマット](05-data-formats) - CSV/TSVファイル構造と解析
+- [データベース操作](06-database-operations) - サポートされるCRUD操作
+- [テストフレームワーク](07-test-frameworks) - JUnitとSpockの統合
+- [SPI](08-spi) - サービスプロバイダーインターフェース拡張ポイント
+- [エラーハンドリング](09-error-handling) - エラーメッセージと例外型

--- a/docs/specs/ja/02-architecture.md
+++ b/docs/specs/ja/02-architecture.md
@@ -1,0 +1,325 @@
+# DB Tester仕様 - アーキテクチャ
+
+DB Testerフレームワークのモジュール構造、依存関係、およびアーキテクチャパターンについて説明します。
+
+## モジュール構造
+
+本フレームワークは、階層化されたアーキテクチャで構成された7つのモジュールから構成されています。
+
+```mermaid
+graph TD
+    BOM[db-tester-bom]
+
+    subgraph Core
+        API[db-tester-api]
+        CORE[db-tester-core]
+    end
+
+    subgraph "Test Frameworks"
+        JUNIT[db-tester-junit]
+        SPOCK[db-tester-spock]
+    end
+
+    subgraph "Spring Boot Starters"
+        JUNIT_STARTER[db-tester-junit-spring-boot-starter]
+        SPOCK_STARTER[db-tester-spock-spring-boot-starter]
+    end
+
+    BOM --> API
+    BOM --> CORE
+    BOM --> JUNIT
+    BOM --> SPOCK
+    BOM --> JUNIT_STARTER
+    BOM --> SPOCK_STARTER
+
+    CORE --> API
+    JUNIT -->|compile| API
+    JUNIT -.->|runtime| CORE
+    SPOCK -->|compile| API
+    SPOCK -.->|runtime| CORE
+    JUNIT_STARTER --> JUNIT
+    SPOCK_STARTER --> SPOCK
+```
+
+### モジュールの責務
+
+| モジュール | 責務 |
+|------------|------|
+| `db-tester-bom` | バージョン管理と依存関係の整合 |
+| `db-tester-api` | パブリックアノテーション、設定、SPIインターフェース |
+| `db-tester-core` | JDBC操作、フォーマット解析、SPI実装 |
+| `db-tester-junit` | JUnit Jupiter BeforeEach/AfterEachコールバック |
+| `db-tester-spock` | Spockアノテーション駆動型拡張とインターセプター |
+| `db-tester-junit-spring-boot-starter` | JUnit用Spring Boot自動設定 |
+| `db-tester-spock-spring-boot-starter` | Spock用Spring Boot自動設定 |
+
+## モジュール依存関係
+
+### APIモジュール（`db-tester-api`）
+
+APIモジュールは内部依存関係を持ちません。外部依存関係は以下の通りです。
+
+| 依存関係 | 目的 |
+|----------|------|
+| `org.jspecify:jspecify` | Nullセーフティアノテーション |
+| `java.sql` | `DataSource`インターフェース |
+
+### Coreモジュール（`db-tester-core`）
+
+| 依存関係 | スコープ | 目的 |
+|----------|----------|------|
+| `db-tester-api` | Compile | パブリックAPIクラス |
+| `org.jspecify:jspecify` | Compile | Nullセーフティアノテーション |
+| `org.slf4j:slf4j-api` | Compile | ロギング抽象化 |
+
+### テストフレームワークモジュール
+
+JUnitおよびSpockモジュールは、コンパイル時に`db-tester-api`に依存します。`db-tester-core`モジュールはServiceLoader経由でランタイム時に検出されます。
+
+| モジュール | コンパイル依存関係 | ランタイム依存関係 |
+|------------|-------------------|-------------------|
+| `db-tester-junit` | `db-tester-api`, `junit-jupiter-api` | `db-tester-core` |
+| `db-tester-spock` | `db-tester-api`, `spock-core` | `db-tester-core` |
+
+### Spring Boot Starterモジュール
+
+| モジュール | 依存関係 |
+|------------|----------|
+| `db-tester-junit-spring-boot-starter` | `db-tester-junit`, `db-tester-core`, `spring-boot-autoconfigure` |
+| `db-tester-spock-spring-boot-starter` | `db-tester-spock`, `db-tester-core`, `spring-boot-autoconfigure` |
+
+## パッケージ構成
+
+### APIモジュールパッケージ
+
+```
+io.github.seijikohara.dbtester.api
+├── annotation/
+│   ├── Preparation.java
+│   ├── Expectation.java
+│   └── DataSet.java
+├── assertion/
+│   ├── DatabaseAssertion.java
+│   └── AssertionFailureHandler.java
+├── config/
+│   ├── Configuration.java
+│   ├── ConventionSettings.java
+│   ├── DataFormat.java
+│   ├── DataSourceRegistry.java
+│   ├── OperationDefaults.java
+│   └── TableMergeStrategy.java
+├── context/
+│   └── TestContext.java
+├── dataset/
+│   ├── DataSet.java
+│   ├── Table.java
+│   └── Row.java
+├── domain/
+│   ├── CellValue.java
+│   ├── ColumnName.java
+│   ├── TableName.java
+│   ├── DataSourceName.java
+│   ├── Column.java
+│   ├── Cell.java
+│   ├── ColumnMetadata.java
+│   └── ComparisonStrategy.java
+├── exception/
+│   ├── DatabaseTesterException.java
+│   ├── ConfigurationException.java
+│   ├── DataSetLoadException.java
+│   ├── DataSourceNotFoundException.java
+│   ├── DatabaseOperationException.java
+│   └── ValidationException.java
+├── loader/
+│   └── DataSetLoader.java
+├── operation/
+│   ├── Operation.java
+│   └── TableOrderingStrategy.java
+├── scenario/
+│   ├── ScenarioName.java
+│   └── ScenarioNameResolver.java
+└── spi/
+    ├── AssertionProvider.java
+    ├── DataSetLoaderProvider.java
+    ├── ExpectationProvider.java
+    └── OperationProvider.java
+```
+
+### Coreモジュールパッケージ
+
+```
+io.github.seijikohara.dbtester.internal
+├── assertion/
+│   ├── ComparisonResult.java
+│   ├── DataSetComparator.java
+│   └── ExpectationVerifier.java
+├── dataset/
+│   ├── SimpleDataSet.java
+│   ├── SimpleTable.java
+│   ├── SimpleRow.java
+│   ├── ScenarioTable.java
+│   └── TableOrderingResolver.java
+├── domain/
+│   ├── ScenarioMarker.java
+│   ├── SchemaName.java
+│   ├── FileExtension.java
+│   └── StringIdentifier.java
+├── format/
+│   ├── TableOrdering.java
+│   ├── csv/CsvFormatProvider.java
+│   ├── tsv/TsvFormatProvider.java
+│   ├── parser/
+│   │   ├── DelimitedParser.java
+│   │   └── DelimiterConfig.java
+│   └── spi/
+│       ├── FormatProvider.java
+│       └── FormatRegistry.java
+├── jdbc/
+│   ├── Jdbc.java
+│   ├── read/
+│   │   ├── TableReader.java
+│   │   ├── TableOrderResolver.java
+│   │   └── TypeConverter.java
+│   └── write/
+│       ├── OperationExecutor.java
+│       ├── SqlBuilder.java
+│       ├── ParameterBinder.java
+│       ├── TableExecutor.java
+│       ├── InsertExecutor.java
+│       ├── UpdateExecutor.java
+│       ├── DeleteExecutor.java
+│       ├── RefreshExecutor.java
+│       └── TruncateExecutor.java
+├── loader/
+│   ├── TestClassNameBasedDataSetLoader.java
+│   ├── DefaultDataSetLoaderProvider.java
+│   ├── AnnotationResolver.java
+│   ├── DataSetFactory.java
+│   ├── DataSetMerger.java
+│   └── DirectoryResolver.java
+├── scenario/
+│   ├── ScenarioFilter.java
+│   ├── FilteredDataSet.java
+│   └── FilteredTable.java
+├── spi/
+│   ├── DefaultAssertionProvider.java
+│   ├── DefaultExpectationProvider.java
+│   ├── DefaultOperationProvider.java
+│   └── ScenarioNameResolverRegistry.java
+└── util/
+    └── TopologicalSorter.java
+```
+
+## アーキテクチャパターン
+
+### 階層化アーキテクチャ
+
+| レイヤー | モジュール | 責務 |
+|----------|----------|------|
+| プレゼンテーション | junit, spock, starters | テストフレームワーク統合 |
+| アプリケーション | api | パブリックインターフェースと契約 |
+| ドメイン | core (dataset, domain) | ビジネスロジックとエンティティ |
+| インフラストラクチャ | core (jdbc, format) | データベースおよびファイルシステムアクセス |
+
+### ドメイン駆動設計パターン
+
+| パターン | 実装 | 説明 |
+|----------|------|------|
+| 値オブジェクト | `TableName`, `ColumnName`, `CellValue` | 値による等価性を持つイミュータブルオブジェクト |
+| エンティティ | `Table`, `Row` | 集約内で識別子を持つオブジェクト |
+| 集約 | `DataSet` | 整合性境界を持つルートエンティティ |
+| ファクトリ | `DataSetFactory` | 複雑なオブジェクトの生成 |
+| リポジトリ | `DataSourceRegistry` | データソース管理 |
+| ドメインサービス | `DataSetComparator` | エンティティに対するステートレス操作 |
+
+### サービスプロバイダーインターフェース（SPI）
+
+モジュール間の疎結合のためにSPIを使用します。
+
+```mermaid
+flowchart LR
+    subgraph JUNIT[db-tester-junit]
+        U1[DataSetLoader]
+        U2[OperationProvider]
+        U3[ScenarioResolver]
+    end
+
+    subgraph CORE[db-tester-core]
+        P1[DataSetLoaderProvider]
+        P2[OperationProvider]
+        P3[ScenarioResolver]
+    end
+
+    JUNIT -->|ServiceLoader| CORE
+```
+
+### ストラテジーパターン
+
+操作と比較戦略はストラテジーパターンを使用します。
+
+| 戦略インターフェース | 実装 |
+|---------------------|------|
+| `Operation` enum | NONE, INSERT, UPDATE, DELETE, REFRESH, CLEAN_INSERTなど |
+| `ComparisonStrategy` | STRICT, IGNORE, NUMERIC, CASE_INSENSITIVE, TIMESTAMP_FLEXIBLE, NOT_NULL, REGEX |
+| `TableMergeStrategy` | FIRST, LAST, UNION, UNION_ALL |
+| `FormatProvider` | CsvFormatProvider, TsvFormatProvider |
+
+## JPMSサポート
+
+### 完全なモジュールサポート
+
+以下のモジュールは完全な`module-info.java`を提供します。
+
+| モジュール | モジュール名 |
+|------------|-------------|
+| `db-tester-api` | `io.github.seijikohara.dbtester.api` |
+| `db-tester-core` | `io.github.seijikohara.dbtester.core` |
+| `db-tester-junit` | `io.github.seijikohara.dbtester.junit` |
+
+### 自動モジュール名
+
+以下のモジュールは`MANIFEST.MF`で`Automatic-Module-Name`を使用します。
+
+| モジュール | Automatic-Module-Name |
+|------------|----------------------|
+| `db-tester-spock` | `io.github.seijikohara.dbtester.spock` |
+| `db-tester-junit-spring-boot-starter` | `io.github.seijikohara.dbtester.junit.spring.autoconfigure` |
+| `db-tester-spock-spring-boot-starter` | `io.github.seijikohara.dbtester.spock.spring.autoconfigure` |
+
+### モジュール依存関係
+
+APIモジュールの`module-info.java`の例を以下に示します。
+
+```java
+module io.github.seijikohara.dbtester.api {
+    requires transitive java.sql;
+    requires transitive org.jspecify;
+
+    exports io.github.seijikohara.dbtester.api.annotation;
+    exports io.github.seijikohara.dbtester.api.assertion;
+    exports io.github.seijikohara.dbtester.api.config;
+    exports io.github.seijikohara.dbtester.api.context;
+    exports io.github.seijikohara.dbtester.api.dataset;
+    exports io.github.seijikohara.dbtester.api.domain;
+    exports io.github.seijikohara.dbtester.api.exception;
+    exports io.github.seijikohara.dbtester.api.loader;
+    exports io.github.seijikohara.dbtester.api.operation;
+    exports io.github.seijikohara.dbtester.api.scenario;
+    exports io.github.seijikohara.dbtester.api.spi;
+
+    uses io.github.seijikohara.dbtester.api.spi.AssertionProvider;
+    uses io.github.seijikohara.dbtester.api.spi.DataSetLoaderProvider;
+    uses io.github.seijikohara.dbtester.api.spi.OperationProvider;
+    uses io.github.seijikohara.dbtester.api.spi.ExpectationProvider;
+    uses io.github.seijikohara.dbtester.api.scenario.ScenarioNameResolver;
+}
+```
+
+## 関連仕様
+
+- [概要](01-overview) - フレームワークの目的と主要概念
+- [パブリックAPI](03-public-api) - アノテーションと設定クラス
+- [設定](04-configuration) - 設定オプション
+- [テストフレームワーク](07-test-frameworks) - JUnitとSpockの統合
+- [SPI](08-spi) - サービスプロバイダーインターフェース拡張ポイント
+- [エラーハンドリング](09-error-handling) - エラーメッセージと例外型

--- a/docs/specs/ja/03-public-api.md
+++ b/docs/specs/ja/03-public-api.md
@@ -1,0 +1,381 @@
+# DB Tester仕様 - パブリックAPI
+
+`db-tester-api`モジュールが提供するパブリックAPIについて説明します。
+
+
+## アノテーション
+
+### @Preparation
+
+テストメソッド実行前に適用するデータセットを宣言します。
+
+**パッケージ**: `io.github.seijikohara.dbtester.api.annotation.Preparation`
+
+**ターゲット**: `METHOD`, `TYPE`
+
+**属性**:
+
+| 属性 | 型 | デフォルト | 説明 |
+|------|-----|-----------|------|
+| `dataSets` | `DataSet[]` | `{}` | 実行するデータセット。空の場合は規約ベースの検出を使用 |
+| `operation` | `Operation` | `CLEAN_INSERT` | 適用するデータベース操作 |
+| `tableOrdering` | `TableOrderingStrategy` | `AUTO` | テーブル処理順序を決定する戦略 |
+
+**アノテーションの継承**:
+
+- クラスレベルのアノテーションはサブクラスに継承されます
+- メソッドレベルのアノテーションはクラスレベルの宣言をオーバーライドします
+- `@Inherited`で注釈されています
+
+**例**:
+
+```java
+@Preparation
+void testMethod() { }
+
+@Preparation(operation = Operation.INSERT)
+void testWithInsertOnly() { }
+
+@Preparation(tableOrdering = TableOrderingStrategy.FOREIGN_KEY)
+void testWithForeignKeyOrdering() { }
+
+@Preparation(dataSets = @DataSet(resourceLocation = "custom/path"))
+void testWithCustomPath() { }
+```
+
+
+### @Expectation
+
+テスト実行後の期待されるデータベース状態を定義するデータセットを宣言します。
+
+**パッケージ**: `io.github.seijikohara.dbtester.api.annotation.Expectation`
+
+**ターゲット**: `METHOD`, `TYPE`
+
+**属性**:
+
+| 属性 | 型 | デフォルト | 説明 |
+|------|-----|-----------|------|
+| `dataSets` | `DataSet[]` | `{}` | 検証用データセット。空の場合は規約ベースの検出を使用 |
+| `tableOrdering` | `TableOrderingStrategy` | `AUTO` | 検証時のテーブル処理順序を決定する戦略 |
+
+**検証の動作**:
+
+- 読み取り専用の比較（データ変更なし）
+- 実際のデータベース状態を期待データセットと照合して検証
+- アサーション失敗はテストフレームワーク経由で報告
+
+**例**:
+
+```java
+@Preparation
+@Expectation
+void testWithVerification() { }
+
+@Expectation(dataSets = @DataSet(resourceLocation = "expected/custom"))
+void testWithCustomExpectation() { }
+
+@Expectation(tableOrdering = TableOrderingStrategy.ALPHABETICAL)
+void testWithAlphabeticalOrdering() { }
+```
+
+
+### @DataSet
+
+`@Preparation`または`@Expectation`内で個々のデータセットパラメータを設定します。
+
+**パッケージ**: `io.github.seijikohara.dbtester.api.annotation.DataSet`
+
+**ターゲット**: アノテーション配列内でのみ使用
+
+**属性**:
+
+| 属性 | 型 | デフォルト | 説明 |
+|------|-----|-----------|------|
+| `resourceLocation` | `String` | `""` | データセットディレクトリパス。空の場合は規約ベースの検出を使用 |
+| `dataSourceName` | `String` | `""` | 名前付きDataSource識別子。空の場合はデフォルトを使用 |
+| `scenarioNames` | `String[]` | `{}` | シナリオフィルタ。空の場合はテストメソッド名を使用 |
+
+**リソースロケーション形式**:
+
+| 形式 | 例 | 解決方法 |
+|------|-----|----------|
+| クラスパス相対 | `data/users` | テストクラスパスルートから |
+| クラスパスプレフィックス | `classpath:data/users` | 明示的なクラスパス解決 |
+| 絶対パス | `/tmp/testdata` | ファイルシステム絶対パス |
+| 空文字列 | `""` | 規約ベースの検出 |
+
+**例**:
+
+```java
+@Preparation(dataSets = {
+    @DataSet(dataSourceName = "primary"),
+    @DataSet(dataSourceName = "secondary", resourceLocation = "secondary-data")
+})
+void testMultipleDataSources() { }
+
+@Preparation(dataSets = @DataSet(scenarioNames = {"scenario1", "scenario2"}))
+void testMultipleScenarios() { }
+```
+
+
+## DataSetインターフェース
+
+### DataSet
+
+データベーステーブルの論理的なコレクションを表します。
+
+**パッケージ**: `io.github.seijikohara.dbtester.api.dataset.DataSet`
+
+**メソッド**:
+
+| メソッド | 戻り値型 | 説明 |
+|----------|---------|------|
+| `getTables()` | `List<Table>` | 宣言順序で格納されたテーブルのイミュータブルリストを返します |
+| `getTable(TableName)` | `Optional<Table>` | 名前でテーブルを検索します |
+| `getDataSource()` | `Optional<DataSource>` | 指定された場合、バインドされたDataSourceを返します |
+
+**保証事項**:
+
+- テーブル順序は保持されます（挿入順序）
+- 返されるすべてのコレクションはイミュータブルです
+- データセット内でテーブル名は一意です
+
+
+### Table
+
+データベーステーブルの構造とデータを表します。
+
+**パッケージ**: `io.github.seijikohara.dbtester.api.dataset.Table`
+
+**メソッド**:
+
+| メソッド | 戻り値型 | 説明 |
+|----------|---------|------|
+| `getName()` | `TableName` | テーブル識別子を返します |
+| `getColumns()` | `List<ColumnName>` | 定義順序でカラム名を返します |
+| `getRows()` | `List<Row>` | すべての行を返します（空の場合もあります） |
+| `getRowCount()` | `int` | 行数を返します |
+
+**保証事項**:
+
+- カラム順序はすべての行で一貫しています
+- 返されるすべてのコレクションはイミュータブルです
+- 行数は`getRows().size()`と等しくなります
+
+
+### Row
+
+単一のデータベースレコードを表します。
+
+**パッケージ**: `io.github.seijikohara.dbtester.api.dataset.Row`
+
+**メソッド**:
+
+| メソッド | 戻り値型 | 説明 |
+|----------|---------|------|
+| `getValues()` | `Map<ColumnName, CellValue>` | イミュータブルなカラム値マッピングを返します |
+| `getValue(ColumnName)` | `CellValue` | カラムの値を返します。存在しない場合は`CellValue.NULL` |
+
+
+## ドメイン値オブジェクト
+
+### CellValue
+
+明示的なnull処理でセル値をラップします。
+
+**パッケージ**: `io.github.seijikohara.dbtester.api.domain.CellValue`
+
+**型**: `record`
+
+**フィールド**:
+
+| フィールド | 型 | 説明 |
+|------------|-----|------|
+| `value` | `@Nullable Object` | ラップされた値 |
+
+**定数**:
+
+| 定数 | 説明 |
+|------|------|
+| `CellValue.NULL` | SQL NULLを表すシングルトン |
+
+**メソッド**:
+
+| メソッド | 戻り値型 | 説明 |
+|----------|---------|------|
+| `isNull()` | `boolean` | 値がnullの場合`true`を返します |
+
+
+### TableName
+
+データベーステーブルのイミュータブルな識別子です。
+
+**パッケージ**: `io.github.seijikohara.dbtester.api.domain.TableName`
+
+**型**: `record`
+
+**フィールド**:
+
+| フィールド | 型 | 説明 |
+|------------|-----|------|
+| `value` | `String` | テーブル名文字列 |
+
+
+### ColumnName
+
+テーブルカラムのイミュータブルな識別子です。
+
+**パッケージ**: `io.github.seijikohara.dbtester.api.domain.ColumnName`
+
+**型**: `record`
+
+**フィールド**:
+
+| フィールド | 型 | 説明 |
+|------------|-----|------|
+| `value` | `String` | カラム名文字列 |
+
+
+### DataSourceName
+
+登録済みDataSourceのイミュータブルな識別子です。
+
+**パッケージ**: `io.github.seijikohara.dbtester.api.domain.DataSourceName`
+
+**型**: `record`
+
+**フィールド**:
+
+| フィールド | 型 | 説明 |
+|------------|-----|------|
+| `value` | `String` | DataSource名文字列 |
+
+
+### ComparisonStrategy
+
+アサーション時の値比較動作を定義します。
+
+**パッケージ**: `io.github.seijikohara.dbtester.api.domain.ComparisonStrategy`
+
+**定義済み戦略**:
+
+| 戦略 | 説明 |
+|------|------|
+| `STRICT` | `equals()`を使用した完全一致（デフォルト） |
+| `IGNORE` | 比較を完全にスキップ |
+| `NUMERIC` | BigDecimalを使用した型を考慮した数値比較 |
+| `CASE_INSENSITIVE` | 大文字小文字を区別しない文字列比較 |
+| `TIMESTAMP_FLEXIBLE` | サブ秒精度とタイムゾーンを無視 |
+| `NOT_NULL` | 値がnullでないことを検証 |
+
+**ファクトリメソッド**:
+
+| メソッド | 説明 |
+|----------|------|
+| `regex(String)` | 正規表現パターンマッチャーを作成 |
+
+**比較動作**:
+
+| 戦略 | null/null | null/value | value/null | value/value |
+|------|-----------|------------|------------|-------------|
+| `STRICT` | true | false | false | equals() |
+| `IGNORE` | true | true | true | true |
+| `NUMERIC` | true | false | false | BigDecimal比較 |
+| `CASE_INSENSITIVE` | true | false | false | equalsIgnoreCase() |
+| `TIMESTAMP_FLEXIBLE` | true | false | false | 正規化比較 |
+| `NOT_NULL` | false | false | false | true |
+| `REGEX` | false | false | false | Pattern.matches() |
+
+
+## 例外
+
+すべての例外は`DatabaseTesterException`を継承します。
+
+### 例外階層
+
+```mermaid
+classDiagram
+    DatabaseTesterException <|-- ConfigurationException
+    DatabaseTesterException <|-- DataSetLoadException
+    DatabaseTesterException <|-- DataSourceNotFoundException
+    DatabaseTesterException <|-- DatabaseOperationException
+    DatabaseTesterException <|-- ValidationException
+```
+
+### DatabaseTesterException
+
+すべてのフレームワークエラーの基底例外です。
+
+**パッケージ**: `io.github.seijikohara.dbtester.api.exception.DatabaseTesterException`
+
+**コンストラクタ**:
+
+| コンストラクタ | 説明 |
+|----------------|------|
+| `DatabaseTesterException(String)` | メッセージのみ |
+| `DatabaseTesterException(String, Throwable)` | メッセージと原因 |
+| `DatabaseTesterException(Throwable)` | 原因のみ |
+
+
+### ConfigurationException
+
+無効なフレームワーク設定を示します。
+
+**一般的な原因**:
+
+- 必須の設定値が欠落
+- 無効なファイルパス
+- 互換性のない設定の組み合わせ
+
+
+### DataSetLoadException
+
+データセットファイルの読み込み失敗を示します。
+
+**一般的な原因**:
+
+- ファイルが見つからない
+- 無効なファイル形式
+- CSV/TSVコンテンツのパースエラー
+
+
+### DataSourceNotFoundException
+
+要求されたDataSourceが登録されていないことを示します。
+
+**一般的な原因**:
+
+- 名前付きDataSourceが`DataSourceRegistry`に登録されていない
+- 必要な場合にデフォルトDataSourceが設定されていない
+
+
+### DatabaseOperationException
+
+データベース操作の失敗を示します。
+
+**一般的な原因**:
+
+- SQL実行エラー
+- 制約違反
+- 接続失敗
+
+
+### ValidationException
+
+アサーションまたは検証の失敗を示します。
+
+**一般的な原因**:
+
+- 期待値と実際のデータの不一致
+- 行数の差異
+- カラム値の不一致
+
+**出力形式**: 検証エラーは人間が読みやすい要約に続いてYAML詳細を出力します。形式の詳細は[エラーハンドリング - 検証エラー](09-error-handling#検証エラー)を参照してください。
+
+
+## 関連仕様
+
+- [概要](01-overview) - フレームワークの紹介
+- [設定](04-configuration) - 設定クラス
+- [データベース操作](06-database-operations) - Operation enumの詳細

--- a/docs/specs/ja/04-configuration.md
+++ b/docs/specs/ja/04-configuration.md
@@ -1,0 +1,313 @@
+# DB Tester仕様 - 設定
+
+DB Testerフレームワークで利用可能な設定クラスとオプションについて説明します。
+
+
+## Configurationクラス
+
+データベーステスト拡張のランタイム設定を集約します。
+
+**パッケージ**: `io.github.seijikohara.dbtester.api.config.Configuration`
+
+**型**: `record`
+
+### コンポーネント
+
+| コンポーネント | 型 | 説明 |
+|---------------|-----|------|
+| `conventions` | `ConventionSettings` | データセットディレクトリ解決ルール |
+| `operations` | `OperationDefaults` | デフォルトのデータベース操作 |
+| `loader` | `DataSetLoader` | データセット読み込み戦略 |
+
+### ファクトリメソッド
+
+| メソッド | 説明 |
+|----------|------|
+| `defaults()` | すべてのフレームワークデフォルトで設定を作成 |
+| `withConventions(ConventionSettings)` | カスタム規約とデフォルトの操作およびローダー |
+| `withOperations(OperationDefaults)` | カスタム操作とデフォルトの規約およびローダー |
+| `withLoader(DataSetLoader)` | カスタムローダーとデフォルトの規約および操作 |
+
+### デフォルト動作
+
+`Configuration.defaults()`を使用する場合:
+
+1. 規約: `ConventionSettings.standard()`
+2. 操作: `OperationDefaults.standard()`
+3. ローダー: `DataSetLoaderProvider`からServiceLoader経由で読み込み
+
+### 使用例
+
+```java
+// JUnitの例 - @BeforeAllで設定をカスタマイズ
+@BeforeAll
+static void setup(ExtensionContext context) {
+    var conventions = ConventionSettings.standard()
+        .withDataFormat(DataFormat.TSV);
+    var config = Configuration.withConventions(conventions);
+    DatabaseTestExtension.setConfiguration(context, config);
+}
+```
+
+
+## ConventionSettings
+
+データセット検出とシナリオフィルタリングのための命名規約を定義します。
+
+**パッケージ**: `io.github.seijikohara.dbtester.api.config.ConventionSettings`
+
+**型**: `record`
+
+### フィールド
+
+| フィールド | 型 | デフォルト | 説明 |
+|------------|-----|-----------|------|
+| `baseDirectory` | `@Nullable String` | `null` | 絶対パスまたは相対ベースパス。nullの場合はクラスパス相対 |
+| `expectationSuffix` | `String` | `"/expected"` | 期待データセット用サブディレクトリ |
+| `scenarioMarker` | `String` | `"[Scenario]"` | シナリオフィルタリング用カラム名 |
+| `dataFormat` | `DataFormat` | `CSV` | データセットファイルのファイル形式 |
+| `tableMergeStrategy` | `TableMergeStrategy` | `UNION_ALL` | 重複テーブルのマージ戦略 |
+| `loadOrderFileName` | `String` | `"load-order.txt"` | テーブル読み込み順序指定用ファイル名 |
+
+### ファクトリメソッド
+
+| メソッド | 説明 |
+|----------|------|
+| `standard()` | すべてのデフォルトで設定を作成 |
+| `withDataFormat(DataFormat)` | 指定した形式でコピーを作成 |
+| `withTableMergeStrategy(TableMergeStrategy)` | 指定したマージ戦略でコピーを作成 |
+| `withLoadOrderFileName(String)` | 指定した読み込み順序ファイル名でコピーを作成 |
+
+### ディレクトリ解決
+
+`baseDirectory`がnull（デフォルト）の場合、データセットはテストクラスに対して相対的に解決されます:
+
+```
+src/test/resources/
+└── {test.class.package}/{TestClassName}/
+    ├── TABLE1.csv           # 準備データセット
+    ├── TABLE2.csv
+    └── expected/            # 期待データセット（サフィックスは設定可能）
+        ├── TABLE1.csv
+        └── TABLE2.csv
+```
+
+`baseDirectory`が指定されている場合:
+
+```
+{baseDirectory}/
+├── TABLE1.csv
+└── expected/
+    └── TABLE1.csv
+```
+
+### 期待サフィックス
+
+`expectationSuffix`は準備パスに追加されます:
+
+| 準備パス | サフィックス | 期待パス |
+|----------|-------------|----------|
+| `com/example/UserTest` | `/expected` | `com/example/UserTest/expected` |
+| `/data/test` | `/expected` | `/data/test/expected` |
+| `custom/path` | `/verify` | `custom/path/verify` |
+
+
+## DataSourceRegistry
+
+`javax.sql.DataSource`インスタンスのミュータブルレジストリです。
+
+**パッケージ**: `io.github.seijikohara.dbtester.api.config.DataSourceRegistry`
+
+### スレッドセーフティ
+
+- 名前付きデータソースには`ConcurrentHashMap`を使用
+- デフォルトデータソースには`volatile`フィールドを使用
+- `registerDefault()`と`clear()`は`synchronized`
+
+### 登録メソッド
+
+| メソッド | 説明 |
+|----------|------|
+| `registerDefault(DataSource)` | デフォルトデータソースを登録 |
+| `register(String, DataSource)` | 名前付きデータソースを登録。名前が空の場合は`registerDefault()`に委譲 |
+
+### 取得メソッド
+
+| メソッド | 戻り値型 | 説明 |
+|----------|---------|------|
+| `getDefault()` | `DataSource` | デフォルトを返す。未登録の場合は例外をスロー |
+| `get(String)` | `DataSource` | 名前付きまたはデフォルトを返す。見つからない場合は例外をスロー |
+| `find(String)` | `Optional<DataSource>` | 名前付きデータソースをOptionalとして返す |
+
+### クエリメソッド
+
+| メソッド | 戻り値型 | 説明 |
+|----------|---------|------|
+| `hasDefault()` | `boolean` | デフォルトが登録されているかチェック |
+| `has(String)` | `boolean` | 名前付きデータソースが存在するかチェック |
+
+### 管理メソッド
+
+| メソッド | 説明 |
+|----------|------|
+| `clear()` | 登録済みのすべてのデータソースを削除 |
+
+### 解決優先順位
+
+`get(name)`を呼び出す場合:
+
+1. 名前が空でない場合、名前で検索
+2. 名前が空または見つからない場合、デフォルトにフォールバック
+3. どちらも見つからない場合、`DataSourceNotFoundException`をスロー
+
+### 使用例
+
+```java
+@BeforeAll
+static void setup(ExtensionContext context) {
+    var registry = DatabaseTestExtension.getRegistry(context);
+
+    // 単一データベース
+    registry.registerDefault(primaryDataSource);
+
+    // 複数データベース
+    registry.register("primary", primaryDataSource);
+    registry.register("secondary", secondaryDataSource);
+}
+```
+
+
+## OperationDefaults
+
+準備フェーズと期待フェーズのデフォルトデータベース操作を定義します。
+
+**パッケージ**: `io.github.seijikohara.dbtester.api.config.OperationDefaults`
+
+**型**: `record`
+
+### フィールド
+
+| フィールド | 型 | デフォルト | 説明 |
+|------------|-----|-----------|------|
+| `preparation` | `Operation` | `CLEAN_INSERT` | テスト実行前に実行されるデフォルト操作 |
+| `expectation` | `Operation` | `NONE` | テスト終了後に実行されるデフォルト操作 |
+
+### ファクトリメソッド
+
+| メソッド | 説明 |
+|----------|------|
+| `standard()` | 準備に`CLEAN_INSERT`、期待に`NONE`のデフォルトを作成 |
+
+
+## DataFormat
+
+データセットファイルでサポートされるファイル形式を定義します。
+
+**パッケージ**: `io.github.seijikohara.dbtester.api.config.DataFormat`
+
+**型**: `enum`
+
+### 値
+
+| 値 | 拡張子 | フィールド区切り文字 |
+|----|--------|---------------------|
+| `CSV` | `.csv` | カンマ（`,`） |
+| `TSV` | `.tsv` | タブ（`\t`） |
+
+### メソッド
+
+| メソッド | 戻り値型 | 説明 |
+|----------|---------|------|
+| `getExtension()` | `String` | ドットを含むファイル拡張子を返す |
+
+### ファイル検出
+
+ディレクトリからデータセットを読み込む場合:
+
+1. 設定された形式拡張子に一致するすべてのファイルをリスト
+2. 各ファイルをテーブルとして解析（拡張子を除いたファイル名 = テーブル名）
+3. 他の拡張子のファイルは無視
+
+
+## TableMergeStrategy
+
+複数のデータセットからのテーブルをマージする方法を定義します。
+
+**パッケージ**: `io.github.seijikohara.dbtester.api.config.TableMergeStrategy`
+
+**型**: `enum`
+
+### 値
+
+| 値 | 説明 | 例 |
+|----|------|-----|
+| `FIRST` | 最初の出現のみを保持 | [A,B] + [C,D] = [A,B] |
+| `LAST` | 最後の出現のみを保持 | [A,B] + [C,D] = [C,D] |
+| `UNION` | マージして重複を除去 | [A,B] + [B,C] = [A,B,C] |
+| `UNION_ALL` | マージして重複を保持（デフォルト） | [A,B] + [B,C] = [A,B,B,C] |
+
+### マージ動作
+
+データセットはアノテーション宣言順に処理されます:
+
+```java
+@Preparation(dataSets = {
+    @DataSet(resourceLocation = "dataset1"),  // 最初に処理
+    @DataSet(resourceLocation = "dataset2")   // 2番目に処理
+})
+```
+
+両方のデータセットに同じテーブルが含まれる場合:
+
+| 戦略 | 結果 |
+|------|------|
+| `FIRST` | dataset1のテーブルのみを使用 |
+| `LAST` | dataset2のテーブルのみを使用 |
+| `UNION` | 行を結合し、完全な重複を除去 |
+| `UNION_ALL` | すべての行を結合し、重複を保持 |
+
+
+## TestContext
+
+テスト実行コンテキストのイミュータブルスナップショットです。
+
+**パッケージ**: `io.github.seijikohara.dbtester.api.context.TestContext`
+
+**型**: `record`
+
+### フィールド
+
+| フィールド | 型 | 説明 |
+|------------|-----|------|
+| `testClass` | `Class<?>` | メソッドを含むテストクラス |
+| `testMethod` | `Method` | 現在実行中のテストメソッド |
+| `configuration` | `Configuration` | アクティブなフレームワーク設定 |
+| `registry` | `DataSourceRegistry` | 登録済みデータソース |
+
+### 目的
+
+`TestContext`は、テスト実行状態のフレームワーク非依存の表現を提供します。テストフレームワーク拡張（JUnit、Spock）は、ネイティブコンテキストオブジェクトから`TestContext`インスタンスを作成します。
+
+### 使用法
+
+```java
+// フレームワーク拡張によって作成
+TestContext context = new TestContext(
+    testClass,
+    testMethod,
+    configuration,
+    registry
+);
+
+// ローダーとエグゼキューターで使用
+List<DataSet> datasets = loader.loadPreparationDataSets(context);
+```
+
+
+## 関連仕様
+
+- [概要](01-overview) - フレームワークの目的と主要概念
+- [パブリックAPI](03-public-api) - アノテーションとインターフェース
+- [データフォーマット](05-data-formats) - CSV/TSVファイル構造
+- [データベース操作](06-database-operations) - サポートされる操作
+- [エラーハンドリング](09-error-handling) - エラーメッセージと例外型

--- a/docs/specs/ja/05-data-formats.md
+++ b/docs/specs/ja/05-data-formats.md
@@ -1,0 +1,376 @@
+# DB Tester仕様 - データフォーマット
+
+DB Testerフレームワークがサポートするファイル形式と解析ルールについて説明します。
+
+
+## サポートされる形式
+
+フレームワークは2つの区切りテキスト形式をサポートします:
+
+| 形式 | 拡張子 | 区切り文字 | デフォルト |
+|------|--------|-----------|-----------|
+| CSV | `.csv` | カンマ（`,`） | はい |
+| TSV | `.tsv` | タブ（`\t`） | いいえ |
+
+### 形式の選択
+
+`ConventionSettings`で形式を設定します:
+
+```java
+var conventions = ConventionSettings.standard()
+    .withDataFormat(DataFormat.TSV);
+```
+
+ディレクトリからデータセットを読み込む際、設定された拡張子に一致するファイルのみが処理されます。
+
+
+## ファイル構造
+
+### 基本構造
+
+各ファイルは1つのデータベーステーブルを表します:
+
+- ファイル名（拡張子なし）= テーブル名
+- 最初の行 = カラムヘッダー
+- 後続の行 = データレコード
+
+### CSVの例
+
+ファイル: `USERS.csv`
+
+```csv
+id,name,email,created_at
+1,Alice,alice@example.com,2024-01-01 00:00:00
+2,Bob,bob@example.com,2024-01-02 00:00:00
+```
+
+表現:
+
+| カラム | 値 |
+|--------|-----|
+| `id` | 1, 2 |
+| `name` | Alice, Bob |
+| `email` | alice@example.com, bob@example.com |
+| `created_at` | 2024-01-01 00:00:00, 2024-01-02 00:00:00 |
+
+### TSVの例
+
+ファイル: `ORDERS.tsv`
+
+```tsv
+order_id	user_id	amount	status
+1001	1	99.99	PENDING
+1002	2	149.50	COMPLETED
+```
+
+
+## シナリオフィルタリング
+
+### シナリオマーカーカラム
+
+シナリオマーカーカラムにより、複数のテストメソッドでデータセットファイルを共有できます:
+
+| カラム名 | 設定可能 | デフォルト |
+|----------|----------|-----------|
+| `[Scenario]` | はい | `[Scenario]` |
+
+### シナリオカラムの動作
+
+データセットファイルにシナリオマーカーカラムが含まれている場合、本フレームワークは以下の処理を行います:
+
+1. マーカーが現在のシナリオに一致する行をフィルタリング
+2. 結果のデータセットからシナリオマーカーカラムを削除
+3. 残りのカラムとデータをデータベース操作に渡す
+
+### シナリオを使用した例
+
+ファイル: `USERS.csv`
+
+```csv
+[Scenario],id,name,email
+testCreate,1,Alice,alice@example.com
+testCreate,2,Bob,bob@example.com
+testUpdate,3,Charlie,charlie@example.com
+testDelete,4,Diana,diana@example.com
+```
+
+テストメソッド`testCreate`の場合、本フレームワークは以下にフィルタリングします:
+
+| id | name | email |
+|----|------|-------|
+| 1 | Alice | alice@example.com |
+| 2 | Bob | bob@example.com |
+
+### シナリオ解決
+
+シナリオ名は以下の順序で解決されます:
+
+1. `@DataSet`アノテーションの明示的な`scenarioNames`
+2. テストメソッド名（`ScenarioNameResolver` SPI経由）
+
+### 複数シナリオ
+
+単一のテストで複数のシナリオを使用できます:
+
+```java
+@Preparation(dataSets = @DataSet(scenarioNames = {"scenario1", "scenario2"}))
+void testMultipleScenarios() { }
+```
+
+指定されたシナリオのいずれかに一致する行が含まれます。
+
+
+## 特殊値
+
+### NULL値
+
+空のフィールドを使用してSQL NULLを表現します:
+
+```csv
+id,name,description
+1,Alice,
+2,Bob,A description
+```
+
+行1: `description`はNULL
+行2: `description`は"A description"
+
+### 空文字列とNULL
+
+| ファイル内容 | 解釈 |
+|--------------|------|
+| 空のフィールド | NULL |
+| 空のクォートフィールド（`""`） | 空文字列 |
+
+例:
+
+```csv
+id,nullable_col,empty_string_col
+1,,""
+```
+
+- `nullable_col` = NULL
+- `empty_string_col` = ""（空文字列）
+
+### クォートされた値
+
+区切り文字や特殊文字を含む値はクォートする必要があります:
+
+| 値 | エンコーディング |
+|----|-----------------|
+| カンマを含む | `"value,with,commas"` |
+| クォートを含む | `"value ""with"" quotes"` |
+| 改行を含む | `"line1\nline2"` |
+| 空白で始まる | `" leading space"` |
+
+
+## ディレクトリ規約
+
+### 標準ディレクトリ構造
+
+```
+src/test/resources/
+└── {package}/
+    └── {TestClassName}/
+        ├── TABLE1.csv          # 準備データ
+        ├── TABLE2.csv
+        └── expected/           # 期待データ
+            ├── TABLE1.csv
+            └── TABLE2.csv
+```
+
+### パッケージパス解決
+
+パッケージパスはテストクラスのパッケージをミラーリングします:
+
+| テストクラス | パッケージパス |
+|--------------|---------------|
+| `com.example.UserRepositoryTest` | `com/example/UserRepositoryTest/` |
+| `org.app.service.OrderServiceTest` | `org/app/service/OrderServiceTest/` |
+
+### ネストされたテストクラス
+
+JUnitのネストされたテストクラスの場合:
+
+| テストクラス | ディレクトリ |
+|--------------|-------------|
+| `UserTest$NestedTest` | `{package}/UserTest$NestedTest/` |
+
+### テーブル名の導出
+
+テーブル名はファイル名から導出されます:
+
+| ファイル名 | テーブル名 |
+|------------|-----------|
+| `USERS.csv` | `USERS` |
+| `order_items.csv` | `order_items` |
+| `CamelCase.csv` | `CamelCase` |
+
+大文字小文字の区別はデータベース設定に依存します。
+
+
+## 読み込み順序
+
+### 概要
+
+`load-order.txt`ファイルは、データベース操作中にテーブルが処理される順序を制御します。これは、親テーブルを子テーブルより先に投入する必要がある外部キー関係を持つテーブルにとって重要です。
+
+### ファイルの場所
+
+読み込み順序ファイルはデータセットディレクトリに配置されます:
+
+```
+src/test/resources/
+└── {package}/
+    └── {TestClassName}/
+        ├── load-order.txt    # 読み込み順序指定
+        ├── PARENT_TABLE.csv
+        └── CHILD_TABLE.csv
+```
+
+### ファイル形式
+
+`load-order.txt`ファイルは単純な行ベースの形式を使用します:
+
+| 要素 | 説明 |
+|------|------|
+| テーブル名 | 1行につき1つのテーブル名（ファイル拡張子なし） |
+| コメント | `#`で始まる行は無視 |
+| 空行 | 無視 |
+| 空白 | 先頭と末尾の空白はトリミング |
+
+### 例
+
+ファイル: `load-order.txt`
+
+```
+# 親テーブルを先に
+USERS
+CATEGORIES
+
+# 子テーブルは親の後に
+ORDERS
+ORDER_ITEMS
+```
+
+### デフォルト動作
+
+データセットディレクトリに`load-order.txt`が存在しない場合:
+
+1. テーブルはファイル名で**アルファベット順**にソートされます
+2. フレームワークはファイルを**自動生成しません**
+
+**注意**: 他のデータベーステストフレームワークとは異なり、db-testerは`load-order.txt`ファイルを自動作成しません。これはDbUnit互換性のため、およびテストリソースの変更を避けるための意図的な設計です。
+
+読み込み順序ファイルを明示的に必須にするには、以下を使用します:
+
+```java
+@Preparation(tableOrdering = TableOrderingStrategy.LOAD_ORDER_FILE)
+```
+
+`load-order.txt`が見つからない場合、`DataSetLoadException`がスローされます。
+
+### 操作ごとの処理順序
+
+テーブル順序はデータベース操作と以下のように相互作用します:
+
+| 操作 | 処理順序 |
+|------|---------|
+| INSERT | ファイル順序で処理（上から下） |
+| DELETE, DELETE_ALL | ファイル順序の逆順で処理（下から上） |
+| TRUNCATE_TABLE | ファイル順序の逆順で処理 |
+| CLEAN_INSERT | 逆順でDELETE、次に順方向でINSERT |
+| TRUNCATE_INSERT | 逆順でTRUNCATE、次に順方向でINSERT |
+
+### TableOrderingStrategyとの関係
+
+`TableOrderingStrategy` enumはテーブル順序の決定方法を制御します。詳細は[データベース操作](06-database-operations#テーブル順序戦略)を参照してください。
+
+| 戦略 | 動作 |
+|------|------|
+| `AUTO`（デフォルト） | `load-order.txt`が存在すれば使用、次にFKメタデータ、次にアルファベット順 |
+| `LOAD_ORDER_FILE` | `load-order.txt`を必須（見つからない場合はエラー） |
+| `FOREIGN_KEY` | FKベースの順序付けにJDBCメタデータを使用 |
+| `ALPHABETICAL` | テーブル名でアルファベット順にソート |
+
+### ベストプラクティス
+
+1. **順序ファイルをコミット**: 再現可能なテストのために`load-order.txt`をバージョン管理に含める
+2. **親テーブルを先に**: 外部キー制約を満たすために親テーブルを子テーブルより先にリスト
+3. **コメントを使用**: 明らかでない順序決定の理由を文書化
+4. **FK戦略を検討**: 適切なFK制約を持つデータベースでは、`TableOrderingStrategy.FOREIGN_KEY`が手動ファイルメンテナンスなしで自動順序付けを提供
+
+### エラーハンドリング
+
+| エラー | 例外 |
+|--------|------|
+| 順序ファイルを読み取れない | `DataSetLoadException` |
+| ファイルが必須だが見つからない（`LOAD_ORDER_FILE`戦略） | `DataSetLoadException` |
+
+
+## 解析ルール
+
+### CSV解析
+
+RFC 4180に拡張機能を追加して準拠:
+
+| ルール | 説明 |
+|--------|------|
+| 区切り文字 | カンマ（`,`） |
+| クォート文字 | ダブルクォート（`"`） |
+| エスケープシーケンス | 埋め込みクォートには`""` |
+| 改行処理 | CRLFとLFをサポート |
+| 先頭/末尾の空白 | クォートされていない限り保持 |
+
+### TSV解析
+
+| ルール | 説明 |
+|--------|------|
+| 区切り文字 | タブ（`\t`） |
+| クォート文字 | ダブルクォート（`"`） |
+| エスケープシーケンス | 埋め込みクォートには`""` |
+| 改行処理 | CRLFとLFをサポート |
+
+### ヘッダー行の要件
+
+- 最初の行はカラム名を含む必要があります
+- カラム名はテーブル内で一意である必要があります
+- 空のカラム名は許可されません
+- シナリオマーカーカラムはオプションです
+
+### データ型処理
+
+すべての値は文字列として解析され、データベース操作中に変換されます:
+
+| データベース型 | 文字列変換 |
+|----------------|-----------|
+| INTEGER, BIGINT | 整数として解析 |
+| DECIMAL, NUMERIC | BigDecimalとして解析 |
+| VARCHAR, TEXT | そのまま使用 |
+| DATE | ISO形式で解析（YYYY-MM-DD） |
+| TIMESTAMP | ISO形式で解析（YYYY-MM-DD HH:MM:SS） |
+| BOOLEAN | "true"/"false"として解析（大文字小文字を区別しない） |
+| BLOB | Base64デコード |
+| CLOB | そのまま使用 |
+
+### エンコーディング
+
+- ファイルエンコーディング: UTF-8
+- BOM（Byte Order Mark）: サポートされていますがオプション
+
+### エラーハンドリング
+
+| エラー | 動作 |
+|--------|------|
+| ファイルが見つからない | `DataSetLoadException` |
+| 無効な形式 | 行番号付きの`DataSetLoadException` |
+| カラム数の不一致 | `DataSetLoadException` |
+| 解析エラー | 詳細付きの`DataSetLoadException` |
+
+
+## 関連仕様
+
+- [設定](04-configuration) - DataFormatとConventionSettings
+- [データベース操作](06-database-operations) - テーブル順序と操作
+- [パブリックAPI](03-public-api) - アノテーション属性
+- [エラーハンドリング](09-error-handling) - データセット読み込みエラー

--- a/docs/specs/ja/06-database-operations.md
+++ b/docs/specs/ja/06-database-operations.md
@@ -1,0 +1,448 @@
+# DB Tester仕様 - データベース操作
+
+DB Testerフレームワークがサポートするデータベース操作について説明します。
+
+
+## Operation列挙型
+
+**パッケージ**: `io.github.seijikohara.dbtester.api.operation.Operation`
+
+### 利用可能な操作
+
+| 操作 | 説明 | ユースケース |
+|------|------|-------------|
+| `NONE` | データベース操作なし | 読み取り専用の検証 |
+| `INSERT` | 新規行を挿入 | 空テーブルまたは追加 |
+| `UPDATE` | 主キーで既存行を更新 | 既存データの変更 |
+| `REFRESH` | Upsert（挿入または更新） | 挿入と更新の混在 |
+| `DELETE` | 主キーで特定行を削除 | 選択的な削除 |
+| `DELETE_ALL` | テーブルの全行を削除 | シーケンスリセットなしのクリア |
+| `TRUNCATE_TABLE` | テーブルを切り捨て | シーケンスリセット付きのクリア |
+| `CLEAN_INSERT` | 全削除後に挿入（デフォルト） | 新鮮なテストデータ |
+| `TRUNCATE_INSERT` | 切り捨て後に挿入 | シーケンスリセット付きの新鮮なデータ |
+
+
+## 操作の詳細
+
+### NONE
+
+データベース操作を実行しません。
+
+**動作**:
+- データセット内のすべてのテーブルをスキップ
+- データベース状態を変更しない
+
+**ユースケース**:
+- 以前のテストから準備データが存在する期待値のみのテスト
+- 手動セットアップシナリオ
+
+
+### INSERT
+
+既存データを変更せずに新規行を挿入します。
+
+**生成されるSQL**: `INSERT INTO table (columns) VALUES (?)`
+
+**動作**:
+- データセットから各行を挿入
+- 主キー重複違反時は失敗
+- 既存行には影響しない
+
+**ユースケース**:
+- 既存データを持つテーブルへの追加
+- 特定の行追加を必要とするテスト
+
+**制約**:
+- ターゲット行が空であるか、一意のキーが必要
+
+
+### UPDATE
+
+主キーで識別される既存行を更新します。
+
+**生成されるSQL**: `UPDATE table SET columns = ? WHERE pk_columns = ?`
+
+**動作**:
+- 主キーで行を照合
+- 非キーカラムを更新
+- データベースに存在しない行は無視
+
+**ユースケース**:
+- 既存テストデータの変更
+- テスト内での状態遷移
+
+**要件**:
+- テーブルに主キーが定義されていること
+- データセットに主キーカラムが含まれていること
+
+
+### REFRESH
+
+Upsert操作（挿入または更新）を実行します。
+
+**動作**:
+- 主キーで行の存在を確認
+- 既存行を更新
+- 新規行を挿入
+
+**ユースケース**:
+- 既存データが部分的に存在する混合シナリオ
+- 増分データセットアップ
+
+**要件**:
+- テーブルに主キーが定義されていること
+
+
+### DELETE
+
+主キーで識別される特定行を削除します。
+
+**生成されるSQL**: `DELETE FROM table WHERE pk_columns = ?`
+
+**動作**:
+- データセットの主キーで行を照合
+- 一致する行のみを削除
+- 他の行は変更されない
+
+**ユースケース**:
+- 特定のテストレコードの削除
+- 個別行のクリーンアップ
+
+**要件**:
+- データセットに主キーカラムが含まれていること
+
+
+### DELETE_ALL
+
+参照されているテーブルの全行を削除します。
+
+**生成されるSQL**: `DELETE FROM table`
+
+**動作**:
+- データセット内の各テーブルから全行を削除
+- ID/シーケンスカラムをリセットしない
+- 外部キー制約を尊重（失敗する場合あり）
+
+**ユースケース**:
+- シーケンスを保持しながらテーブルをクリア
+- 挿入専用操作のセットアップ
+
+**テーブル処理順序**:
+- テーブルは外部キーの逆順で処理
+
+
+### TRUNCATE_TABLE
+
+テーブルを切り捨て、サポートされている場合はIDカラムをリセットします。
+
+**生成されるSQL**: `TRUNCATE TABLE table`
+
+**動作**:
+- テーブルから全行を削除
+- ID/自動インクリメントカラムをリセット
+- 外部キーの動作はデータベース依存
+
+**ユースケース**:
+- シーケンスを含む完全なテーブルリセット
+- パフォーマンス重視のクリーンアップ
+
+**データベースサポート**:
+
+| データベース | IDリセット | FK処理 |
+|-------------|-----------|--------|
+| H2 | 対応 | CASCADEが必要 |
+| MySQL | 対応 | FKチェックの無効化が必要 |
+| PostgreSQL | 対応 | CASCADEが必要 |
+| SQL Server | 対応 | FK参照がないことが必要 |
+| Oracle | 対応 | CASCADEが必要 |
+
+
+### CLEAN_INSERT
+
+全行を削除してからデータセットの行を挿入します。
+
+**等価操作**: `DELETE_ALL`に続いて`INSERT`
+
+**動作**:
+1. 各テーブルから全行を削除（FK逆順）
+2. データセットから全行を挿入（FK順）
+
+**ユースケース**:
+- 標準的なテスト準備（デフォルト操作）
+- 決定論的な初期状態
+
+**実行順序**:
+- DELETEフェーズ: 子テーブルが先
+- INSERTフェーズ: 親テーブルが先
+
+
+### TRUNCATE_INSERT
+
+テーブルを切り捨ててからデータセットの行を挿入します。
+
+**等価操作**: `TRUNCATE_TABLE`に続いて`INSERT`
+
+**動作**:
+1. 各テーブルを切り捨て（CASCADEが必要な場合あり）
+2. データセットから全行を挿入
+
+**ユースケース**:
+- シーケンスリセット付きのテスト準備
+- パフォーマンス最適化されたセットアップ
+
+
+## 実行フロー
+
+### 準備フェーズ
+
+1. 設定された場所からデータセットファイルを読み込む
+2. シナリオマーカーで行をフィルタリング
+3. 外部キーに基づいてテーブル順序を解決
+4. 設定された操作を実行
+5. トランザクションをコミット
+
+### 期待フェーズ
+
+1. 期待データセットファイルを読み込む
+2. シナリオマーカーで行をフィルタリング
+3. データベースから実際のデータを読み取る
+4. 期待値と実際のデータを比較
+5. 不一致をテスト失敗として報告
+
+### 操作の実行
+
+```mermaid
+flowchart TD
+    subgraph OperationExecutor
+        A[DataSourceからコネクションを取得] --> B[AutoCommit = falseに設定]
+        B --> C[テーブル順序を解決]
+        C --> D{各テーブルに対して}
+        D --> E[SQLステートメントを構築]
+        E --> F[パラメータをバインド]
+        F --> G[ステートメントを実行]
+        G --> D
+        D --> H{成功?}
+        H -->|Yes| I[コミット]
+        H -->|No| J[ロールバック]
+        I --> K[コネクションをクローズ]
+        J --> K
+    end
+```
+
+
+## テーブル順序戦略
+
+### TableOrderingStrategy列挙型
+
+**パッケージ**: `io.github.seijikohara.dbtester.api.operation.TableOrderingStrategy`
+
+`TableOrderingStrategy`列挙型は、データベース操作中にテーブルが処理される順序を本フレームワークがどのように決定するかを制御します。
+
+### 利用可能な戦略
+
+| 戦略 | 説明 |
+|------|------|
+| `AUTO` | 最適な順序を自動的に決定（デフォルト） |
+| `LOAD_ORDER_FILE` | `load-order.txt`ファイルを使用（見つからない場合はエラー） |
+| `FOREIGN_KEY` | FKベースの順序付けにJDBCメタデータを使用 |
+| `ALPHABETICAL` | テーブル名でアルファベット順にソート |
+
+### 戦略の詳細
+
+#### AUTO（デフォルト）
+
+本フレームワークは以下の順序で戦略を試みます:
+
+1. **LOAD_ORDER_FILE** - データセットディレクトリに`load-order.txt`が存在する場合、それを使用
+2. **FOREIGN_KEY** - JDBCメタデータをクエリして外部キー依存関係を解決
+3. **ALPHABETICAL** - 大文字小文字を区別しないアルファベット順にフォールバック
+
+AUTO戦略は最も柔軟な動作を提供し、ほとんどのユースケースに適しています。
+
+#### LOAD_ORDER_FILE
+
+データセットディレクトリに`load-order.txt`ファイルが必要です。ファイルが存在しない場合、`DataSetLoadException`がスローされます。
+
+**ユースケース**: テーブル順序を明示的に制御し、順序が常に指定されていることを保証したい場合。
+
+```java
+@Preparation(tableOrdering = TableOrderingStrategy.LOAD_ORDER_FILE)
+void testWithExplicitOrder() { }
+```
+
+#### FOREIGN_KEY
+
+JDBCデータベースメタデータ（`DatabaseMetaData.getExportedKeys()`）を使用して外部キー依存関係を分析し、トポロジカルソートを実行します。
+
+**動作**:
+- 親テーブル（外部キーによって参照されるテーブル）が子テーブルより先に処理される
+- 外部キーメタデータを取得できない場合、元のテーブル順序にフォールバック
+- 循環依存が検出された場合、警告をログに出力して宣言順を使用
+
+**ユースケース**: 外部キー制約が適切に定義されており、自動順序付けが望ましいデータベース。
+
+```java
+@Preparation(tableOrdering = TableOrderingStrategy.FOREIGN_KEY)
+void testWithFkOrdering() { }
+```
+
+#### ALPHABETICAL
+
+テーブルはアルファベット昇順（大文字小文字を区別しない）でソートされます。
+
+**ユースケース**: テーブル順序が重要でない場合（FK制約がない）、またはシンプルなシナリオでの決定論的な順序付け。
+
+```java
+@Preparation(tableOrdering = TableOrderingStrategy.ALPHABETICAL)
+void testWithAlphabeticalOrder() { }
+```
+
+### アノテーションでの使用
+
+```java
+// デフォルトのAUTO戦略
+@Preparation
+void testDefault() { }
+
+// @Preparationで明示的な戦略
+@Preparation(tableOrdering = TableOrderingStrategy.FOREIGN_KEY)
+void testWithFkOrder() { }
+
+// @Expectationでの戦略（検証順序に影響）
+@Expectation(tableOrdering = TableOrderingStrategy.ALPHABETICAL)
+void testExpectationOrder() { }
+
+// 組み合わせて使用
+@Preparation(operation = Operation.CLEAN_INSERT, tableOrdering = TableOrderingStrategy.LOAD_ORDER_FILE)
+@Expectation(tableOrdering = TableOrderingStrategy.ALPHABETICAL)
+void testBothPhases() { }
+```
+
+
+## テーブル順序
+
+### `load-order.txt`による手動順序付け
+
+テーブル処理順序を制御する推奨方法は`load-order.txt`ファイルです。`load-order.txt`ファイルは、テーブルが処理される正確な順序を指定します。
+
+ファイル形式と使用方法の詳細については、[データフォーマット - 読み込み順序](05-data-formats#読み込み順序)を参照してください。
+
+### 外部キーの認識
+
+`load-order.txt`ファイルが存在しない場合、本フレームワークはデータベースメタデータを使用してテーブル依存関係を解決できます:
+
+1. 各テーブルに対して`DatabaseMetaData.getExportedKeys()`をクエリ
+2. 依存関係グラフを構築
+3. テーブルをトポロジカルソート
+
+### 順序付けルール
+
+| 操作 | 順序 |
+|------|------|
+| INSERT, REFRESH | 親テーブルが先（FK順） |
+| DELETE, DELETE_ALL | 子テーブルが先（FK逆順） |
+| TRUNCATE_TABLE | 子テーブルが先 |
+| CLEAN_INSERT | DELETE逆順、INSERT順方向 |
+| TRUNCATE_INSERT | TRUNCATE逆順、INSERT順方向 |
+
+### 順序解決の優先順位
+
+テーブル順序は`TableOrderingStrategy`によって決定されます。`AUTO`（デフォルト）を使用する場合、優先順位は以下の通りです:
+
+1. **手動順序付け**: データセットディレクトリの`load-order.txt`ファイル
+2. **FKベースの順序付け**: データベースメタデータを使用した自動解決
+3. **アルファベット順**: 他の順序付けが利用できない場合のフォールバック
+
+**注意**: 他のフレームワークとは異なり、DB Testerは`load-order.txt`ファイルを自動生成**しません**。詳細は[テーブル順序戦略](#テーブル順序戦略)を参照してください。
+
+### 循環依存
+
+循環外部キー参照を持つテーブルの場合:
+
+1. 依存関係グラフで循環を検出
+2. 警告をログに出力
+3. データセット宣言順で処理
+
+
+## トランザクション処理
+
+### デフォルト動作
+
+- 操作中はAutoCommitが無効
+- データセットごとに単一トランザクション
+- 成功時はコミット、失敗時はロールバック
+
+### トランザクション境界
+
+| フェーズ | トランザクションスコープ |
+|----------|-------------------------|
+| 準備 | 全テーブルで単一トランザクション |
+| 期待 | 読み取り専用（トランザクションなし） |
+
+### コネクション管理
+
+1. `DataSource`からコネクションを取得
+2. 現在のAutoCommit設定を保存
+3. AutoCommit = falseに設定
+4. 操作を実行
+5. コミットまたはロールバック
+6. AutoCommit設定を復元
+7. コネクションをクローズ
+
+### エラー回復
+
+例外発生時:
+1. トランザクションをロールバック
+2. コネクションをクローズ
+3. 例外を`DatabaseOperationException`でラップ
+4. テストフレームワークに伝播
+
+
+## 型変換
+
+### 文字列からSQL型への変換
+
+本フレームワークは、CSV/TSVの文字列値を適切なSQL型に変換します:
+
+| ターゲットSQL型 | 変換メソッド |
+|-----------------|--------------|
+| `VARCHAR`, `CHAR`, `TEXT` | 文字列のまま |
+| `INTEGER`, `SMALLINT` | `Integer.parseInt()` |
+| `BIGINT` | `Long.parseLong()` |
+| `DECIMAL`, `NUMERIC` | `new BigDecimal()` |
+| `REAL`, `FLOAT` | `Float.parseFloat()` |
+| `DOUBLE` | `Double.parseDouble()` |
+| `BOOLEAN`, `BIT` | `Boolean.parseBoolean()` |
+| `DATE` | `LocalDate.parse()` |
+| `TIME` | `LocalTime.parse()` |
+| `TIMESTAMP` | `LocalDateTime.parse()` |
+| `BLOB`, `BINARY` | Base64デコード |
+| `CLOB` | 文字列のまま |
+
+### NULL処理
+
+- 空のCSVフィールド = SQL NULL
+- 適切なSQL型で`PreparedStatement.setNull()`を使用
+
+### 日付/時刻形式
+
+| 型 | 受け入れられる形式 |
+|-----|-------------------|
+| DATE | `yyyy-MM-dd` |
+| TIME | `HH:mm:ss`, `HH:mm:ss.SSS` |
+| TIMESTAMP | `yyyy-MM-dd HH:mm:ss`, `yyyy-MM-dd HH:mm:ss.SSS` |
+
+### LOB処理
+
+| 型 | 変換 |
+|-----|------|
+| BLOB | Base64文字列 → byte[] |
+| CLOB | String → Reader |
+
+
+## 関連仕様
+
+- [パブリックAPI](03-public-api) - Operation enumリファレンス
+- [データフォーマット](05-data-formats) - ソースファイル構造
+- [設定](04-configuration) - OperationDefaults
+- [エラーハンドリング](09-error-handling) - データベース操作エラー

--- a/docs/specs/ja/07-test-frameworks.md
+++ b/docs/specs/ja/07-test-frameworks.md
@@ -1,0 +1,427 @@
+# DB Tester仕様 - テストフレームワーク統合
+
+JUnitおよびSpockテストフレームワークとの統合について説明します。
+
+
+## JUnit統合
+
+### モジュール
+
+`db-tester-junit`
+
+### 拡張クラス
+
+**パッケージ**: `io.github.seijikohara.dbtester.junit.jupiter.extension.DatabaseTestExtension`
+
+**実装インターフェース**:
+- `BeforeEachCallback` - 準備フェーズの実行
+- `AfterEachCallback` - 期待フェーズの検証
+- `ParameterResolver` - `ExtensionContext`のインジェクション
+
+### 登録
+
+```java
+@ExtendWith(DatabaseTestExtension.class)
+class UserRepositoryTest {
+    // ...
+}
+```
+
+### DataSource登録
+
+`@BeforeAll`でデータソースを登録します:
+
+```java
+@ExtendWith(DatabaseTestExtension.class)
+class UserRepositoryTest {
+
+    @BeforeAll
+    static void setup(ExtensionContext context) {
+        var registry = DatabaseTestExtension.getRegistry(context);
+        registry.registerDefault(dataSource);
+    }
+
+    @Test
+    @Preparation
+    @Expectation
+    void testCreateUser() {
+        // テスト実装
+    }
+}
+```
+
+### 設定のカスタマイズ
+
+```java
+@BeforeAll
+static void setup(ExtensionContext context) {
+    var registry = DatabaseTestExtension.getRegistry(context);
+    registry.registerDefault(dataSource);
+
+    var conventions = ConventionSettings.standard()
+        .withDataFormat(DataFormat.TSV);
+    var config = Configuration.withConventions(conventions);
+    DatabaseTestExtension.setConfiguration(context, config);
+}
+```
+
+### 静的メソッド
+
+| メソッド | 説明 |
+|----------|------|
+| `getRegistry(ExtensionContext)` | DataSourceRegistryを返すか作成 |
+| `setConfiguration(ExtensionContext, Configuration)` | カスタム設定を設定 |
+
+### ネストされたテストクラス
+
+拡張機能はネストされたテストクラス間で状態を共有します:
+
+```java
+@ExtendWith(DatabaseTestExtension.class)
+class UserRepositoryTest {
+
+    @BeforeAll
+    static void setup(ExtensionContext context) {
+        var registry = DatabaseTestExtension.getRegistry(context);
+        registry.registerDefault(dataSource);
+    }
+
+    @Nested
+    class CreateTests {
+        @Test
+        @Preparation
+        @Expectation
+        void testCreateUser() { }  // 親のレジストリを使用
+    }
+
+    @Nested
+    class UpdateTests {
+        @Test
+        @Preparation
+        @Expectation
+        void testUpdateUser() { }  // 親のレジストリを使用
+    }
+}
+```
+
+### アノテーション優先順位
+
+メソッドレベルのアノテーションがクラスレベルをオーバーライドします:
+
+```java
+@Preparation(operation = Operation.CLEAN_INSERT)  // クラスデフォルト
+class UserRepositoryTest {
+
+    @Test
+    @Preparation(operation = Operation.INSERT)  // クラスをオーバーライド
+    void testWithInsert() { }
+
+    @Test
+    @Preparation  // クラスデフォルトを使用
+    void testWithDefault() { }
+}
+```
+
+
+## Spock統合
+
+### モジュール
+
+`db-tester-spock`
+
+### 拡張クラス
+
+**パッケージ**: `io.github.seijikohara.dbtester.spock.extension.DatabaseTestExtension`
+
+**タイプ**: アノテーション駆動型拡張（`IAnnotationDrivenExtension<DatabaseTest>`）
+
+### 登録
+
+拡張機能は、Specificationクラスに`@DatabaseTest`を追加することで有効化されます:
+
+```groovy
+@DatabaseTest
+class UserRepositorySpec extends Specification {
+
+    @Shared
+    DataSourceRegistry dbTesterRegistry
+
+    def setupSpec() {
+        dbTesterRegistry = new DataSourceRegistry()
+        dbTesterRegistry.registerDefault(dataSource)
+    }
+
+    @Preparation
+    @Expectation
+    def 'should create user'() {
+        // テスト実装
+    }
+}
+```
+
+### 設定のカスタマイズ
+
+`dbTesterConfiguration`という名前の`@Shared`フィールドを使用します:
+
+```groovy
+@DatabaseTest
+class UserRepositorySpec extends Specification {
+
+    @Shared
+    DataSourceRegistry dbTesterRegistry
+
+    @Shared
+    Configuration dbTesterConfiguration
+
+    def setupSpec() {
+        dbTesterRegistry = new DataSourceRegistry()
+        dbTesterRegistry.registerDefault(dataSource)
+
+        def conventions = ConventionSettings.standard()
+            .withDataFormat(DataFormat.TSV)
+        dbTesterConfiguration = Configuration.withConventions(conventions)
+    }
+
+    @Preparation
+    @Expectation
+    def 'should create user'() { }
+}
+```
+
+### 予約フィールド名
+
+| フィールド名 | 型 | 目的 |
+|--------------|-----|------|
+| `dbTesterRegistry` | `DataSourceRegistry` | データソース登録 |
+| `dbTesterConfiguration` | `Configuration` | カスタム設定 |
+
+### フィーチャーメソッド命名
+
+シナリオ名はフィーチャーメソッドから導出されます:
+
+```groovy
+@Preparation
+def 'should create user with email'() {
+    // シナリオ名: "should create user with email"
+}
+```
+
+### データ駆動テスト
+
+`where:`ブロックを使用したパラメータ化テストの場合、イテレーション名が使用されます:
+
+```groovy
+@Preparation
+def 'should process #status order'() {
+    expect:
+    // テスト実装
+
+    where:
+    status << ['PENDING', 'COMPLETED']
+}
+```
+
+シナリオ名: `"should process PENDING order"`, `"should process COMPLETED order"`
+
+
+## Spring Boot統合
+
+### JUnit Spring Boot Starter
+
+**モジュール**: `db-tester-junit-spring-boot-starter`
+
+**拡張機能**: `SpringBootDatabaseTestExtension`
+
+### 自動DataSource検出
+
+Spring Boot拡張機能は自動的に以下を実行します:
+1. Spring `ApplicationContext`を検出
+2. `DataSource` Beanを検索
+3. `DataSourceRegistry`に登録
+
+```java
+@SpringBootTest
+@ExtendWith(SpringBootDatabaseTestExtension.class)
+class UserRepositoryTest {
+
+    @Test
+    @Preparation
+    @Expectation
+    void testCreateUser() {
+        // DataSourceはSpringコンテキストから自動登録
+    }
+}
+```
+
+### 複数DataSource
+
+複数のデータソースには`@Qualifier`を使用します:
+
+```java
+@Configuration
+class DataSourceConfig {
+
+    @Bean
+    @Primary
+    DataSource primaryDataSource() { }
+
+    @Bean
+    @Qualifier("secondary")
+    DataSource secondaryDataSource() { }
+}
+```
+
+```java
+@SpringBootTest
+@ExtendWith(SpringBootDatabaseTestExtension.class)
+class MultiDatabaseTest {
+
+    @Test
+    @Preparation(dataSets = {
+        @DataSet(dataSourceName = ""),          // Primary（デフォルト）
+        @DataSet(dataSourceName = "secondary")  // Secondary
+    })
+    void testMultipleDatabases() { }
+}
+```
+
+### 設定プロパティ
+
+`application.properties`または`application.yml`で設定します:
+
+```properties
+# DB Testerの有効化/無効化（デフォルト: true）
+db-tester.enabled=true
+
+# DataSource Beanの自動登録（デフォルト: true）
+db-tester.auto-register-data-sources=true
+
+# データフォーマット（CSVまたはTSV）
+db-tester.convention.data-format=CSV
+
+# 期待ディレクトリサフィックス
+db-tester.convention.expectation-suffix=/expected
+
+# シナリオマーカーカラム名
+db-tester.convention.scenario-marker=[Scenario]
+
+# テーブルマージ戦略（FIRST, LAST, UNION, UNION_ALL）
+db-tester.convention.table-merge-strategy=UNION_ALL
+
+# デフォルト準備操作
+db-tester.operation.preparation=CLEAN_INSERT
+
+# デフォルト期待操作（通常は検証のみのためNONE）
+db-tester.operation.expectation=NONE
+```
+
+**注意**: プロパティ名は複数形ではなく単数形（`convention`, `operation`）を使用します。
+
+### Spock Spring Boot Starter
+
+**モジュール**: `db-tester-spock-spring-boot-starter`
+
+**拡張機能**: `SpringBootDatabaseTestExtension`（Groovy）
+
+**タイプ**: アノテーション駆動型拡張（`IAnnotationDrivenExtension<SpringBootDatabaseTest>`）
+
+```groovy
+@SpringBootTest
+@SpringBootDatabaseTest
+class UserRepositorySpec extends Specification {
+
+    @Preparation
+    @Expectation
+    def 'should create user'() {
+        // DataSourceはSpringコンテキストから自動登録
+    }
+}
+```
+
+### 自動設定
+
+自動設定クラス:
+
+| モジュール | 自動設定クラス |
+|------------|---------------|
+| JUnit Starter | `DbTesterJUnitAutoConfiguration` |
+| Spock Starter | `DbTesterSpockAutoConfiguration` |
+
+
+## ライフサイクルフック
+
+### JUnitライフサイクル
+
+```mermaid
+flowchart TD
+    subgraph テスト実行
+        BA["@BeforeAll"]
+        BA --> BA1[DataSourceを登録]
+        BA1 --> BA2[設定を設定]
+
+        subgraph each["各テストメソッドに対して"]
+            BE["beforeEach()"]
+            BE --> BE1["Preparationを検索"]
+            BE1 --> BE2[データセットを読み込み]
+            BE2 --> BE3[操作を実行]
+            BE3 --> TM[テストメソッド実行]
+            TM --> AE["afterEach()"]
+            AE --> AE1["Expectationを検索"]
+            AE1 --> AE2[期待データセットを読み込み]
+            AE2 --> AE3[データベースと比較]
+            AE3 --> AE4[不一致を報告]
+        end
+
+        BA2 --> each
+        each --> AA["@AfterAll"]
+        AA --> AA1[クリーンアップ]
+    end
+```
+
+### Spockライフサイクル
+
+```mermaid
+flowchart TD
+    subgraph Specification実行
+        SS["setupSpec()"]
+        SS --> SS1[dbTesterRegistryを初期化]
+        SS1 --> SS2[DataSourceを登録]
+        SS2 --> SS3[dbTesterConfigurationを設定]
+
+        subgraph each["各フィーチャーメソッドに対して"]
+            INT1["インターセプター（前）"]
+            INT1 --> INT1A["Preparationを実行"]
+            INT1A --> FM[フィーチャーメソッド実行]
+            FM --> INT2["インターセプター（後）"]
+            INT2 --> INT2A["Expectationを実行"]
+        end
+
+        SS3 --> each
+        each --> CS["cleanupSpec()"]
+        CS --> CS1[クリーンアップ]
+    end
+```
+
+### ライフサイクル実行クラス
+
+| フレームワーク | 準備 | 期待 |
+|---------------|------|------|
+| JUnit | `PreparationExecutor` | `ExpectationVerifier` |
+| Spock | `SpockPreparationExecutor` | `SpockExpectationVerifier` |
+
+### エラーハンドリング
+
+| フェーズ | エラー型 | 動作 |
+|---------|----------|------|
+| 準備 | `DatabaseOperationException` | 実行前にテスト失敗 |
+| テスト | 任意の例外 | Expectationは引き続き実行 |
+| 期待 | `ValidationException` | 比較詳細付きでテスト失敗 |
+
+
+## 関連仕様
+
+- [概要](01-overview) - フレームワークの目的と主要概念
+- [パブリックAPI](03-public-api) - アノテーションの詳細
+- [設定](04-configuration) - 設定オプション
+- [SPI](08-spi) - サービスプロバイダーインターフェース拡張ポイント
+- [エラーハンドリング](09-error-handling) - ライフサイクルエラーハンドリング

--- a/docs/specs/ja/08-spi.md
+++ b/docs/specs/ja/08-spi.md
@@ -1,0 +1,433 @@
+# DB Tester仕様 - サービスプロバイダーインターフェース（SPI）
+
+DB TesterフレームワークのSPI拡張ポイントについて説明します。
+
+
+## SPI概要
+
+本フレームワークはモジュール間の疎結合のためにJava ServiceLoaderを使用します:
+
+```mermaid
+flowchart TB
+    subgraph API[db-tester-api]
+        SPI[SPIインターフェース]
+    end
+
+    subgraph CORE[db-tester-core]
+        IMPL[実装]
+    end
+
+    subgraph Frameworks[テストフレームワーク]
+        JUNIT[db-tester-junit]
+        SPOCK[db-tester-spock]
+    end
+
+    API <-->|ServiceLoader| CORE
+    Frameworks -->|コンパイル時| API
+    CORE -.->|ServiceLoader経由でランタイム時| Frameworks
+```
+
+### 設計原則
+
+1. **API独立性**: テストフレームワークモジュールは`db-tester-api`のみに依存
+2. **ランタイム検出**: Core実装はServiceLoader経由で読み込み
+3. **拡張性**: カスタム実装でデフォルトを置換可能
+
+
+## APIモジュールSPI
+
+### DataSetLoaderProvider
+
+デフォルトの`DataSetLoader`実装を提供します。
+
+**パッケージ**: `io.github.seijikohara.dbtester.api.spi.DataSetLoaderProvider`
+
+**インターフェース**:
+
+```java
+public interface DataSetLoaderProvider {
+    DataSetLoader getLoader();
+}
+```
+
+**デフォルト実装**: `db-tester-core`の`DefaultDataSetLoaderProvider`
+
+**使用方法**: ローダーを取得するために`Configuration.defaults()`から呼び出される
+
+
+### OperationProvider
+
+データセットに対するデータベース操作を実行します。
+
+**パッケージ**: `io.github.seijikohara.dbtester.api.spi.OperationProvider`
+
+**インターフェース**:
+
+```java
+public interface OperationProvider {
+    void execute(
+        Operation operation,
+        DataSet dataSet,
+        DataSource dataSource,
+        TableOrderingStrategy tableOrderingStrategy);
+}
+```
+
+**デフォルト実装**: `db-tester-core`の`DefaultOperationProvider`
+
+**パラメータ**:
+
+| パラメータ | 型 | 説明 |
+|-----------|-----|------|
+| `operation` | `Operation` | 実行するデータベース操作 |
+| `dataSet` | `DataSet` | テーブルと行を含むデータセット |
+| `dataSource` | `DataSource` | コネクション用のJDBCデータソース |
+| `tableOrderingStrategy` | `TableOrderingStrategy` | テーブル処理順序の戦略 |
+
+**操作**:
+- `NONE` - 操作なし
+- `INSERT` - 行を挿入
+- `UPDATE` - 主キーで更新
+- `DELETE` - 主キーで削除
+- `DELETE_ALL` - 全行を削除
+- `REFRESH` - Upsert（挿入または更新）
+- `TRUNCATE_TABLE` - テーブルを切り捨て
+- `CLEAN_INSERT` - 全削除後に挿入
+- `TRUNCATE_INSERT` - 切り捨て後に挿入
+
+
+### AssertionProvider
+
+期待値検証のためのデータベースアサーションを実行します。
+
+**パッケージ**: `io.github.seijikohara.dbtester.api.spi.AssertionProvider`
+
+**インターフェース**:
+
+```java
+public interface AssertionProvider {
+    // コア比較メソッド
+    void assertEquals(DataSet expected, DataSet actual);
+    void assertEquals(DataSet expected, DataSet actual, AssertionFailureHandler failureHandler);
+    void assertEquals(Table expected, Table actual);
+    void assertEquals(Table expected, Table actual, Collection<String> additionalColumnNames);
+    void assertEquals(Table expected, Table actual, AssertionFailureHandler failureHandler);
+
+    // カラム除外付き比較
+    void assertEqualsIgnoreColumns(DataSet expected, DataSet actual, String tableName,
+                                   Collection<String> ignoreColumnNames);
+    void assertEqualsIgnoreColumns(Table expected, Table actual,
+                                   Collection<String> ignoreColumnNames);
+
+    // SQLクエリベース比較
+    void assertEqualsByQuery(DataSet expected, DataSource dataSource, String sqlQuery,
+                             String tableName, Collection<String> ignoreColumnNames);
+    void assertEqualsByQuery(Table expected, DataSource dataSource, String tableName,
+                             String sqlQuery, Collection<String> ignoreColumnNames);
+}
+```
+
+**デフォルト実装**: `db-tester-core`の`DefaultAssertionProvider`
+
+**主要メソッド**:
+
+| メソッド | 説明 |
+|----------|------|
+| `assertEquals(DataSet, DataSet)` | 2つのデータセットを比較 |
+| `assertEquals(Table, Table)` | 2つのテーブルを比較 |
+| `assertEqualsIgnoreColumns(...)` | 特定カラムを無視して比較 |
+| `assertEqualsByQuery(...)` | クエリ結果を期待データと比較 |
+
+**動作**:
+1. 期待値と実際のデータセット/テーブルを比較
+2. カラムごとに比較戦略を適用（STRICT、IGNORE、NUMERICなど）
+3. すべての差異を収集（フェイルファストではない）
+4. 不一致時は人間が読みやすい要約 + YAML詳細を出力
+
+出力形式の詳細については[エラーハンドリング - 検証エラー](09-error-handling#検証エラー)を参照してください。
+
+
+### ExpectationProvider
+
+期待データセットに対するデータベース状態を検証します。
+
+**パッケージ**: `io.github.seijikohara.dbtester.api.spi.ExpectationProvider`
+
+**インターフェース**:
+
+```java
+public interface ExpectationProvider {
+    void verifyExpectation(DataSet expectedDataSet, DataSource dataSource);
+}
+```
+
+**デフォルト実装**: `db-tester-core`の`DefaultExpectationProvider`
+
+**パラメータ**:
+
+| パラメータ | 型 | 説明 |
+|-----------|-----|------|
+| `expectedDataSet` | `DataSet` | 期待テーブルデータを含む期待データセット |
+| `dataSource` | `DataSource` | 実際のデータを取得するためのデータベースコネクションソース |
+
+**プロセス**:
+1. 期待データセット内の各テーブルに対して、データベースから実際のデータを取得
+2. 実際のデータを期待テーブルに存在するカラムのみにフィルタリング
+3. フィルタリングされた実際のデータを期待データと比較
+4. 検証失敗時は`AssertionError`をスロー
+
+
+### ScenarioNameResolver
+
+テストメソッドコンテキストからシナリオ名を解決します。
+
+**パッケージ**: `io.github.seijikohara.dbtester.api.scenario.ScenarioNameResolver`
+
+**インターフェース**:
+
+```java
+public interface ScenarioNameResolver {
+    int DEFAULT_PRIORITY = 0;
+
+    ScenarioName resolve(Method testMethod);
+
+    default boolean canResolve(Method testMethod) {
+        return true;
+    }
+
+    default int priority() {
+        return DEFAULT_PRIORITY;
+    }
+}
+```
+
+**メソッド**:
+
+| メソッド | 戻り値型 | デフォルト | 説明 |
+|----------|---------|----------|------|
+| `resolve(Method)` | `ScenarioName` | - | テストメソッドからシナリオ名を解決 |
+| `canResolve(Method)` | `boolean` | `true` | リゾルバがメソッドを処理できるかを返す |
+| `priority()` | `int` | `0` | リゾルバ選択の優先度を返す（大きいほど優先） |
+
+**実装**:
+
+| 実装 | モジュール | 説明 |
+|------|----------|------|
+| `JUnitScenarioNameResolver` | `db-tester-junit` | JUnitメソッド名から解決 |
+| `SpockScenarioNameResolver` | `db-tester-spock` | Spockフィーチャー名から解決 |
+
+**解決ロジック**:
+1. 登録されたすべてのリゾルバを`priority()`で降順ソート
+2. 各リゾルバに`canResolve()`を問い合わせ
+3. `true`を返す最初のリゾルバを使用
+4. `resolve()`を呼び出してシナリオ名を取得
+
+
+## CoreモジュールSPI
+
+### FormatProvider
+
+特定形式のデータセットファイルを解析します。
+
+**パッケージ**: `io.github.seijikohara.dbtester.internal.format.spi.FormatProvider`
+
+**インターフェース**:
+
+```java
+public interface FormatProvider {
+    FileExtension supportedFileExtension();
+    DataSet parse(Path directory);
+}
+```
+
+**メソッド**:
+
+| メソッド | 戻り値型 | 説明 |
+|----------|---------|------|
+| `supportedFileExtension()` | `FileExtension` | 先頭ドットなしのファイル拡張子を返す（例: "csv"） |
+| `parse(Path)` | `DataSet` | ディレクトリ内のすべてのファイルをDataSetに解析 |
+
+**実装**:
+
+| 実装 | 拡張子 | 区切り文字 |
+|------|--------|----------|
+| `CsvFormatProvider` | `.csv` | カンマ |
+| `TsvFormatProvider` | `.tsv` | タブ |
+
+**注意**: FormatProviderは外部実装を意図していない内部SPIです。
+
+
+## ServiceLoader登録
+
+### META-INF/servicesファイル
+
+**db-tester-core**:
+
+```
+# META-INF/services/io.github.seijikohara.dbtester.api.spi.DataSetLoaderProvider
+io.github.seijikohara.dbtester.internal.loader.DefaultDataSetLoaderProvider
+
+# META-INF/services/io.github.seijikohara.dbtester.api.spi.OperationProvider
+io.github.seijikohara.dbtester.internal.spi.DefaultOperationProvider
+
+# META-INF/services/io.github.seijikohara.dbtester.api.spi.AssertionProvider
+io.github.seijikohara.dbtester.internal.spi.DefaultAssertionProvider
+
+# META-INF/services/io.github.seijikohara.dbtester.api.spi.ExpectationProvider
+io.github.seijikohara.dbtester.internal.spi.DefaultExpectationProvider
+
+# META-INF/services/io.github.seijikohara.dbtester.internal.format.spi.FormatProvider
+io.github.seijikohara.dbtester.internal.format.csv.CsvFormatProvider
+io.github.seijikohara.dbtester.internal.format.tsv.TsvFormatProvider
+```
+
+**db-tester-junit**:
+
+```
+# META-INF/services/io.github.seijikohara.dbtester.api.scenario.ScenarioNameResolver
+io.github.seijikohara.dbtester.junit.jupiter.spi.JUnitScenarioNameResolver
+```
+
+**db-tester-spock**:
+
+```
+# META-INF/services/io.github.seijikohara.dbtester.api.scenario.ScenarioNameResolver
+io.github.seijikohara.dbtester.spock.spi.SpockScenarioNameResolver
+```
+
+### JPMSモジュール宣言
+
+**db-tester-api module-info.java**:
+
+```java
+module io.github.seijikohara.dbtester.api {
+    uses io.github.seijikohara.dbtester.api.spi.DataSetLoaderProvider;
+    uses io.github.seijikohara.dbtester.api.spi.OperationProvider;
+    uses io.github.seijikohara.dbtester.api.spi.AssertionProvider;
+    uses io.github.seijikohara.dbtester.api.spi.ExpectationProvider;
+    uses io.github.seijikohara.dbtester.api.scenario.ScenarioNameResolver;
+}
+```
+
+**db-tester-core module-info.java**:
+
+```java
+module io.github.seijikohara.dbtester.core {
+    provides io.github.seijikohara.dbtester.api.spi.DataSetLoaderProvider
+        with io.github.seijikohara.dbtester.internal.loader.DefaultDataSetLoaderProvider;
+    provides io.github.seijikohara.dbtester.api.spi.OperationProvider
+        with io.github.seijikohara.dbtester.internal.spi.DefaultOperationProvider;
+    // ... 他のプロバイダー
+}
+```
+
+
+## カスタム実装
+
+### カスタムDataSetLoader
+
+カスタムデータセットローダーを提供するには:
+
+1. `DataSetLoader`インターフェースを実装:
+
+```java
+public class CustomDataSetLoader implements DataSetLoader {
+    @Override
+    public List<DataSet> loadPreparationDataSets(TestContext context) {
+        // カスタム読み込みロジック
+    }
+
+    @Override
+    public List<DataSet> loadExpectationDataSets(TestContext context) {
+        // カスタム読み込みロジック
+    }
+}
+```
+
+2. `Configuration`経由で登録:
+
+```java
+var config = Configuration.withLoader(new CustomDataSetLoader());
+DatabaseTestExtension.setConfiguration(context, config);
+```
+
+### カスタムScenarioNameResolver
+
+カスタムシナリオリゾルバを提供するには:
+
+1. `ScenarioNameResolver`を実装:
+
+```java
+public class CustomScenarioNameResolver implements ScenarioNameResolver {
+    private static final int HIGH_PRIORITY = 100;
+
+    @Override
+    public ScenarioName resolve(Method testMethod) {
+        // メソッドからシナリオ名を抽出
+    }
+
+    @Override
+    public boolean canResolve(Method testMethod) {
+        // サポートされるメソッドに対してtrueを返す
+    }
+
+    @Override
+    public int priority() {
+        return HIGH_PRIORITY;  // デフォルトリゾルバより高い優先度
+    }
+}
+```
+
+2. ServiceLoader経由で登録:
+
+```
+# META-INF/services/io.github.seijikohara.dbtester.api.scenario.ScenarioNameResolver
+com.example.CustomScenarioNameResolver
+```
+
+### カスタムFormatProvider
+
+追加のファイル形式をサポートするには（内部SPI）:
+
+1. `FormatProvider`を実装:
+
+```java
+public class XmlFormatProvider implements FormatProvider {
+    @Override
+    public boolean canHandle(String fileExtension) {
+        return ".xml".equals(fileExtension);
+    }
+
+    @Override
+    public DataSet parseDataSet(Path filePath, ConventionSettings conventions) {
+        // XMLファイルを解析
+    }
+}
+```
+
+2. ServiceLoader経由で登録:
+
+```
+# META-INF/services/io.github.seijikohara.dbtester.internal.format.spi.FormatProvider
+com.example.XmlFormatProvider
+```
+
+### プロバイダー優先順位
+
+複数のプロバイダーが登録されている場合:
+
+| SPI | 選択方法 |
+|-----|----------|
+| `DataSetLoaderProvider` | 最初に見つかったもの |
+| `OperationProvider` | 最初に見つかったもの |
+| `AssertionProvider` | 最初に見つかったもの |
+| `ExpectationProvider` | 最初に見つかったもの |
+| `ScenarioNameResolver` | `priority()`でソート、`canResolve()`がtrueを返す最初のもの |
+| `FormatProvider` | `canHandle()`がtrueを返す最初のもの |
+
+
+## 関連仕様
+
+- [アーキテクチャ](02-architecture) - モジュール構造
+- [設定](04-configuration) - 設定クラス
+- [テストフレームワーク](07-test-frameworks) - フレームワーク統合

--- a/docs/specs/ja/09-error-handling.md
+++ b/docs/specs/ja/09-error-handling.md
@@ -1,0 +1,328 @@
+# DB Tester仕様 - エラーハンドリング
+
+本ドキュメントでは、DB Testerフレームワークのエラーハンドリングとエラー出力について説明します。
+
+
+## 例外階層
+
+すべてのフレームワーク例外は`DatabaseTesterException`を継承します:
+
+```mermaid
+classDiagram
+    RuntimeException <|-- DatabaseTesterException
+    DatabaseTesterException <|-- ValidationException
+    DatabaseTesterException <|-- DataSetLoadException
+    DatabaseTesterException <|-- DataSourceNotFoundException
+    DatabaseTesterException <|-- DatabaseOperationException
+    DatabaseTesterException <|-- ConfigurationException
+```
+
+**パッケージ**: `io.github.seijikohara.dbtester.api.exception`
+
+| 例外 | 原因 |
+|------|------|
+| `ValidationException` | 期待値と実際のデータの不一致 |
+| `DataSetLoadException` | データセットファイルの読み込み/解析失敗 |
+| `DataSourceNotFoundException` | DataSourceが登録されていない |
+| `DatabaseOperationException` | SQL実行失敗 |
+| `ConfigurationException` | フレームワーク初期化失敗 |
+
+
+## 検証エラー
+
+期待値検証が失敗した場合にスローされます（`@Expectation`フェーズ）。
+
+### 出力形式
+
+検証エラーは**すべての差異**を収集し、人間が読みやすい要約に続いてYAML詳細を報告します:
+
+```
+Assertion failed: 3 differences in USERS, ORDERS
+summary:
+  status: FAILED
+  total_differences: 3
+tables:
+  USERS:
+    differences:
+      - path: row_count
+        expected: 3
+        actual: 2
+  ORDERS:
+    differences:
+      - path: "row[0].STATUS"
+        expected: COMPLETED
+        actual: PENDING
+        column:
+          type: VARCHAR(50)
+          nullable: true
+      - path: "row[1].AMOUNT"
+        expected: 100.00
+        actual: 99.99
+        column:
+          type: "DECIMAL(10,2)"
+```
+
+出力は（最初の要約行の後）**有効なYAML**であり、CI/CD統合のために標準YAMLライブラリで解析できます。
+
+### 出力構造
+
+| フィールド | 説明 |
+|------------|------|
+| `summary.status` | 差異が存在する場合は`FAILED` |
+| `summary.total_differences` | すべての差異の合計数 |
+| `tables.<name>.differences` | 各テーブルの差異リスト |
+| `path` | 場所: `table_count`、`row_count`、または`row[N].COLUMN` |
+| `expected` / `actual` | 期待値と実際の値 |
+| `column` | 利用可能な場合のJDBCメタデータ（type、nullable、primary_key） |
+
+### 差異の種類
+
+| パス | 説明 |
+|------|------|
+| `table_count` | 期待テーブル数と実際のテーブル数が異なる |
+| `table` | 期待テーブルが存在しない（`expected: exists`、`actual: not found`） |
+| `row_count` | テーブルの行数が異なる |
+| `row[N].COLUMN` | 行インデックスNのセル値が異なる |
+
+### 値比較ルール
+
+コンパレータは不一致を報告する前に以下のルールを適用します:
+
+| ルール | 説明 |
+|--------|------|
+| NULL処理 | 両方がNULL = 一致、片方がNULL = 不一致 |
+| 数値比較 | 文字列"123"はInteger 123と一致 |
+| 浮動小数点 | イプシロン比較（精度1e-6） |
+| ブール値 | "1"/"0"/"true"/"false"/"yes"/"no"/"y"/"n"をサポート |
+| タイムスタンプ精度 | "2024-01-01 10:00:00"は"2024-01-01 10:00:00.0"と一致 |
+| CLOB | 文字列として比較 |
+
+
+## データセット読み込みエラー
+
+データセットファイルを読み込めないか解析できない場合にスローされます。
+
+### ディレクトリが見つからない（クラスパス）
+
+データセットディレクトリがクラスパス上に存在しない場合:
+
+```
+Dataset directory not found on classpath: 'com/example/UserRepositoryTest'
+Expected location: src/test/resources/com/example/UserRepositoryTest
+Hint: Create the directory and add dataset files...
+```
+
+### ディレクトリが見つからない（ファイルシステム）
+
+データセットディレクトリがファイルシステム上に存在しない場合:
+
+```
+Dataset directory does not exist: '/path/to/datasets'
+Hint: Create the directory and add dataset files...
+```
+
+### パスがディレクトリではない
+
+パスは存在するがファイルの場合:
+
+```
+Path exists but is not a directory: '/path/to/file.csv'
+Hint: Ensure the path points to a directory, not a file.
+```
+
+### サポートされるファイルがない
+
+ディレクトリは存在するがサポートされるデータファイルがない場合:
+
+```
+Dataset directory exists but contains no supported data files: '/path/to/datasets'
+Supported file extensions: .csv, .tsv
+Hint: Add at least one data file (for example, TABLE_NAME.csv)...
+```
+
+### 空のファイル
+
+データファイルが空の場合:
+
+```
+File is empty: /path/to/USERS.csv
+```
+
+### 解析失敗
+
+ファイル解析が失敗した場合:
+
+```
+Failed to parse file: /path/to/USERS.csv
+```
+
+### 読み込み順序ファイルエラー
+
+`load-order.txt`ファイルを読み取れないか書き込めない場合:
+
+```
+Failed to read load order file: /path/to/load-order.txt
+```
+
+```
+Failed to write load order file: /path/to/load-order.txt
+```
+
+読み込み順序ファイルの形式と使用方法の詳細については、[データフォーマット - 読み込み順序](05-data-formats#読み込み順序)を参照してください。
+
+
+## DataSourceエラー
+
+DataSourceの検索が失敗した場合にスローされます。
+
+### デフォルトDataSourceが登録されていない
+
+デフォルトDataSourceが登録されていない場合:
+
+```
+No default data source registered
+```
+
+**解決策**: `@BeforeAll`または`setupSpec()`でデフォルトDataSourceを登録:
+
+```java
+registry.registerDefault(dataSource);
+```
+
+### 名前付きDataSourceが見つからない
+
+名前付きDataSourceが登録されていない場合:
+
+```
+No data source registered for name: secondary_db
+```
+
+**解決策**: 名前付きDataSourceを登録:
+
+```java
+registry.register("secondary_db", dataSource);
+```
+
+
+## データベース操作エラー
+
+準備フェーズ中にSQL操作が失敗した場合にスローされます。
+
+### ラップされたSQL例外
+
+データベース操作エラーは基盤となる`SQLException`をラップします:
+
+```
+DatabaseOperationException: Failed to execute INSERT on table USERS
+Caused by: SQLException: Duplicate entry '1' for key 'PRIMARY'
+```
+
+### 一般的な原因
+
+| エラー | 原因 | 解決策 |
+|--------|------|--------|
+| 重複キー | 既存の主キーでINSERT | CLEAN_INSERTまたはREFRESHを使用 |
+| 外部キー違反 | 親より先に子をINSERT | テーブル順序を確認 |
+| カラムが見つからない | CSVカラム名のタイプミス | カラム名がスキーマと一致することを確認 |
+| データ切り詰め | 値がカラムサイズを超過 | データがカラム定義に収まることを確認 |
+
+
+## 設定エラー
+
+フレームワーク初期化中にスローされます。
+
+### 無効な設定
+
+設定値が無効な場合:
+
+```
+ConfigurationException: Invalid data format: XML
+```
+
+### 必須設定が欠落
+
+必須設定が欠落している場合:
+
+```
+ConfigurationException: Convention settings cannot be null
+```
+
+
+## テスト出力でのエラーコンテキスト
+
+### JUnitエラー出力
+
+```
+org.example.UserRepositoryTest > shouldCreateUser FAILED
+    java.lang.AssertionError:
+        Assertion failed: 1 difference in USERS
+        summary:
+          status: FAILED
+          total_differences: 1
+        tables:
+          USERS:
+            differences:
+              - path: "row[0].EMAIL"
+                expected: john@example.com
+                actual: jane@example.com
+                column:
+                  type: VARCHAR(255)
+                  nullable: false
+
+        at io.github.seijikohara.dbtester.internal.assertion.DataSetComparator.assertEquals(DataSetComparator.java:85)
+        at io.github.seijikohara.dbtester.junit.jupiter.lifecycle.ExpectationVerifier.verify(ExpectationVerifier.java:42)
+```
+
+### Spockエラー出力
+
+```
+example.UserRepositorySpec > should create user FAILED
+    java.lang.AssertionError:
+        Assertion failed: 1 difference in USERS
+        summary:
+          status: FAILED
+          total_differences: 1
+        tables:
+          USERS:
+            differences:
+              - path: row_count
+                expected: 2
+                actual: 1
+
+Condition not satisfied:
+    Expectation verification failed
+```
+
+### テストメソッドコンテキスト
+
+エラーにはコンテキストとしてテストメソッド名が含まれます:
+
+```
+Failed to verify expectation dataset for testUserCreation
+```
+
+
+## デバッグのヒント
+
+| 症状 | 確認事項 |
+|------|----------|
+| テーブルが見つからない | CSVファイル名がテーブル名と一致することを確認（大文字小文字を区別） |
+| 行数の不一致 | `[Scenario]`カラムのフィルタリングを確認 |
+| 値の不一致 | 期待CSVを実際のデータベース状態と比較 |
+| ディレクトリが見つからない | パスが`{package}/{TestClassName}/`規約と一致することを確認 |
+| DataSourceが見つからない | `@BeforeAll`または`setupSpec()`での登録を確認 |
+
+### ロギング
+
+詳細な操作出力のためにDEBUGロギングを有効化:
+
+```properties
+logging.level.io.github.seijikohara.dbtester=DEBUG
+```
+
+
+## 関連仕様
+
+- [パブリックAPI](03-public-api) - 例外クラス
+- [データベース操作](06-database-operations) - 操作失敗
+- [テストフレームワーク](07-test-frameworks) - テストライフサイクルとエラーハンドリング

--- a/docs/specs/ja/index.md
+++ b/docs/specs/ja/index.md
@@ -1,0 +1,174 @@
+---
+layout: home
+
+hero:
+  name: "DB Tester"
+  text: "データベーステストフレームワーク"
+  tagline: アノテーションによるテストデータの準備と検証 - JUnit・Spock対応
+  image:
+    src: /favicon.svg
+    alt: DB Tester
+  actions:
+    - theme: brand
+      text: はじめる
+      link: /ja/01-overview
+    - theme: alt
+      text: GitHubで見る
+      link: https://github.com/seijikohara/db-tester
+    - theme: alt
+      text: Maven Central
+      link: https://central.sonatype.com/artifact/io.github.seijikohara/db-tester-junit
+
+features:
+  - icon: 📝
+    title: 宣言的なテスト
+    details: "@Preparationと@Expectationアノテーションを使用して、ボイラープレートコードなしでテストデータのセットアップと検証を定義できます。"
+    link: /ja/03-public-api
+    linkText: APIリファレンスを見る
+  - icon: 📁
+    title: 設定より規約
+    details: テストクラスとメソッド名に基づいた自動データセット検出。規約に従うだけで動作します。
+    link: /ja/04-configuration
+    linkText: 規約を学ぶ
+  - icon: 🔧
+    title: 複数フレームワーク対応
+    details: JUnit JupiterとSpock Frameworkを完全サポート。Spring Boot統合も利用可能です。
+    link: /ja/07-test-frameworks
+    linkText: フレームワーク統合
+  - icon: 📊
+    title: 柔軟なデータフォーマット
+    details: CSVとTSVをサポート。シナリオフィルタリングにより複数のテストでデータセットを共有できます。
+    link: /ja/05-data-formats
+    linkText: データフォーマットガイド
+  - icon: 🗄️
+    title: データベース操作
+    details: CLEAN_INSERT、INSERT、UPDATE、DELETE、TRUNCATEなどをサポート。テーブル順序のカスタマイズも可能です。
+    link: /ja/06-database-operations
+    linkText: 操作リファレンス
+  - icon: 🔌
+    title: 拡張可能なアーキテクチャ
+    details: カスタムデータローダー、コンパレータ、操作ハンドラー用のサービスプロバイダーインターフェース（SPI）を提供します。
+    link: /ja/08-spi
+    linkText: 拡張ポイント
+---
+
+## クイックスタート
+
+### インストール
+
+::: code-group
+
+```kotlin [Gradle (Kotlin DSL)]
+dependencies {
+    // BOMを使用（推奨）
+    testImplementation(platform("io.github.seijikohara:db-tester-bom:VERSION"))
+
+    // JUnit
+    testImplementation("io.github.seijikohara:db-tester-junit")
+
+    // または Spock
+    testImplementation("io.github.seijikohara:db-tester-spock")
+}
+```
+
+```groovy [Gradle (Groovy DSL)]
+dependencies {
+    // BOMを使用（推奨）
+    testImplementation platform('io.github.seijikohara:db-tester-bom:VERSION')
+
+    // JUnit
+    testImplementation 'io.github.seijikohara:db-tester-junit'
+
+    // または Spock
+    testImplementation 'io.github.seijikohara:db-tester-spock'
+}
+```
+
+```xml [Maven]
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>io.github.seijikohara</groupId>
+            <artifactId>db-tester-bom</artifactId>
+            <version>VERSION</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+
+<dependencies>
+    <!-- JUnit -->
+    <dependency>
+        <groupId>io.github.seijikohara</groupId>
+        <artifactId>db-tester-junit</artifactId>
+        <scope>test</scope>
+    </dependency>
+
+    <!-- または Spock -->
+    <dependency>
+        <groupId>io.github.seijikohara</groupId>
+        <artifactId>db-tester-spock</artifactId>
+        <scope>test</scope>
+    </dependency>
+</dependencies>
+```
+
+:::
+
+### 基本的な使い方
+
+```java
+@ExtendWith(DatabaseTestExtension.class)
+class UserRepositoryTest {
+
+    @Preparation  // CSVからテストデータを読み込む
+    @Expectation  // データベースの状態を検証
+    @Test
+    void shouldCreateUser() {
+        // テストロジックをここに記述
+        userRepository.create(new User("john", "john@example.com"));
+    }
+}
+```
+
+### ディレクトリ構造
+
+```
+src/test/resources/
+└── com/example/UserRepositoryTest/
+    ├── shouldCreateUser/
+    │   └── users.csv           # 準備データ
+    └── shouldCreateUser/
+        └── expected/
+            └── users.csv       # 期待される状態
+```
+
+### 検証出力
+
+期待値の検証が失敗した場合、DB Testerは詳細なYAML形式のエラーメッセージを提供します：
+
+```yaml
+Assertion failed: 2 differences in USERS
+summary:
+  status: FAILED
+  total_differences: 2
+tables:
+  USERS:
+    differences:
+      - path: row_count
+        expected: 3
+        actual: 2
+      - path: "row[0].EMAIL"
+        expected: john@example.com
+        actual: john@test.com
+        column:
+          type: VARCHAR(255)
+          nullable: false
+```
+
+::: tip
+出力は有効なYAMLであり、CI/CD統合のために標準的なYAMLライブラリで解析できます。
+:::
+
+詳細は[エラーハンドリング](/ja/09-error-handling)を参照してください。


### PR DESCRIPTION
## Summary

- Add complete Japanese translations for all specification pages (01-09)
- Add Japanese homepage with localized feature descriptions  
- Configure VitePress i18n for Japanese locale
- Add search localization for Japanese interface
- Add accessibility labels (langMenuLabel, skipToContentLabel, etc.)
- Add custom CSS theme styles

## Changes

### New Japanese Documentation Files
- `docs/specs/ja/index.md` - Homepage
- `docs/specs/ja/01-overview.md` - Overview
- `docs/specs/ja/02-architecture.md` - Architecture
- `docs/specs/ja/03-public-api.md` - Public API
- `docs/specs/ja/04-configuration.md` - Configuration
- `docs/specs/ja/05-data-formats.md` - Data Formats
- `docs/specs/ja/06-database-operations.md` - Database Operations
- `docs/specs/ja/07-test-frameworks.md` - Test Frameworks
- `docs/specs/ja/08-spi.md` - SPI
- `docs/specs/ja/09-error-handling.md` - Error Handling

### VitePress Configuration Updates
- Add Japanese locale configuration with navigation and sidebar
- Add search localization for Japanese UI
- Add accessibility labels for better screen reader support
- Add custom CSS theme styles

## Test plan

- [x] Verify Japanese pages render correctly at `/ja/` path
- [x] Verify language switcher works between English and Japanese
- [x] Verify search works in Japanese locale
- [x] Verify all internal links point to correct Japanese pages