### PR TITLE
refactor: encapsulate internal dependencies and add public factory methods

### DIFF
--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/dataset/DataSet.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/dataset/DataSet.java
@@ -26,6 +26,26 @@ import javax.sql.DataSource;
 public interface DataSet {
 
   /**
+   * Creates a new dataset with the given tables.
+   *
+   * @param tables the tables in this dataset
+   * @return a new immutable dataset instance
+   */
+  static DataSet of(final List<Table> tables) {
+    return new SimpleDataSet(List.copyOf(tables));
+  }
+
+  /**
+   * Creates a new dataset with the given tables.
+   *
+   * @param tables the tables in this dataset
+   * @return a new immutable dataset instance
+   */
+  static DataSet of(final Table... tables) {
+    return new SimpleDataSet(List.of(tables));
+  }
+
+  /**
    * Returns the tables that belong to this dataset in declaration order.
    *
    * @return immutable list of tables composing the dataset
@@ -47,4 +67,43 @@ public interface DataSet {
    * @return an Optional containing the bound data source, or empty if not specified
    */
   Optional<DataSource> getDataSource();
+
+  /**
+   * Simple immutable implementation of {@link DataSet}.
+   *
+   * @param tables the tables in this dataset
+   */
+  record SimpleDataSet(List<Table> tables) implements DataSet {
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return immutable list of tables in this dataset
+     */
+    @Override
+    public List<Table> getTables() {
+      return tables;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param tableName the name of the table to retrieve
+     * @return an Optional containing the table if found, or empty if not found
+     */
+    @Override
+    public Optional<Table> getTable(final TableName tableName) {
+      return tables.stream().filter(t -> t.getName().equals(tableName)).findFirst();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return an Optional that is always empty since this dataset has no associated data source
+     */
+    @Override
+    public Optional<DataSource> getDataSource() {
+      return Optional.empty();
+    }
+  }
 }

--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/dataset/Row.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/dataset/Row.java
@@ -20,6 +20,16 @@ import java.util.Map;
 public interface Row {
 
   /**
+   * Creates a new row with the given column-value pairs.
+   *
+   * @param values the column-value pairs for this row
+   * @return a new immutable row instance
+   */
+  static Row of(final Map<ColumnName, CellValue> values) {
+    return new SimpleRow(Map.copyOf(values));
+  }
+
+  /**
    * Returns the column/value pairs that compose this row.
    *
    * @return immutable mapping of columns to their values
@@ -35,4 +45,33 @@ public interface Row {
    * @return the data value for the requested column, wrapping {@code null} when absent
    */
   CellValue getValue(ColumnName column);
+
+  /**
+   * Simple immutable implementation of {@link Row}.
+   *
+   * @param values the column-value pairs for this row
+   */
+  record SimpleRow(Map<ColumnName, CellValue> values) implements Row {
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return immutable mapping of columns to their values
+     */
+    @Override
+    public Map<ColumnName, CellValue> getValues() {
+      return values;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param column the identifier of the column to look up
+     * @return the data value for the requested column, or {@link CellValue#NULL} when absent
+     */
+    @Override
+    public CellValue getValue(final ColumnName column) {
+      return values.getOrDefault(column, CellValue.NULL);
+    }
+  }
 }

--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/dataset/Table.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/dataset/Table.java
@@ -22,6 +22,31 @@ import java.util.List;
 public interface Table {
 
   /**
+   * Creates a new table with the given name, columns, and rows.
+   *
+   * @param name the table name
+   * @param columns the column names in declaration order
+   * @param rows the rows in this table
+   * @return a new immutable table instance
+   */
+  static Table of(final TableName name, final List<ColumnName> columns, final List<Row> rows) {
+    return new SimpleTable(name, List.copyOf(columns), List.copyOf(rows));
+  }
+
+  /**
+   * Creates a new table with the given name (as string), columns (as strings), and rows.
+   *
+   * @param name the table name
+   * @param columns the column names in declaration order
+   * @param rows the rows in this table
+   * @return a new immutable table instance
+   */
+  static Table of(final String name, final List<String> columns, final List<Row> rows) {
+    return new SimpleTable(
+        new TableName(name), columns.stream().map(ColumnName::new).toList(), List.copyOf(rows));
+  }
+
+  /**
    * Returns the logical name of this table.
    *
    * @return the table identifier
@@ -55,4 +80,54 @@ public interface Table {
    * @return number of rows contained in the table (zero or positive)
    */
   int getRowCount();
+
+  /**
+   * Simple immutable implementation of {@link Table}.
+   *
+   * @param name the table name
+   * @param columns the column names
+   * @param rows the rows in this table
+   */
+  record SimpleTable(TableName name, List<ColumnName> columns, List<Row> rows) implements Table {
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return the table name
+     */
+    @Override
+    public TableName getName() {
+      return name;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return immutable list of column names
+     */
+    @Override
+    public List<ColumnName> getColumns() {
+      return columns;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return immutable list of rows
+     */
+    @Override
+    public List<Row> getRows() {
+      return rows;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return the number of rows in this table
+     */
+    @Override
+    public int getRowCount() {
+      return rows.size();
+    }
+  }
 }

--- a/db-tester-core/build.gradle.kts
+++ b/db-tester-core/build.gradle.kts
@@ -9,12 +9,12 @@ dependencies {
     // API module (exposed to consumers)
     api(project(":db-tester-api"))
 
-    // Logging
-    api(platform(libs.slf4j.bom))
-    api(libs.slf4j.api)
+    // Logging (compile-time only - users provide their own SLF4J binding)
+    compileOnly(platform(libs.slf4j.bom))
+    compileOnly(libs.slf4j.api)
 
-    // CSV/TSV parsing and YAML output
-    api(platform(libs.jackson.bom))
+    // CSV/TSV parsing and YAML output (internal implementation only)
+    implementation(platform(libs.jackson.bom))
     implementation(libs.jackson.dataformat.csv)
     implementation(libs.jackson.dataformat.yaml)
 }
@@ -26,6 +26,8 @@ testing {
                 implementation(platform(libs.mockito.bom))
                 implementation(libs.mockito.core)
                 implementation(libs.mockito.junit.jupiter)
+                runtimeOnly(platform(libs.slf4j.bom))
+                runtimeOnly(libs.slf4j.simple)
             }
         }
     }

--- a/db-tester-core/src/main/java/module-info.java
+++ b/db-tester-core/src/main/java/module-info.java
@@ -1,8 +1,8 @@
 /**
  * DB Tester Core module providing internal implementation for database testing.
  *
- * <p>This module provides SPI implementations for the API module and exports internal packages for
- * framework integration (JUnit, Spock extensions).
+ * <p>This module provides SPI implementations for the API module. Internal packages are not
+ * exported to end users; they are only accessible within this module and via the SPI mechanism.
  */
 module io.github.seijikohara.dbtester.core {
   // API module dependency
@@ -11,27 +11,11 @@ module io.github.seijikohara.dbtester.core {
   // Required dependencies
   requires transitive java.sql;
   requires transitive org.jspecify;
-  requires transitive org.slf4j;
+  requires static org.slf4j;
   requires com.fasterxml.jackson.core;
   requires com.fasterxml.jackson.databind;
   requires com.fasterxml.jackson.dataformat.csv;
   requires com.fasterxml.jackson.dataformat.yaml;
-
-  // Internal packages exported for framework integration
-  exports io.github.seijikohara.dbtester.internal.assertion;
-  exports io.github.seijikohara.dbtester.internal.dataset;
-  exports io.github.seijikohara.dbtester.internal.domain;
-  exports io.github.seijikohara.dbtester.internal.format;
-  exports io.github.seijikohara.dbtester.internal.format.csv;
-  exports io.github.seijikohara.dbtester.internal.format.parser;
-  exports io.github.seijikohara.dbtester.internal.format.spi;
-  exports io.github.seijikohara.dbtester.internal.format.tsv;
-  exports io.github.seijikohara.dbtester.internal.jdbc;
-  exports io.github.seijikohara.dbtester.internal.jdbc.read;
-  exports io.github.seijikohara.dbtester.internal.jdbc.write;
-  exports io.github.seijikohara.dbtester.internal.loader;
-  exports io.github.seijikohara.dbtester.internal.scenario;
-  exports io.github.seijikohara.dbtester.internal.spi;
 
   // Internal SPI uses
   uses io.github.seijikohara.dbtester.api.scenario.ScenarioNameResolver;

--- a/db-tester-junit-spring-boot-starter/build.gradle.kts
+++ b/db-tester-junit-spring-boot-starter/build.gradle.kts
@@ -35,6 +35,7 @@ testing {
                 implementation(libs.mockito.junit.jupiter)
                 implementation(libs.spring.test)
                 implementation(libs.spring.boot.test)
+                runtimeOnly(platform(libs.slf4j.bom))
                 runtimeOnly(libs.slf4j.simple)
             }
         }

--- a/db-tester-junit/build.gradle.kts
+++ b/db-tester-junit/build.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 description = "DB Tester JUnit - JUnit Jupiter Extension for database testing"
 
 dependencies {
-    // Public API dependencies (only db-tester-api)
+    // Public API dependencies (only db-tester-api and JUnit API)
     api(project(":db-tester-api"))
-    api(platform(libs.junit.bom))
     api(libs.junit.jupiter.api)
 
-    // JUnit Jupiter implementation
+    // JUnit BOM for version management (internal only)
+    implementation(platform(libs.junit.bom))
     implementation(libs.junit.jupiter)
 
     // Compile-time dependency for logging
@@ -27,6 +27,7 @@ testing {
                 implementation(libs.mockito.core)
                 implementation(libs.mockito.junit.jupiter)
                 runtimeOnly(project(":db-tester-core"))
+                runtimeOnly(platform(libs.slf4j.bom))
                 runtimeOnly(libs.slf4j.simple)
             }
         }

--- a/db-tester-spock-spring-boot-starter/build.gradle.kts
+++ b/db-tester-spock-spring-boot-starter/build.gradle.kts
@@ -41,6 +41,7 @@ testing {
                 implementation(libs.mockito.core)
                 implementation(libs.spring.test)
                 implementation(libs.spring.boot.test)
+                runtimeOnly(platform(libs.slf4j.bom))
                 runtimeOnly(libs.slf4j.simple)
             }
         }

--- a/db-tester-spock/build.gradle.kts
+++ b/db-tester-spock/build.gradle.kts
@@ -7,12 +7,14 @@ plugins {
 description = "DB Tester Spock - Spock Framework Extension for database testing"
 
 dependencies {
-    // Public API dependencies (only db-tester-api)
+    // Public API dependencies (only db-tester-api and Spock API)
     api(project(":db-tester-api"))
-    api(platform(libs.groovy.bom))
-    api(libs.groovy)
-    api(platform(libs.spock.bom))
     api(libs.spock.core)
+
+    // Groovy and Spock BOM for version management (internal only)
+    implementation(platform(libs.groovy.bom))
+    implementation(libs.groovy)
+    implementation(platform(libs.spock.bom))
 
     // Compile-time dependency for logging
     compileOnly(platform(libs.slf4j.bom))
@@ -24,6 +26,7 @@ testing {
         val test by getting(JvmTestSuite::class) {
             dependencies {
                 runtimeOnly(project(":db-tester-core"))
+                runtimeOnly(platform(libs.slf4j.bom))
                 runtimeOnly(libs.slf4j.simple)
                 runtimeOnly(libs.junit.platform.launcher)
             }

--- a/docs/specs/03-public-api.md
+++ b/docs/specs/03-public-api.md
@@ -127,7 +127,14 @@ Represents a logical collection of database tables.
 
 **Location**: `io.github.seijikohara.dbtester.api.dataset.DataSet`
 
-**Methods**:
+**Factory Methods**:
+
+| Method | Return Type | Description |
+|--------|-------------|-------------|
+| `of(List<Table>)` | `DataSet` | Creates a dataset with the specified tables |
+| `of(Table...)` | `DataSet` | Creates a dataset with the specified tables (varargs) |
+
+**Instance Methods**:
 
 | Method | Return Type | Description |
 |--------|-------------|-------------|
@@ -148,7 +155,14 @@ Represents the structure and data of a database table.
 
 **Location**: `io.github.seijikohara.dbtester.api.dataset.Table`
 
-**Methods**:
+**Factory Methods**:
+
+| Method | Return Type | Description |
+|--------|-------------|-------------|
+| `of(TableName, List<ColumnName>, List<Row>)` | `Table` | Creates a table with type-safe names |
+| `of(String, List<String>, List<Row>)` | `Table` | Creates a table with string names (convenience) |
+
+**Instance Methods**:
 
 | Method | Return Type | Description |
 |--------|-------------|-------------|
@@ -170,7 +184,13 @@ Represents a single database record.
 
 **Location**: `io.github.seijikohara.dbtester.api.dataset.Row`
 
-**Methods**:
+**Factory Methods**:
+
+| Method | Return Type | Description |
+|--------|-------------|-------------|
+| `of(Map<ColumnName, CellValue>)` | `Row` | Creates a row with the specified column-value pairs |
+
+**Instance Methods**:
 
 | Method | Return Type | Description |
 |--------|-------------|-------------|

--- a/docs/specs/ja/03-public-api.md
+++ b/docs/specs/ja/03-public-api.md
@@ -127,7 +127,14 @@ void testMultipleScenarios() { }
 
 **パッケージ**: `io.github.seijikohara.dbtester.api.dataset.DataSet`
 
-**メソッド**:
+**ファクトリメソッド**:
+
+| メソッド | 戻り値型 | 説明 |
+|----------|---------|------|
+| `of(List<Table>)` | `DataSet` | 指定されたテーブルでデータセットを作成します |
+| `of(Table...)` | `DataSet` | 指定されたテーブルでデータセットを作成します（可変長引数） |
+
+**インスタンスメソッド**:
 
 | メソッド | 戻り値型 | 説明 |
 |----------|---------|------|
@@ -148,7 +155,14 @@ void testMultipleScenarios() { }
 
 **パッケージ**: `io.github.seijikohara.dbtester.api.dataset.Table`
 
-**メソッド**:
+**ファクトリメソッド**:
+
+| メソッド | 戻り値型 | 説明 |
+|----------|---------|------|
+| `of(TableName, List<ColumnName>, List<Row>)` | `Table` | 型安全な名前でテーブルを作成します |
+| `of(String, List<String>, List<Row>)` | `Table` | 文字列名でテーブルを作成します（簡易版） |
+
+**インスタンスメソッド**:
 
 | メソッド | 戻り値型 | 説明 |
 |----------|---------|------|
@@ -170,7 +184,13 @@ void testMultipleScenarios() { }
 
 **パッケージ**: `io.github.seijikohara.dbtester.api.dataset.Row`
 
-**メソッド**:
+**ファクトリメソッド**:
+
+| メソッド | 戻り値型 | 説明 |
+|----------|---------|------|
+| `of(Map<ColumnName, CellValue>)` | `Row` | 指定されたカラム値ペアで行を作成します |
+
+**インスタンスメソッド**:
 
 | メソッド | 戻り値型 | 説明 |
 |----------|---------|------|

--- a/examples/db-tester-example-junit/src/test/java/example/feature/ComparisonStrategyTest.java
+++ b/examples/db-tester-example-junit/src/test/java/example/feature/ComparisonStrategyTest.java
@@ -11,8 +11,6 @@ import io.github.seijikohara.dbtester.api.domain.CellValue;
 import io.github.seijikohara.dbtester.api.domain.ColumnName;
 import io.github.seijikohara.dbtester.api.domain.ComparisonStrategy;
 import io.github.seijikohara.dbtester.api.domain.TableName;
-import io.github.seijikohara.dbtester.internal.dataset.SimpleRow;
-import io.github.seijikohara.dbtester.internal.dataset.SimpleTable;
 import io.github.seijikohara.dbtester.junit.jupiter.extension.DatabaseTestExtension;
 import java.math.BigDecimal;
 import java.sql.SQLException;
@@ -142,8 +140,8 @@ public final class ComparisonStrategyTest {
     for (int i = 0; i < columns.size() && i < values.length; i++) {
       rowValues.put(columns.get(i), new CellValue(values[i]));
     }
-    final Row row = new SimpleRow(rowValues);
-    return new SimpleTable(new TableName(tableName), columns, List.of(row));
+    final var row = Row.of(rowValues);
+    return Table.of(new TableName(tableName), columns, List.of(row));
   }
 
   /**
@@ -162,8 +160,8 @@ public final class ComparisonStrategyTest {
     for (int i = 0; i < columns.size() && i < values.length; i++) {
       rowValues.put(columns.get(i), new CellValue(values[i]));
     }
-    final Row row = new SimpleRow(rowValues);
-    return new SimpleTable(new TableName(tableName), columns, List.of(row));
+    final var row = Row.of(rowValues);
+    return Table.of(new TableName(tableName), columns, List.of(row));
   }
 
   /** Tests for STRICT comparison strategy (default). */

--- a/examples/db-tester-example-junit/src/test/java/example/feature/ErrorHandlingTest.java
+++ b/examples/db-tester-example-junit/src/test/java/example/feature/ErrorHandlingTest.java
@@ -4,11 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.seijikohara.dbtester.api.assertion.DatabaseAssertion;
+import io.github.seijikohara.dbtester.api.dataset.Row;
+import io.github.seijikohara.dbtester.api.dataset.Table;
 import io.github.seijikohara.dbtester.api.domain.CellValue;
 import io.github.seijikohara.dbtester.api.domain.ColumnName;
 import io.github.seijikohara.dbtester.api.domain.TableName;
-import io.github.seijikohara.dbtester.internal.dataset.SimpleRow;
-import io.github.seijikohara.dbtester.internal.dataset.SimpleTable;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
@@ -58,21 +58,18 @@ public final class ErrorHandlingTest {
     final var columnValue = new ColumnName("NAME");
 
     // Expected: 3 rows
-    final var row1 =
-        new SimpleRow(Map.of(columnId, new CellValue(1), columnValue, new CellValue("One")));
-    final var row2 =
-        new SimpleRow(Map.of(columnId, new CellValue(2), columnValue, new CellValue("Two")));
+    final var row1 = Row.of(Map.of(columnId, new CellValue(1), columnValue, new CellValue("One")));
+    final var row2 = Row.of(Map.of(columnId, new CellValue(2), columnValue, new CellValue("Two")));
     final var row3 =
-        new SimpleRow(Map.of(columnId, new CellValue(3), columnValue, new CellValue("Three")));
+        Row.of(Map.of(columnId, new CellValue(3), columnValue, new CellValue("Three")));
 
     final var expectedTable =
-        new SimpleTable(
+        Table.of(
             new TableName("TEST_TABLE"), List.of(columnId, columnValue), List.of(row1, row2, row3));
 
     // Actual: 2 rows
     final var actualTable =
-        new SimpleTable(
-            new TableName("TEST_TABLE"), List.of(columnId, columnValue), List.of(row1, row2));
+        Table.of(new TableName("TEST_TABLE"), List.of(columnId, columnValue), List.of(row1, row2));
 
     final var exception =
         assertThrows(
@@ -101,19 +98,16 @@ public final class ErrorHandlingTest {
     final var columnValue = new ColumnName("NAME");
 
     // Expected: 1 row
-    final var row1 =
-        new SimpleRow(Map.of(columnId, new CellValue(1), columnValue, new CellValue("One")));
+    final var row1 = Row.of(Map.of(columnId, new CellValue(1), columnValue, new CellValue("One")));
 
     final var expectedTable =
-        new SimpleTable(new TableName("TEST_TABLE"), List.of(columnId, columnValue), List.of(row1));
+        Table.of(new TableName("TEST_TABLE"), List.of(columnId, columnValue), List.of(row1));
 
     // Actual: 2 rows
-    final var row2 =
-        new SimpleRow(Map.of(columnId, new CellValue(2), columnValue, new CellValue("Two")));
+    final var row2 = Row.of(Map.of(columnId, new CellValue(2), columnValue, new CellValue("Two")));
 
     final var actualTable =
-        new SimpleTable(
-            new TableName("TEST_TABLE"), List.of(columnId, columnValue), List.of(row1, row2));
+        Table.of(new TableName("TEST_TABLE"), List.of(columnId, columnValue), List.of(row1, row2));
 
     final var exception =
         assertThrows(
@@ -139,20 +133,16 @@ public final class ErrorHandlingTest {
     final var columnValue = new ColumnName("NAME");
 
     final var expectedRow =
-        new SimpleRow(
-            Map.of(columnId, new CellValue(1), columnValue, new CellValue("ExpectedValue")));
+        Row.of(Map.of(columnId, new CellValue(1), columnValue, new CellValue("ExpectedValue")));
 
     final var actualRow =
-        new SimpleRow(
-            Map.of(columnId, new CellValue(1), columnValue, new CellValue("ActualValue")));
+        Row.of(Map.of(columnId, new CellValue(1), columnValue, new CellValue("ActualValue")));
 
     final var expectedTable =
-        new SimpleTable(
-            new TableName("TEST_TABLE"), List.of(columnId, columnValue), List.of(expectedRow));
+        Table.of(new TableName("TEST_TABLE"), List.of(columnId, columnValue), List.of(expectedRow));
 
     final var actualTable =
-        new SimpleTable(
-            new TableName("TEST_TABLE"), List.of(columnId, columnValue), List.of(actualRow));
+        Table.of(new TableName("TEST_TABLE"), List.of(columnId, columnValue), List.of(actualRow));
 
     final var exception =
         assertThrows(
@@ -177,18 +167,16 @@ public final class ErrorHandlingTest {
     final var columnValue = new ColumnName("NAME");
 
     final var expectedRow =
-        new SimpleRow(Map.of(columnId, new CellValue(100), columnValue, new CellValue("Test")));
+        Row.of(Map.of(columnId, new CellValue(100), columnValue, new CellValue("Test")));
 
     final var actualRow =
-        new SimpleRow(Map.of(columnId, new CellValue(999), columnValue, new CellValue("Test")));
+        Row.of(Map.of(columnId, new CellValue(999), columnValue, new CellValue("Test")));
 
     final var expectedTable =
-        new SimpleTable(
-            new TableName("TEST_TABLE"), List.of(columnId, columnValue), List.of(expectedRow));
+        Table.of(new TableName("TEST_TABLE"), List.of(columnId, columnValue), List.of(expectedRow));
 
     final var actualTable =
-        new SimpleTable(
-            new TableName("TEST_TABLE"), List.of(columnId, columnValue), List.of(actualRow));
+        Table.of(new TableName("TEST_TABLE"), List.of(columnId, columnValue), List.of(actualRow));
 
     final var exception =
         assertThrows(
@@ -212,19 +200,16 @@ public final class ErrorHandlingTest {
     final var columnId = new ColumnName("ID");
     final var columnValue = new ColumnName("NAME");
 
-    final var expectedRow =
-        new SimpleRow(Map.of(columnId, new CellValue(1), columnValue, CellValue.NULL));
+    final var expectedRow = Row.of(Map.of(columnId, new CellValue(1), columnValue, CellValue.NULL));
 
     final var actualRow =
-        new SimpleRow(Map.of(columnId, new CellValue(1), columnValue, new CellValue("NotNull")));
+        Row.of(Map.of(columnId, new CellValue(1), columnValue, new CellValue("NotNull")));
 
     final var expectedTable =
-        new SimpleTable(
-            new TableName("TEST_TABLE"), List.of(columnId, columnValue), List.of(expectedRow));
+        Table.of(new TableName("TEST_TABLE"), List.of(columnId, columnValue), List.of(expectedRow));
 
     final var actualTable =
-        new SimpleTable(
-            new TableName("TEST_TABLE"), List.of(columnId, columnValue), List.of(actualRow));
+        Table.of(new TableName("TEST_TABLE"), List.of(columnId, columnValue), List.of(actualRow));
 
     final var exception =
         assertThrows(
@@ -251,7 +236,7 @@ public final class ErrorHandlingTest {
     final var columnExtra = new ColumnName("EXTRA");
 
     final var expectedRow =
-        new SimpleRow(
+        Row.of(
             Map.of(
                 columnId,
                 new CellValue(1),
@@ -261,17 +246,16 @@ public final class ErrorHandlingTest {
                 new CellValue("ExtraData")));
 
     final var actualRow =
-        new SimpleRow(Map.of(columnId, new CellValue(1), columnValue, new CellValue("One")));
+        Row.of(Map.of(columnId, new CellValue(1), columnValue, new CellValue("One")));
 
     final var expectedTable =
-        new SimpleTable(
+        Table.of(
             new TableName("TEST_TABLE"),
             List.of(columnId, columnValue, columnExtra),
             List.of(expectedRow));
 
     final var actualTable =
-        new SimpleTable(
-            new TableName("TEST_TABLE"), List.of(columnId, columnValue), List.of(actualRow));
+        Table.of(new TableName("TEST_TABLE"), List.of(columnId, columnValue), List.of(actualRow));
 
     final var exception =
         assertThrows(
@@ -298,20 +282,19 @@ public final class ErrorHandlingTest {
     final var columnDescription = new ColumnName("DESCRIPTION");
 
     final var expectedRow =
-        new SimpleRow(Map.of(columnId, new CellValue(1), columnDescription, new CellValue("Desc")));
+        Row.of(Map.of(columnId, new CellValue(1), columnDescription, new CellValue("Desc")));
 
     final var actualRow =
-        new SimpleRow(Map.of(columnId, new CellValue(1), columnValue, new CellValue("Desc")));
+        Row.of(Map.of(columnId, new CellValue(1), columnValue, new CellValue("Desc")));
 
     final var expectedTable =
-        new SimpleTable(
+        Table.of(
             new TableName("TEST_TABLE"),
             List.of(columnId, columnDescription),
             List.of(expectedRow));
 
     final var actualTable =
-        new SimpleTable(
-            new TableName("TEST_TABLE"), List.of(columnId, columnValue), List.of(actualRow));
+        Table.of(new TableName("TEST_TABLE"), List.of(columnId, columnValue), List.of(actualRow));
 
     final var exception =
         assertThrows(
@@ -339,7 +322,7 @@ public final class ErrorHandlingTest {
 
     // Create multiple rows where only the third row differs
     final var row1 =
-        new SimpleRow(
+        Row.of(
             Map.of(
                 columnId,
                 new CellValue(1),
@@ -348,7 +331,7 @@ public final class ErrorHandlingTest {
                 columnStatus,
                 new CellValue("ACTIVE")));
     final var row2 =
-        new SimpleRow(
+        Row.of(
             Map.of(
                 columnId,
                 new CellValue(2),
@@ -357,7 +340,7 @@ public final class ErrorHandlingTest {
                 columnStatus,
                 new CellValue("ACTIVE")));
     final var expectedRow3 =
-        new SimpleRow(
+        Row.of(
             Map.of(
                 columnId,
                 new CellValue(3),
@@ -366,7 +349,7 @@ public final class ErrorHandlingTest {
                 columnStatus,
                 new CellValue("INACTIVE")));
     final var actualRow3 =
-        new SimpleRow(
+        Row.of(
             Map.of(
                 columnId,
                 new CellValue(3),
@@ -376,13 +359,13 @@ public final class ErrorHandlingTest {
                 new CellValue("ACTIVE")));
 
     final var expectedTable =
-        new SimpleTable(
+        Table.of(
             new TableName("USER_STATUS_TABLE"),
             List.of(columnId, columnName, columnStatus),
             List.of(row1, row2, expectedRow3));
 
     final var actualTable =
-        new SimpleTable(
+        Table.of(
             new TableName("USER_STATUS_TABLE"),
             List.of(columnId, columnName, columnStatus),
             List.of(row1, row2, actualRow3));

--- a/examples/db-tester-example-junit/src/test/java/example/feature/ProgrammaticAssertionApiTest.java
+++ b/examples/db-tester-example-junit/src/test/java/example/feature/ProgrammaticAssertionApiTest.java
@@ -5,12 +5,12 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import io.github.seijikohara.dbtester.api.annotation.Expectation;
 import io.github.seijikohara.dbtester.api.annotation.Preparation;
 import io.github.seijikohara.dbtester.api.assertion.DatabaseAssertion;
+import io.github.seijikohara.dbtester.api.dataset.DataSet;
+import io.github.seijikohara.dbtester.api.dataset.Row;
+import io.github.seijikohara.dbtester.api.dataset.Table;
 import io.github.seijikohara.dbtester.api.domain.CellValue;
 import io.github.seijikohara.dbtester.api.domain.ColumnName;
 import io.github.seijikohara.dbtester.api.domain.TableName;
-import io.github.seijikohara.dbtester.internal.dataset.SimpleDataSet;
-import io.github.seijikohara.dbtester.internal.dataset.SimpleRow;
-import io.github.seijikohara.dbtester.internal.dataset.SimpleTable;
 import io.github.seijikohara.dbtester.junit.jupiter.extension.DatabaseTestExtension;
 import java.sql.SQLException;
 import java.util.Arrays;
@@ -268,20 +268,20 @@ public final class ProgrammaticAssertionApiTest {
     final var columnNumber = new ColumnName("COLUMN2");
 
     final var row1 =
-        new SimpleRow(
+        Row.of(
             Map.of(
                 columnId, new CellValue(1),
                 columnValue, new CellValue("Value1"),
                 columnNumber, new CellValue(100)));
     final var row2 =
-        new SimpleRow(
+        Row.of(
             Map.of(
                 columnId, new CellValue(2),
                 columnValue, new CellValue("Value2"),
                 columnNumber, new CellValue(200)));
 
     final var expectedTable =
-        new SimpleTable(
+        Table.of(
             new TableName("QUERY_RESULT"),
             List.of(columnId, columnValue, columnNumber),
             List.of(row1, row2));
@@ -327,21 +327,21 @@ public final class ProgrammaticAssertionApiTest {
     final var columnExtra = new ColumnName("COLUMN3");
 
     final var row1 =
-        new SimpleRow(
+        Row.of(
             Map.of(
                 columnId, new CellValue(1),
                 columnValue, new CellValue("Value1"),
                 columnNumber, new CellValue(100),
                 columnExtra, new CellValue("Extra1")));
     final var row2 =
-        new SimpleRow(
+        Row.of(
             Map.of(
                 columnId, new CellValue(2),
                 columnValue, new CellValue("Value2"),
                 columnNumber, new CellValue(200),
                 columnExtra, new CellValue("Extra2")));
     final var row3 =
-        new SimpleRow(
+        Row.of(
             Map.of(
                 columnId,
                 new CellValue(3),
@@ -353,28 +353,28 @@ public final class ProgrammaticAssertionApiTest {
                 new CellValue("IGNORED"))); // This value won't be compared
 
     final var expectedTable =
-        new SimpleTable(
+        Table.of(
             new TableName("TABLE1"),
             List.of(columnId, columnValue, columnNumber, columnExtra),
             List.of(row1, row2, row3));
 
     // Build actual table from query
     final var actualRow1 =
-        new SimpleRow(
+        Row.of(
             Map.of(
                 columnId, new CellValue(1),
                 columnValue, new CellValue("Value1"),
                 columnNumber, new CellValue(100),
                 columnExtra, new CellValue("Extra1")));
     final var actualRow2 =
-        new SimpleRow(
+        Row.of(
             Map.of(
                 columnId, new CellValue(2),
                 columnValue, new CellValue("Value2"),
                 columnNumber, new CellValue(200),
                 columnExtra, new CellValue("Extra2")));
     final var actualRow3 =
-        new SimpleRow(
+        Row.of(
             Map.of(
                 columnId,
                 new CellValue(3),
@@ -386,7 +386,7 @@ public final class ProgrammaticAssertionApiTest {
                 new CellValue("RandomExtra"))); // Different value but will be ignored
 
     final var actualTable =
-        new SimpleTable(
+        Table.of(
             new TableName("TABLE1"),
             List.of(columnId, columnValue, columnNumber, columnExtra),
             List.of(actualRow1, actualRow2, actualRow3));
@@ -422,14 +422,14 @@ public final class ProgrammaticAssertionApiTest {
     final var columnExtra = new ColumnName("COLUMN3");
 
     final var row1 =
-        new SimpleRow(
+        Row.of(
             Map.of(
                 columnId, new CellValue(1),
                 columnValue, new CellValue("Value1"),
                 columnNumber, new CellValue(100),
                 columnExtra, new CellValue("Extra1")));
     final var row2 =
-        new SimpleRow(
+        Row.of(
             Map.of(
                 columnId, new CellValue(2),
                 columnValue, new CellValue("Value2"),
@@ -437,14 +437,14 @@ public final class ProgrammaticAssertionApiTest {
                 columnExtra, new CellValue("Extra2")));
 
     final var expectedTable =
-        new SimpleTable(
+        Table.of(
             new TableName("TABLE1"),
             List.of(columnId, columnValue, columnNumber, columnExtra),
             List.of(row1, row2));
 
     // Build actual table (simulating what would be read from the database)
     final var actualTable =
-        new SimpleTable(
+        Table.of(
             new TableName("TABLE1"),
             List.of(columnId, columnValue, columnNumber, columnExtra),
             List.of(row1, row2)); // Same data as expected
@@ -475,22 +475,21 @@ public final class ProgrammaticAssertionApiTest {
     final var columnValue = new ColumnName("COLUMN1");
 
     final var row1 =
-        new SimpleRow(
+        Row.of(
             Map.of(
                 columnId, new CellValue(1),
                 columnValue, new CellValue("Value1")));
     final var row2 =
-        new SimpleRow(
+        Row.of(
             Map.of(
                 columnId, new CellValue(2),
                 columnValue, new CellValue("Value2")));
 
     final var expectedTable =
-        new SimpleTable(
-            new TableName("TABLE1"), List.of(columnId, columnValue), List.of(row1, row2));
+        Table.of(new TableName("TABLE1"), List.of(columnId, columnValue), List.of(row1, row2));
 
     // Wrap table in a DataSet
-    final var expectedDataSet = new SimpleDataSet(List.of(expectedTable));
+    final var expectedDataSet = DataSet.of(expectedTable);
 
     // Use DataSet-based assertEqualsByQuery
     DatabaseAssertion.assertEqualsByQuery(


### PR DESCRIPTION
## Summary

- Add factory methods (`of()`) to `DataSet`, `Table`, `Row` interfaces with inner record implementations
- Change dependency scopes to prevent internal structure exposure:
  - SLF4J: `api` → `compileOnly` in db-tester-core
  - Jackson BOM: `api` → `implementation` in db-tester-core  
  - JUnit/Spock/Groovy BOMs: `api` → `implementation`
- Remove internal package exports from `module-info.java`
- Update example tests to use new public API
- Update documentation (EN/JA) with factory method references

## Test plan

- [x] `./gradlew build` passes
- [x] `./gradlew test` passes
- [x] Example tests updated and verified
- [x] Documentation updated (EN/JA)