### PR TITLE
docs: improve specifications and add framework comparison

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -12,8 +12,8 @@ export default withMermaid({
 
   markdown: {
     theme: {
-      light: 'catppuccin-latte',
-      dark: 'catppuccin-mocha',
+      light: 'github-light',
+      dark: 'github-dark',
     },
   },
 
@@ -43,6 +43,7 @@ export default withMermaid({
               { text: 'Test Frameworks', link: '/07-test-frameworks' },
               { text: 'SPI', link: '/08-spi' },
               { text: 'Error Handling', link: '/09-error-handling' },
+              { text: 'Framework Comparison', link: '/10-comparison' },
             ],
           },
         ],
@@ -73,6 +74,7 @@ export default withMermaid({
               { text: 'テストフレームワーク', link: '/ja/07-test-frameworks' },
               { text: 'SPI', link: '/ja/08-spi' },
               { text: 'エラーハンドリング', link: '/ja/09-error-handling' },
+              { text: 'フレームワーク比較', link: '/ja/10-comparison' },
             ],
           },
         ],
@@ -143,6 +145,6 @@ export default withMermaid({
   },
 
   mermaid: {
-    theme: 'default',
+    theme: 'neutral',
   },
 })

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -39,6 +39,20 @@
   font-size: var(--vp-code-font-size);
 }
 
+/* Ensure Shiki syntax highlighting is visible in home layout */
+.VPHomeContent .shiki,
+.VPHomeContent .shiki code {
+  background-color: transparent;
+}
+
+.VPHomeContent .shiki span {
+  color: var(--shiki-light);
+}
+
+.dark .VPHomeContent .shiki span {
+  color: var(--shiki-dark);
+}
+
 /* Inline code styling for home layout */
 .VPHomeContent :not(pre) > code {
   background-color: var(--vp-code-bg);

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,5 +1,46 @@
 import DefaultTheme from 'vitepress/theme'
-import '@catppuccin/vitepress/theme/mocha/mauve.css'
+import type { Theme } from 'vitepress'
+import { createLanguageDetector } from './languageDetector'
 import './custom.css'
 
-export default DefaultTheme
+/**
+ * Locale configuration for the site.
+ * Add new languages here to support automatic detection.
+ */
+const languageDetector = createLanguageDetector({
+  basePath: '/db-tester/',
+  defaultLocale: '', // English (root)
+  locales: [
+    {
+      path: '', // Root path for English
+      matches: ['en', 'en-US', 'en-GB', 'en-AU', 'en-CA'],
+    },
+    {
+      path: 'ja',
+      matches: ['ja', 'ja-JP'],
+    },
+    // Add more locales here:
+    // {
+    //   path: 'zh',
+    //   matches: ['zh', 'zh-CN', 'zh-TW', 'zh-HK'],
+    // },
+    // {
+    //   path: 'ko',
+    //   matches: ['ko', 'ko-KR'],
+    // },
+  ],
+})
+
+const theme: Theme = {
+  extends: DefaultTheme,
+  enhanceApp({ router }) {
+    if (typeof window !== 'undefined') {
+      const targetUrl = languageDetector.detectAndRedirect(window.location.pathname)
+      if (targetUrl) {
+        router.go(targetUrl)
+      }
+    }
+  },
+}
+
+export default theme

--- a/docs/.vitepress/theme/languageDetector.ts
+++ b/docs/.vitepress/theme/languageDetector.ts
@@ -1,0 +1,146 @@
+/**
+ * Language detection and redirection utility.
+ *
+ * Supports priority-based matching:
+ * 1. Exact match (e.g., 'ja-JP' -> 'ja')
+ * 2. Prefix match (e.g., 'ja' -> 'ja')
+ * 3. Fallback to default language
+ */
+
+export interface LocaleConfig {
+  /** Locale path (e.g., 'ja' for /ja/, '' for root) */
+  path: string
+  /** Language codes that match this locale (e.g., ['ja', 'ja-JP']) */
+  matches: string[]
+}
+
+export interface LanguageDetectorConfig {
+  /** Base path of the site (e.g., '/db-tester/') */
+  basePath: string
+  /** Supported locales configuration */
+  locales: LocaleConfig[]
+  /** Default locale path when no match found (e.g., '' for root/English) */
+  defaultLocale: string
+  /** Storage key for redirect flag */
+  storageKey?: string
+}
+
+/**
+ * Detects browser language and returns the best matching locale path.
+ */
+export function detectLocale(
+  browserLanguages: readonly string[],
+  locales: LocaleConfig[],
+  defaultLocale: string
+): string {
+  for (const browserLang of browserLanguages) {
+    const normalizedBrowserLang = browserLang.toLowerCase()
+
+    // Exact match
+    for (const locale of locales) {
+      if (locale.matches.some((m) => m.toLowerCase() === normalizedBrowserLang)) {
+        return locale.path
+      }
+    }
+
+    // Prefix match (e.g., 'ja-JP' matches 'ja')
+    const prefix = normalizedBrowserLang.split('-')[0]
+    for (const locale of locales) {
+      if (locale.matches.some((m) => m.toLowerCase() === prefix)) {
+        return locale.path
+      }
+    }
+  }
+
+  return defaultLocale
+}
+
+/**
+ * Gets browser languages in preference order.
+ */
+export function getBrowserLanguages(): string[] {
+  if (typeof navigator === 'undefined') {
+    return []
+  }
+
+  const languages: string[] = []
+
+  if (navigator.languages && navigator.languages.length > 0) {
+    languages.push(...navigator.languages)
+  } else if (navigator.language) {
+    languages.push(navigator.language)
+  }
+
+  // Fallback for older browsers
+  const nav = navigator as Navigator & { userLanguage?: string; browserLanguage?: string }
+  if (nav.userLanguage) {
+    languages.push(nav.userLanguage)
+  }
+  if (nav.browserLanguage) {
+    languages.push(nav.browserLanguage)
+  }
+
+  return languages
+}
+
+/**
+ * Builds the target URL for the detected locale.
+ */
+export function buildLocaleUrl(basePath: string, localePath: string): string {
+  const base = basePath.endsWith('/') ? basePath : `${basePath}/`
+  if (localePath === '') {
+    return base
+  }
+  return `${base}${localePath}/`
+}
+
+/**
+ * Checks if current path is the root path (where redirection should occur).
+ */
+export function isRootPath(currentPath: string, basePath: string): boolean {
+  const normalizedBase = basePath.endsWith('/') ? basePath : `${basePath}/`
+  const normalizedCurrent = currentPath.endsWith('/') ? currentPath : `${currentPath}/`
+  return normalizedCurrent === normalizedBase
+}
+
+/**
+ * Creates a language detector with the given configuration.
+ */
+export function createLanguageDetector(config: LanguageDetectorConfig) {
+  const storageKey = config.storageKey || 'vitepress-lang-redirected'
+
+  return {
+    /**
+     * Performs language detection and redirection if needed.
+     * Returns the target URL if redirection is needed, null otherwise.
+     */
+    detectAndRedirect(currentPath: string): string | null {
+      if (typeof window === 'undefined') {
+        return null
+      }
+
+      // Only redirect from root path
+      if (!isRootPath(currentPath, config.basePath)) {
+        return null
+      }
+
+      // Check if already redirected in this session
+      if (sessionStorage.getItem(storageKey)) {
+        return null
+      }
+
+      const browserLanguages = getBrowserLanguages()
+      const detectedLocale = detectLocale(browserLanguages, config.locales, config.defaultLocale)
+
+      // Mark as redirected
+      sessionStorage.setItem(storageKey, 'true')
+
+      // Only redirect if detected locale differs from default (root)
+      if (detectedLocale !== config.defaultLocale) {
+        return buildLocaleUrl(config.basePath, detectedLocale)
+      }
+
+      return null
+    },
+  }
+}

--- a/docs/public/favicon.svg
+++ b/docs/public/favicon.svg
@@ -1,35 +1,25 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="512" height="512">
   <defs>
-    <linearGradient id="layer1" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#c4b5fd"/>
-      <stop offset="100%" style="stop-color:#a78bfa"/>
+    <!-- Blue Glass Gradient -->
+    <linearGradient id="gradGlass" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#3b82f6;stop-opacity:0.8" />
+      <stop offset="100%" style="stop-color:#60a5fa;stop-opacity:0.4" />
     </linearGradient>
-    <linearGradient id="layer2" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#a78bfa"/>
-      <stop offset="100%" style="stop-color:#8b5cf6"/>
-    </linearGradient>
-    <linearGradient id="layer3" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#8b5cf6"/>
-      <stop offset="100%" style="stop-color:#6d28d9"/>
-    </linearGradient>
-    <filter id="soft">
-      <feDropShadow dx="0" dy="2" stdDeviation="2" flood-color="#4c1d95" flood-opacity="0.2"/>
+
+    <!-- Soft Drop Shadow -->
+    <filter id="softShadow" x="-50%" y="-50%" width="200%" height="200%">
+      <feDropShadow dx="0" dy="4" stdDeviation="4" flood-color="#1e40af" flood-opacity="0.2"/>
     </filter>
   </defs>
 
-  <g filter="url(#soft)">
-    <!-- Top layer -->
-    <rect x="16" y="22" width="68" height="14" rx="4" fill="url(#layer1)"/>
+  <!-- Background Plate (Blue Glass) -->
+  <rect x="20" y="25" width="40" height="50" rx="6" fill="url(#gradGlass)" filter="url(#softShadow)"/>
 
-    <!-- Middle layer -->
-    <rect x="16" y="43" width="68" height="14" rx="4" fill="url(#layer2)"/>
+  <!-- Foreground Plate (Green Overlay) -->
+  <!-- Note: mix-blend-mode is used for the overlapping effect.
+       If not supported by your viewer, it will appear as a solid semi-transparent green. -->
+  <rect x="40" y="25" width="40" height="50" rx="6" fill="#10b981" fill-opacity="0.7" style="mix-blend-mode: multiply;"/>
 
-    <!-- Bottom layer -->
-    <rect x="16" y="64" width="68" height="14" rx="4" fill="url(#layer3)"/>
-  </g>
-
-  <!-- Accent dots (red = failure, green = success) -->
-  <circle cx="76" cy="29" r="3" fill="#f87171"/>
-  <circle cx="76" cy="50" r="3" fill="#10b981"/>
-  <circle cx="76" cy="71" r="3" fill="#059669"/>
+  <!-- Checkmark Icon -->
+  <path d="M45 50 L50 55 L60 45" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
 </svg>

--- a/docs/public/icons/convention.svg
+++ b/docs/public/icons/convention.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2z"/>
+  <path d="M12 10v6"/>
+  <path d="m9 13 3-3 3 3"/>
+</svg>

--- a/docs/public/icons/data-formats.svg
+++ b/docs/public/icons/data-formats.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2"/>
+  <path d="M3 9h18"/>
+  <path d="M3 15h18"/>
+  <path d="M9 3v18"/>
+  <path d="M15 3v18"/>
+</svg>

--- a/docs/public/icons/database.svg
+++ b/docs/public/icons/database.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <ellipse cx="12" cy="5" rx="9" ry="3"/>
+  <path d="M3 5v14a9 3 0 0 0 18 0V5"/>
+  <path d="M3 12a9 3 0 0 0 18 0"/>
+</svg>

--- a/docs/public/icons/declarative.svg
+++ b/docs/public/icons/declarative.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M14 3v4a1 1 0 0 0 1 1h4"/>
+  <path d="M17 21H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h7l5 5v11a2 2 0 0 1-2 2z"/>
+  <path d="m9 15 2 2 4-4"/>
+</svg>

--- a/docs/public/icons/extensible.svg
+++ b/docs/public/icons/extensible.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 22v-6"/>
+  <path d="M12 8V2"/>
+  <path d="M4 12H2"/>
+  <path d="M10 12H8"/>
+  <path d="M16 12h-2"/>
+  <path d="M22 12h-2"/>
+  <circle cx="12" cy="12" r="2"/>
+</svg>

--- a/docs/public/icons/frameworks.svg
+++ b/docs/public/icons/frameworks.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/>
+</svg>

--- a/docs/specs/02-architecture.md
+++ b/docs/specs/02-architecture.md
@@ -53,9 +53,9 @@ graph TD
 | Module | Responsibility |
 |--------|----------------|
 | `db-tester-bom` | Version management and dependency alignment |
-| `db-tester-api` | Public annotations, configuration, SPI interfaces |
+| `db-tester-api` | Public annotations, configuration, domain models, SPI interfaces |
 | `db-tester-core` | JDBC operations, format parsing, SPI implementations |
-| `db-tester-junit` | JUnit Jupiter BeforeEach/AfterEach callbacks |
+| `db-tester-junit` | JUnit Jupiter BeforeEach and AfterEach callbacks |
 | `db-tester-spock` | Spock annotation-driven extension and interceptors |
 | `db-tester-kotest` | Kotest AnnotationSpec TestCaseExtension |
 | `db-tester-junit-spring-boot-starter` | Spring Boot auto-configuration for JUnit |
@@ -64,162 +64,55 @@ graph TD
 
 ## Module Dependencies
 
-### API Module (`db-tester-api`)
+Dependencies are defined in each module's `build.gradle.kts`. See the source files for current dependencies:
 
-The API module has no internal dependencies. External dependencies:
+| Module | Build Configuration |
+|--------|---------------------|
+| `db-tester-api` | [build.gradle.kts](https://github.com/seijikohara/db-tester/blob/main/db-tester-api/build.gradle.kts) |
+| `db-tester-core` | [build.gradle.kts](https://github.com/seijikohara/db-tester/blob/main/db-tester-core/build.gradle.kts) |
+| `db-tester-junit` | [build.gradle.kts](https://github.com/seijikohara/db-tester/blob/main/db-tester-junit/build.gradle.kts) |
+| `db-tester-spock` | [build.gradle.kts](https://github.com/seijikohara/db-tester/blob/main/db-tester-spock/build.gradle.kts) |
+| `db-tester-kotest` | [build.gradle.kts](https://github.com/seijikohara/db-tester/blob/main/db-tester-kotest/build.gradle.kts) |
+| `db-tester-junit-spring-boot-starter` | [build.gradle.kts](https://github.com/seijikohara/db-tester/blob/main/db-tester-junit-spring-boot-starter/build.gradle.kts) |
+| `db-tester-spock-spring-boot-starter` | [build.gradle.kts](https://github.com/seijikohara/db-tester/blob/main/db-tester-spock-spring-boot-starter/build.gradle.kts) |
+| `db-tester-kotest-spring-boot-starter` | [build.gradle.kts](https://github.com/seijikohara/db-tester/blob/main/db-tester-kotest-spring-boot-starter/build.gradle.kts) |
 
-| Dependency | Purpose |
-|------------|---------|
-| `org.jspecify:jspecify` | Null safety annotations |
-| `java.sql` | `DataSource` interface |
-
-### Core Module (`db-tester-core`)
-
-| Dependency | Scope | Purpose |
-|------------|-------|---------|
-| `db-tester-api` | Compile | Public API classes |
-| `org.jspecify:jspecify` | Compile | Null safety annotations |
-| `org.slf4j:slf4j-api` | Compile | Logging abstraction |
-
-### Test Framework Modules
-
-JUnit, Spock, and Kotest modules depend on `db-tester-api` at compile time. The `db-tester-core` module is discovered at runtime via ServiceLoader.
-
-| Module | Compile Dependencies | Runtime Dependencies |
-|--------|---------------------|----------------------|
-| `db-tester-junit` | `db-tester-api`, `junit-jupiter-api` | `db-tester-core` |
-| `db-tester-spock` | `db-tester-api`, `spock-core` | `db-tester-core` |
-| `db-tester-kotest` | `db-tester-api`, `kotest-framework-api` | `db-tester-core` |
-
-### Spring Boot Starter Modules
-
-| Module | Dependencies |
-|--------|--------------|
-| `db-tester-junit-spring-boot-starter` | `db-tester-junit`, `db-tester-core`, `spring-boot-autoconfigure` |
-| `db-tester-spock-spring-boot-starter` | `db-tester-spock`, `db-tester-core`, `spring-boot-autoconfigure` |
-| `db-tester-kotest-spring-boot-starter` | `db-tester-kotest`, `db-tester-core`, `spring-boot-autoconfigure` |
+Test framework modules depend on `db-tester-api` at compile time. The `db-tester-core` module loads at runtime via ServiceLoader.
 
 ## Package Organization
 
-### API Module Packages
+### API Module
 
-```
-io.github.seijikohara.dbtester.api
-├── annotation/
-│   ├── Preparation.java
-│   ├── Expectation.java
-│   └── DataSet.java
-├── assertion/
-│   ├── DatabaseAssertion.java
-│   └── AssertionFailureHandler.java
-├── config/
-│   ├── Configuration.java
-│   ├── ConventionSettings.java
-│   ├── DataFormat.java
-│   ├── DataSourceRegistry.java
-│   ├── OperationDefaults.java
-│   └── TableMergeStrategy.java
-├── context/
-│   └── TestContext.java
-├── dataset/
-│   ├── DataSet.java
-│   ├── Table.java
-│   └── Row.java
-├── domain/
-│   ├── CellValue.java
-│   ├── ColumnName.java
-│   ├── TableName.java
-│   ├── DataSourceName.java
-│   ├── Column.java
-│   ├── Cell.java
-│   ├── ColumnMetadata.java
-│   └── ComparisonStrategy.java
-├── exception/
-│   ├── DatabaseTesterException.java
-│   ├── ConfigurationException.java
-│   ├── DataSetLoadException.java
-│   ├── DataSourceNotFoundException.java
-│   ├── DatabaseOperationException.java
-│   └── ValidationException.java
-├── loader/
-│   └── DataSetLoader.java
-├── operation/
-│   ├── Operation.java
-│   └── TableOrderingStrategy.java
-├── scenario/
-│   ├── ScenarioName.java
-│   └── ScenarioNameResolver.java
-└── spi/
-    ├── AssertionProvider.java
-    ├── DataSetLoaderProvider.java
-    ├── ExpectationProvider.java
-    └── OperationProvider.java
-```
+| Package | Responsibility |
+|---------|----------------|
+| `annotation` | `@Preparation`, `@Expectation`, `@DataSet` annotations |
+| `assertion` | Programmatic assertion API |
+| `config` | Configuration classes and registries |
+| `context` | Test execution context |
+| `dataset` | Dataset, Table, Row interfaces |
+| `domain` | Value objects (`TableName`, `ColumnName`, `CellValue`) |
+| `exception` | Exception hierarchy |
+| `loader` | Dataset loader interface |
+| `operation` | Operation enum and strategies |
+| `scenario` | Scenario filtering interfaces |
+| `spi` | Service provider interfaces |
 
-### Core Module Packages
+Source: [db-tester-api/src/main/java](https://github.com/seijikohara/db-tester/tree/main/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api)
 
-```
-io.github.seijikohara.dbtester.internal
-├── assertion/
-│   ├── ComparisonResult.java
-│   ├── DataSetComparator.java
-│   └── ExpectationVerifier.java
-├── dataset/
-│   ├── SimpleDataSet.java
-│   ├── SimpleTable.java
-│   ├── SimpleRow.java
-│   ├── ScenarioTable.java
-│   └── TableOrderingResolver.java
-├── domain/
-│   ├── ScenarioMarker.java
-│   ├── SchemaName.java
-│   ├── FileExtension.java
-│   └── StringIdentifier.java
-├── format/
-│   ├── TableOrdering.java
-│   ├── csv/CsvFormatProvider.java
-│   ├── tsv/TsvFormatProvider.java
-│   ├── parser/
-│   │   ├── DelimitedParser.java
-│   │   └── DelimiterConfig.java
-│   └── spi/
-│       ├── FormatProvider.java
-│       └── FormatRegistry.java
-├── jdbc/
-│   ├── Jdbc.java
-│   ├── read/
-│   │   ├── TableReader.java
-│   │   ├── TableOrderResolver.java
-│   │   └── TypeConverter.java
-│   └── write/
-│       ├── OperationExecutor.java
-│       ├── SqlBuilder.java
-│       ├── ParameterBinder.java
-│       ├── TableExecutor.java
-│       ├── InsertExecutor.java
-│       ├── UpdateExecutor.java
-│       ├── DeleteExecutor.java
-│       ├── RefreshExecutor.java
-│       └── TruncateExecutor.java
-├── loader/
-│   ├── TestClassNameBasedDataSetLoader.java
-│   ├── DefaultDataSetLoaderProvider.java
-│   ├── AnnotationResolver.java
-│   ├── DataSetFactory.java
-│   ├── DataSetMerger.java
-│   └── DirectoryResolver.java
-├── scenario/
-│   ├── ScenarioFilter.java
-│   ├── FilteredDataSet.java
-│   └── FilteredTable.java
-├── spi/
-│   ├── DefaultAssertionProvider.java
-│   ├── DefaultExpectationProvider.java
-│   ├── DefaultOperationProvider.java
-│   └── ScenarioNameResolverRegistry.java
-└── util/
-    └── TopologicalSorter.java
-```
+### Core Module
+
+| Package | Responsibility |
+|---------|----------------|
+| `assertion` | Dataset comparison and verification |
+| `dataset` | Dataset, Table, Row implementations |
+| `domain` | Internal value objects |
+| `format` | CSV/TSV parsing and format providers |
+| `jdbc` | JDBC read/write operations |
+| `loader` | Convention-based dataset loading |
+| `scenario` | Scenario filtering implementation |
+| `spi` | SPI implementations |
+
+Source: [db-tester-core/src/main/java](https://github.com/seijikohara/db-tester/tree/main/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal)
 
 ## Architectural Patterns
 
@@ -227,7 +120,7 @@ io.github.seijikohara.dbtester.internal
 
 | Layer | Modules | Responsibility |
 |-------|---------|----------------|
-| Presentation | junit, spock, starters | Test framework integration |
+| Presentation | junit, spock, kotest, starters | Test framework integration |
 | Application | api | Public interfaces and contracts |
 | Domain | core (dataset, domain) | Business logic and entities |
 | Infrastructure | core (jdbc, format) | Database and file system access |
@@ -270,9 +163,10 @@ Operations and comparison strategies use the strategy pattern:
 
 | Strategy Interface | Implementations |
 |-------------------|-----------------|
-| `Operation` enum | NONE, INSERT, UPDATE, DELETE, REFRESH, CLEAN_INSERT, etc. |
+| `Operation` enum | NONE, INSERT, UPDATE, DELETE, DELETE_ALL, REFRESH, TRUNCATE_TABLE, CLEAN_INSERT, TRUNCATE_INSERT |
 | `ComparisonStrategy` | STRICT, IGNORE, NUMERIC, CASE_INSENSITIVE, TIMESTAMP_FLEXIBLE, NOT_NULL, REGEX |
 | `TableMergeStrategy` | FIRST, LAST, UNION, UNION_ALL |
+| `TableOrderingStrategy` | AUTO, LOAD_ORDER_FILE, FOREIGN_KEY, ALPHABETICAL |
 | `FormatProvider` | CsvFormatProvider, TsvFormatProvider |
 
 ## JPMS Support

--- a/docs/specs/04-configuration.md
+++ b/docs/specs/04-configuration.md
@@ -2,7 +2,6 @@
 
 This document describes the configuration classes and options available in the DB Tester framework.
 
-
 ## Configuration Class
 
 Aggregates runtime configuration for the database testing extension.
@@ -49,7 +48,6 @@ static void setup(ExtensionContext context) {
 }
 ```
 
-
 ## ConventionSettings
 
 Defines naming conventions for dataset discovery and scenario filtering.
@@ -87,6 +85,7 @@ src/test/resources/
 └── {test.class.package}/{TestClassName}/
     ├── TABLE1.csv           # Preparation dataset
     ├── TABLE2.csv
+    ├── load-order.txt       # Table ordering (optional)
     └── expected/            # Expectation datasets (suffix configurable)
         ├── TABLE1.csv
         └── TABLE2.csv
@@ -97,6 +96,7 @@ When `baseDirectory` is specified:
 ```
 {baseDirectory}/
 ├── TABLE1.csv
+├── load-order.txt
 └── expected/
     └── TABLE1.csv
 ```
@@ -111,10 +111,9 @@ The `expectationSuffix` is appended to the preparation path:
 | `/data/test` | `/expected` | `/data/test/expected` |
 | `custom/path` | `/verify` | `custom/path/verify` |
 
-
 ## DataSourceRegistry
 
-Mutable registry for `javax.sql.DataSource` instances.
+Thread-safe registry for `javax.sql.DataSource` instances.
 
 **Location**: `io.github.seijikohara.dbtester.api.config.DataSourceRegistry`
 
@@ -176,7 +175,6 @@ static void setup(ExtensionContext context) {
 }
 ```
 
-
 ## OperationDefaults
 
 Defines default database operations for preparation and expectation phases.
@@ -189,15 +187,14 @@ Defines default database operations for preparation and expectation phases.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `preparation` | `Operation` | `CLEAN_INSERT` | Default operation executed before a test runs |
-| `expectation` | `Operation` | `NONE` | Default operation executed after a test finishes |
+| `preparation` | `Operation` | `CLEAN_INSERT` | Default operation executed before test runs |
+| `expectation` | `Operation` | `NONE` | Default operation executed after test completes |
 
 ### Factory Methods
 
 | Method | Description |
 |--------|-------------|
 | `standard()` | Creates defaults with `CLEAN_INSERT` for preparation and `NONE` for expectation |
-
 
 ## DataFormat
 
@@ -228,10 +225,9 @@ When loading datasets from a directory:
 2. Parse each file as a table (filename without extension = table name)
 3. Ignore files with other extensions
 
-
 ## TableMergeStrategy
 
-Defines how tables from multiple datasets are merged.
+Defines how tables from multiple datasets merge.
 
 **Location**: `io.github.seijikohara.dbtester.api.config.TableMergeStrategy`
 
@@ -266,7 +262,6 @@ When both datasets contain the same table:
 | `UNION` | Combine rows, remove exact duplicates |
 | `UNION_ALL` | Combine all rows, keep duplicates |
 
-
 ## TestContext
 
 Immutable snapshot of test execution context.
@@ -286,7 +281,7 @@ Immutable snapshot of test execution context.
 
 ### Purpose
 
-`TestContext` provides a framework-agnostic representation of test execution state. Test framework extensions (JUnit, Spock) create `TestContext` instances from their native context objects.
+`TestContext` provides a framework-agnostic representation of test execution state. Test framework extensions (JUnit, Spock, and Kotest) create `TestContext` instances from their native context objects.
 
 ### Usage
 
@@ -303,11 +298,11 @@ TestContext context = new TestContext(
 List<DataSet> datasets = loader.loadPreparationDataSets(context);
 ```
 
-
 ## Related Specifications
 
 - [Overview](01-overview) - Framework purpose and key concepts
 - [Public API](03-public-api) - Annotations and interfaces
-- [Data Formats](05-data-formats) - CSV/TSV file structure
+- [Data Formats](05-data-formats) - CSV and TSV file structure
 - [Database Operations](06-database-operations) - Supported operations
+- [Test Frameworks](07-test-frameworks) - JUnit, Spock, and Kotest integration
 - [Error Handling](09-error-handling) - Error messages and exception types

--- a/docs/specs/05-data-formats.md
+++ b/docs/specs/05-data-formats.md
@@ -2,7 +2,6 @@
 
 This document describes the file formats supported by the DB Tester framework and their parsing rules.
 
-
 ## Supported Formats
 
 The framework supports two delimited text formats:
@@ -22,7 +21,6 @@ var conventions = ConventionSettings.standard()
 ```
 
 When loading datasets from a directory, only files matching the configured extension are processed.
-
 
 ## File Structure
 
@@ -62,7 +60,6 @@ order_id	user_id	amount	status
 1001	1	99.99	PENDING
 1002	2	149.50	COMPLETED
 ```
-
 
 ## Scenario Filtering
 
@@ -119,7 +116,6 @@ void testMultipleScenarios() { }
 
 Rows matching any of the specified scenarios are included.
 
-
 ## Special Values
 
 ### NULL Values
@@ -163,7 +159,6 @@ Values containing delimiters or special characters must be quoted:
 | Contains newline | `"line1\nline2"` |
 | Starts with whitespace | `" leading space"` |
 
-
 ## Directory Convention
 
 ### Standard Directory Structure
@@ -174,6 +169,7 @@ src/test/resources/
     └── {TestClassName}/
         ├── TABLE1.csv          # Preparation data
         ├── TABLE2.csv
+        ├── load-order.txt      # Table ordering (optional)
         └── expected/           # Expectation data
             ├── TABLE1.csv
             └── TABLE2.csv
@@ -208,7 +204,6 @@ Table names are derived from filenames:
 
 Case sensitivity depends on the database configuration.
 
-
 ## Load Order
 
 ### Overview
@@ -230,7 +225,7 @@ src/test/resources/
 
 ### File Format
 
-The `load-order.txt` file uses a simple line-based format:
+The `load-order.txt` file uses a line-based format:
 
 | Element | Description |
 |---------|-------------|
@@ -257,10 +252,8 @@ ORDER_ITEMS
 
 When `load-order.txt` does not exist in the dataset directory:
 
-1. Tables are sorted **alphabetically** by filename
-2. The framework does **not** automatically generate the file
-
-**Note**: Unlike some other database testing frameworks, db-tester does not auto-create the `load-order.txt` file. This is intentional for DbUnit compatibility and to avoid modifying test resources.
+1. Tables are sorted alphabetically by filename
+2. The framework does not automatically generate the file
 
 To explicitly require the load order file, use:
 
@@ -268,7 +261,7 @@ To explicitly require the load order file, use:
 @Preparation(tableOrdering = TableOrderingStrategy.LOAD_ORDER_FILE)
 ```
 
-This will throw a `DataSetLoadException` if `load-order.txt` is not found.
+This throws a `DataSetLoadException` if `load-order.txt` is not found.
 
 ### Processing Order by Operation
 
@@ -306,7 +299,6 @@ The `TableOrderingStrategy` enum controls how table ordering is determined. See 
 |-------|-----------|
 | Cannot read ordering file | `DataSetLoadException` |
 | File required but not found (`LOAD_ORDER_FILE` strategy) | `DataSetLoadException` |
-
 
 ## Parsing Rules
 
@@ -349,7 +341,7 @@ All values are parsed as strings and converted during database operations:
 | VARCHAR, TEXT | Use as-is |
 | DATE | Parse ISO format (YYYY-MM-DD) |
 | TIMESTAMP | Parse ISO format (YYYY-MM-DD HH:MM:SS) |
-| BOOLEAN | Parse "true"/"false" (case-insensitive) |
+| BOOLEAN | Parse "true" or "false" (case-insensitive) |
 | BLOB | Base64 decode |
 | CLOB | Use as-is |
 
@@ -367,9 +359,9 @@ All values are parsed as strings and converted during database operations:
 | Mismatched column count | `DataSetLoadException` |
 | Parse error | `DataSetLoadException` with details |
 
-
 ## Related Specifications
 
+- [Overview](01-overview) - Framework purpose and key concepts
 - [Configuration](04-configuration) - DataFormat and ConventionSettings
 - [Database Operations](06-database-operations) - Table ordering and operations
 - [Public API](03-public-api) - Annotation attributes

--- a/docs/specs/07-test-frameworks.md
+++ b/docs/specs/07-test-frameworks.md
@@ -2,7 +2,6 @@
 
 This document describes the integration with JUnit, Spock, and Kotest test frameworks.
 
-
 ## JUnit Integration
 
 ### Module
@@ -122,7 +121,6 @@ class UserRepositoryTest {
 }
 ```
 
-
 ## Spock Integration
 
 ### Module
@@ -223,7 +221,6 @@ def 'should process #status order'() {
 
 Scenario names: `"should process PENDING order"`, `"should process COMPLETED order"`
 
-
 ## Kotest Integration
 
 ### Module
@@ -232,7 +229,7 @@ Scenario names: `"should process PENDING order"`, `"should process COMPLETED ord
 
 ### Extension Class
 
-**Location**: `io.github.seijikohara.dbtester.kotest.DatabaseTestExtension`
+**Location**: `io.github.seijikohara.dbtester.kotest.extension.DatabaseTestExtension`
 
 **Type**: `TestCaseExtension` - Intercepts test case execution for preparation and expectation phases.
 
@@ -341,7 +338,6 @@ DB Tester requires `AnnotationSpec` style for Kotest integration because:
 2. Method resolution via reflection is reliable
 3. Familiar JUnit-like structure for Java developers
 
-
 ## Spring Boot Integration
 
 ### JUnit Spring Boot Starter
@@ -408,7 +404,7 @@ class MultiDatabaseTest {
 Configure via `application.properties` or `application.yml`:
 
 ```properties
-# Enable/disable DB Tester (default: true)
+# Enable or disable DB Tester (default: true)
 db-tester.enabled=true
 
 # Auto-register DataSource beans (default: true)
@@ -433,7 +429,7 @@ db-tester.operation.preparation=CLEAN_INSERT
 db-tester.operation.expectation=NONE
 ```
 
-**Note**: Property names use singular form (`convention`, `operation`) not plural.
+Property names use singular form (`convention`, `operation`) not plural.
 
 ### Spock Spring Boot Starter
 
@@ -493,7 +489,6 @@ Auto-configuration classes:
 | JUnit Starter | `DbTesterJUnitAutoConfiguration` |
 | Spock Starter | `DbTesterSpockAutoConfiguration` |
 | Kotest Starter | `DbTesterKotestAutoConfiguration` |
-
 
 ## Lifecycle Hooks
 
@@ -595,7 +590,6 @@ flowchart TD
 | Preparation | `DatabaseOperationException` | Test fails before execution |
 | Test | Any exception | Expectation still runs |
 | Expectation | `ValidationException` | Test fails with comparison details |
-
 
 ## Related Specifications
 

--- a/docs/specs/08-spi.md
+++ b/docs/specs/08-spi.md
@@ -31,7 +31,7 @@ flowchart TB
 ### Design Principles
 
 1. **API Independence**: Test framework modules depend only on `db-tester-api`
-2. **Runtime Discovery**: Core implementations loaded via ServiceLoader
+2. **Runtime Discovery**: Core implementations load via ServiceLoader
 3. **Extensibility**: Custom implementations can replace defaults
 
 
@@ -86,15 +86,18 @@ public interface OperationProvider {
 | `tableOrderingStrategy` | `TableOrderingStrategy` | Strategy for table processing order |
 
 **Operations**:
-- `NONE` - No operation
-- `INSERT` - Insert rows
-- `UPDATE` - Update by primary key
-- `DELETE` - Delete by primary key
-- `DELETE_ALL` - Delete all rows
-- `REFRESH` - Upsert (insert or update)
-- `TRUNCATE_TABLE` - Truncate tables
-- `CLEAN_INSERT` - Delete all then insert
-- `TRUNCATE_INSERT` - Truncate then insert
+
+| Operation | Description |
+|-----------|-------------|
+| `NONE` | No operation |
+| `INSERT` | Insert rows |
+| `UPDATE` | Update by primary key |
+| `DELETE` | Delete by primary key |
+| `DELETE_ALL` | Delete all rows |
+| `REFRESH` | Upsert (insert or update) |
+| `TRUNCATE_TABLE` | Truncate tables |
+| `CLEAN_INSERT` | Delete all then insert |
+| `TRUNCATE_INSERT` | Truncate then insert |
 
 
 ### AssertionProvider
@@ -140,10 +143,10 @@ public interface AssertionProvider {
 | `assertEqualsByQuery(...)` | Compare query results against expected data |
 
 **Behavior**:
-1. Compare expected vs actual datasets/tables
-2. Apply comparison strategies per column (STRICT, IGNORE, NUMERIC, etc.)
+1. Compare expected vs actual datasets or tables
+2. Apply comparison strategies per column (STRICT, IGNORE, NUMERIC, and others)
 3. Collect all differences (not fail-fast)
-4. Output human-readable summary + YAML details on mismatch
+4. Output human-readable summary with YAML details on mismatch
 
 See [Error Handling - Validation Errors](09-error-handling#validation-errors) for output format details.
 
@@ -173,7 +176,7 @@ public interface ExpectationProvider {
 
 **Process**:
 1. For each table in the expected dataset, fetch actual data from the database
-2. Filter actual data to only include columns present in expected table
+2. Filter actual data to include only columns present in expected table
 3. Compare filtered actual data against expected data
 4. Throw `AssertionError` if verification fails
 
@@ -246,7 +249,7 @@ public interface FormatProvider {
 
 | Method | Return Type | Description |
 |--------|-------------|-------------|
-| `supportedFileExtension()` | `FileExtension` | Returns the file extension without leading dot (e.g., "csv") |
+| `supportedFileExtension()` | `FileExtension` | Returns the file extension without leading dot (for example, "csv") |
 | `parse(Path)` | `DataSet` | Parses all files in directory into a DataSet |
 
 **Implementations**:
@@ -256,7 +259,7 @@ public interface FormatProvider {
 | `CsvFormatProvider` | `.csv` | Comma |
 | `TsvFormatProvider` | `.tsv` | Tab |
 
-**Note**: This is an internal SPI not intended for external implementation.
+This is an internal SPI not intended for external implementation.
 
 
 ## ServiceLoader Registration
@@ -337,7 +340,7 @@ module io.github.seijikohara.dbtester.core {
 
 To provide a custom dataset loader:
 
-1. Implement `DataSetLoader` interface:
+1. Implement the `DataSetLoader` interface:
 
 ```java
 public class CustomDataSetLoader implements DataSetLoader {
@@ -403,13 +406,13 @@ To support additional file formats (internal SPI):
 ```java
 public class XmlFormatProvider implements FormatProvider {
     @Override
-    public boolean canHandle(String fileExtension) {
-        return ".xml".equals(fileExtension);
+    public FileExtension supportedFileExtension() {
+        return new FileExtension("xml");
     }
 
     @Override
-    public DataSet parseDataSet(Path filePath, ConventionSettings conventions) {
-        // Parse XML file
+    public DataSet parse(Path directory) {
+        // Parse all XML files in directory
     }
 }
 ```
@@ -432,11 +435,12 @@ When multiple providers are registered:
 | `AssertionProvider` | First found |
 | `ExpectationProvider` | First found |
 | `ScenarioNameResolver` | Sorted by `priority()`, first that `canResolve()` returns true |
-| `FormatProvider` | First that `canHandle()` returns true |
+| `FormatProvider` | First matching `supportedFileExtension()` |
 
 
 ## Related Specifications
 
+- [Overview](01-overview) - Framework purpose and key concepts
 - [Architecture](02-architecture) - Module structure
 - [Configuration](04-configuration) - Configuration classes
 - [Test Frameworks](07-test-frameworks) - Framework integration

--- a/docs/specs/09-error-handling.md
+++ b/docs/specs/09-error-handling.md
@@ -22,7 +22,7 @@ classDiagram
 | Exception | Cause |
 |-----------|-------|
 | `ValidationException` | Expected vs actual data mismatch |
-| `DataSetLoadException` | Dataset file read/parse failure |
+| `DataSetLoadException` | Dataset file read or parse failure |
 | `DataSourceNotFoundException` | DataSource not registered |
 | `DatabaseOperationException` | SQL execution failure |
 | `ConfigurationException` | Framework initialization failure |
@@ -62,7 +62,7 @@ tables:
           type: "DECIMAL(10,2)"
 ```
 
-The output is **valid YAML** (after the first summary line) and can be parsed by standard YAML libraries for CI/CD integration.
+The output is **valid YAML** (after the first summary line). Standard YAML libraries can parse it for CI/CD integration.
 
 ### Output Structure
 
@@ -72,7 +72,7 @@ The output is **valid YAML** (after the first summary line) and can be parsed by
 | `summary.total_differences` | Total count of all differences |
 | `tables.<name>.differences` | List of differences for each table |
 | `path` | Location: `table_count`, `row_count`, or `row[N].COLUMN` |
-| `expected` / `actual` | The expected and actual values |
+| `expected` and `actual` | The expected and actual values |
 | `column` | JDBC metadata (type, nullable, primary_key) when available |
 
 ### Difference Types
@@ -93,7 +93,7 @@ The comparator applies the following rules before reporting mismatches:
 | NULL handling | Both NULL = match, one NULL = mismatch |
 | Numeric comparison | String "123" matches Integer 123 |
 | Floating point | Epsilon comparison (precision 1e-6) |
-| Boolean | "1"/"0"/"true"/"false"/"yes"/"no"/"y"/"n" supported |
+| Boolean | "1", "0", "true", "false", "yes", "no", "y", and "n" supported |
 | Timestamp precision | "2024-01-01 10:00:00" matches "2024-01-01 10:00:00.0" |
 | CLOB | Compared as string |
 
@@ -323,6 +323,7 @@ logging.level.io.github.seijikohara.dbtester=DEBUG
 
 ## Related Specifications
 
+- [Overview](01-overview) - Framework purpose and key concepts
 - [Public API](03-public-api) - Exception classes
 - [Database Operations](06-database-operations) - Operation failures
 - [Test Frameworks](07-test-frameworks) - Test lifecycle and error handling

--- a/docs/specs/10-comparison.md
+++ b/docs/specs/10-comparison.md
@@ -1,0 +1,506 @@
+# Framework Comparison
+
+This page provides an in-depth comparison of DB Tester with other database testing frameworks in the Java/JVM ecosystem.
+
+## Executive Summary
+
+| Framework | Best For | Trade-offs |
+|-----------|----------|------------|
+| **DB Tester** | Convention-based testing with JUnit 6/Spock 2/Kotest 6 | Limited data formats, newer project |
+| **DBUnit** | Extensive format support and customization | Verbose configuration, no JUnit 5 |
+| **Database Rider** | Comprehensive annotation-driven testing | Complex dependency tree |
+| **Spring Test DBUnit** | Spring-centric projects | Spring-only, aging project |
+| **DbSetup** | Code-only setup without external files | No assertion capabilities |
+| **JDBDT** | Incremental change verification | Smaller community |
+
+::: info Testcontainers
+[Testcontainers](https://testcontainers.com/) is complementary to these frameworks. It provides database infrastructure (Docker containers), while the frameworks above manage test data. They can be used together.
+:::
+
+## Detailed Feature Comparison
+
+### Test Framework Integration
+
+| Feature | DB Tester | DBUnit | Database Rider | Spring Test DBUnit | DbSetup | JDBDT |
+|---------|:---------:|:------:|:--------------:|:------------------:|:-------:|:-----:|
+| JUnit 6 | Yes | - | - | - | - | - |
+| JUnit 5 | - | - | Yes | - | Yes | Yes |
+| JUnit 4 | - | Yes | Yes | Yes | Yes | Yes |
+| Spock 2 | Yes | - | DSL* | - | Yes | - |
+| Kotest | Yes | - | - | - | - | - |
+| TestNG | - | Yes | - | - | Yes | Yes |
+| Spring Boot | Yes | - | Yes | Yes | - | - |
+| CDI/Jakarta EE | - | - | Yes | - | - | - |
+| Cucumber/BDD | - | - | Yes | - | - | - |
+
+*DSL: Annotations (`@DataSet`, `@ExpectedDataSet`) are not supported. Use [RiderDSL](https://database-rider.github.io/database-rider/latest/documentation.html#_rider_dsl) programmatic API.
+
+**Analysis:**
+- DB Tester is the only framework with native JUnit 6 and Kotest support
+- Database Rider has the widest test framework coverage for JUnit 5, but Spock requires programmatic API
+- DBUnit lacks JUnit 5/6 support
+
+### Data Format Support
+
+| Format | DB Tester | DBUnit | Database Rider | Spring Test DBUnit | DbSetup | JDBDT |
+|--------|:---------:|:------:|:--------------:|:------------------:|:-------:|:-----:|
+| CSV | Yes | Yes | Yes | Yes | - | Yes |
+| TSV | Yes | - | - | - | - | - |
+| Flat XML | - | Yes | Yes | Yes | - | - |
+| Full XML | - | Yes | Yes | Yes | - | - |
+| YAML | - | - | Yes | - | - | - |
+| JSON | - | - | Yes | - | - | - |
+| Excel (XLS/XLSX) | - | Yes | Yes | Yes | - | - |
+| Java DSL | - | - | Yes | - | Yes | Yes |
+| Kotlin DSL | - | - | - | - | Yes | - |
+| SQL Scripts | - | - | Yes | - | Yes | - |
+
+**Analysis:**
+- Database Rider supports the most formats (YAML, JSON, XML, CSV, Excel)
+- DB Tester focuses on CSV/TSV for straightforward data management
+- DbSetup and JDBDT prefer programmatic data definition
+
+### Configuration Approach
+
+| Approach | DB Tester | DBUnit | Database Rider | Spring Test DBUnit | DbSetup | JDBDT |
+|----------|:---------:|:------:|:--------------:|:------------------:|:-------:|:-----:|
+| Annotations | Yes | - | Yes | Yes | - | - |
+| Convention-based | Yes | - | - | - | - | - |
+| Programmatic API | Yes | Yes | Yes | Yes | Yes | Yes |
+| External Config (YAML/XML) | - | Yes | Yes | Yes | - | - |
+| Global Defaults | Yes | - | Yes | Yes | - | - |
+
+**Convention-based Discovery (DB Tester unique):**
+```
+src/test/resources/
+└── com/example/UserRepositoryTest/    ← Matches test class
+    ├── users.csv                       ← Table name
+    └── expected/
+        └── users.csv                   ← Expected state
+```
+
+### Database Operations
+
+| Operation | DB Tester | DBUnit | Database Rider | Spring Test DBUnit | DbSetup | JDBDT |
+|-----------|:---------:|:------:|:--------------:|:------------------:|:-------:|:-----:|
+| NONE | Yes | Yes | Yes | Yes | - | - |
+| INSERT | Yes | Yes | Yes | Yes | Yes | Yes |
+| UPDATE | Yes | Yes | Yes | Yes | - | - |
+| REFRESH | Yes | Yes | Yes | Yes | - | - |
+| DELETE | Yes | Yes | Yes | Yes | Yes | Yes |
+| DELETE_ALL | Yes | Yes | Yes | Yes | Yes | - |
+| TRUNCATE_TABLE | Yes | Yes | Yes | Yes | Yes | - |
+| CLEAN_INSERT | Yes | Yes | Yes | Yes | Yes | Yes |
+| TRUNCATE_INSERT | Yes | Yes | Yes | Yes | - | - |
+
+### Assertion Capabilities
+
+| Feature | DB Tester | DBUnit | Database Rider | Spring Test DBUnit | DbSetup | JDBDT |
+|---------|:---------:|:------:|:--------------:|:------------------:|:-------:|:-----:|
+| Full State Verification | Yes | Yes | Yes | Yes | - | Yes |
+| Delta Assertions | - | - | - | - | - | Yes |
+| Column Exclusion | Yes | Yes | Yes | Yes | - | Yes |
+| Row Ordering Control | Yes | Yes | Yes | Yes | - | Yes |
+| Regex Matching | - | - | Yes | - | - | - |
+| Scriptable Expected Values | - | - | Yes | - | - | - |
+| Scenario Filtering | Yes | - | - | - | - | - |
+| Structured Error Output | Yes (YAML) | - | - | - | - | - |
+
+**Delta Assertions (JDBDT unique):**
+```java
+// Verify only inserted rows, ignore unchanged data
+assertInserted(expected);
+
+// Verify query had no side effects
+assertUnchanged(dataSource);
+```
+
+**Scenario Filtering (DB Tester unique):**
+```csv
+[Scenario],id,name,email
+shouldCreateUser,1,john,john@example.com
+shouldUpdateUser,1,john,john.updated@example.com
+```
+
+### Advanced Features
+
+| Feature | DB Tester | DBUnit | Database Rider | Spring Test DBUnit | DbSetup | JDBDT |
+|---------|:---------:|:------:|:--------------:|:------------------:|:-------:|:-----:|
+| Multiple DataSources | Yes | Yes | Yes | Yes | Yes | Yes |
+| Transaction Support | Yes | Yes | Yes | Yes | Yes | - |
+| FK Constraint Handling | Yes | Yes | Yes | Yes | Yes | - |
+| Sequence/Identity Reset | - | Yes | Yes | Yes | - | - |
+| Dataset Export | - | Yes | Yes | - | - | Yes |
+| Replacement/Placeholder | - | Yes | Yes | - | - | - |
+| Scriptable Datasets | - | - | Yes | - | - | - |
+| Connection Leak Detection | - | - | Yes | - | - | - |
+| SPI Extensibility | Yes | - | - | - | - | - |
+| Logging/Diagnostics | Yes | Yes | Yes | Yes | - | Yes |
+
+**Scriptable Datasets (Database Rider):**
+```yaml
+USER:
+  - ID: 1
+    NAME: "js:(new Date()).toString()"
+    CREATED_AT: "groovy:new Date()"
+```
+
+**SPI Extensibility (DB Tester):**
+- Custom `DataSetLoaderProvider` implementations
+- Custom `OperationProvider` implementations
+- Custom `ExpectationProvider` implementations
+
+---
+
+## DB Tester Limitations
+
+### Data Format Limitations
+
+| Limitation | Impact | Workaround |
+|------------|--------|------------|
+| **No YAML/JSON support** | Cannot use human-friendly formats for complex nested data | Use CSV with clear column naming |
+| **No XML support** | Cannot migrate from existing DBUnit XML datasets | Convert XML to CSV manually or via script |
+| **No Excel support** | Business users cannot maintain test data in spreadsheets | Export Excel to CSV |
+| **No programmatic dataset builder** | Cannot generate dynamic test data in code | Use SPI to implement custom DataLoader |
+
+### Feature Limitations
+
+| Limitation | Impact | Alternative |
+|------------|--------|-------------|
+| **No delta assertions** | Cannot verify only the changes made by test | Verify full expected state |
+| **No regex in assertions** | Cannot match patterns like UUIDs or timestamps | Use column exclusion for dynamic values |
+| **No scriptable datasets** | Cannot embed dynamic values in CSV | Prepare data programmatically before test |
+| **No dataset export** | Cannot capture current DB state for debugging | Use database client tools |
+| **No replacement/placeholder** | Cannot use variables in datasets | Define explicit values per scenario |
+| **No sequence reset** | Cannot reset auto-increment counters | Handle via SQL in @BeforeEach |
+| **No connection leak detection** | Memory leaks may go unnoticed | Use external monitoring tools |
+
+### Ecosystem Limitations
+
+| Limitation | Impact | Consideration |
+|------------|--------|---------------|
+| **No JUnit 4/5 support** | Cannot use with legacy test suites | Migrate to JUnit 6 or use Database Rider |
+| **No TestNG support** | Limited options for TestNG users | Use DbSetup or JDBDT |
+| **No CDI integration** | Cannot auto-inject in Jakarta EE | Manual DataSource registration required |
+| **No Cucumber support** | Cannot use in BDD scenarios | Use Database Rider for BDD |
+| **New project** | Smaller community, less battle-tested | Evaluate thoroughly before production use |
+| **Limited documentation** | Fewer examples and tutorials | Refer to test cases in source code |
+
+### When NOT to Choose DB Tester
+
+Consider alternatives if you need:
+
+1. **Multiple data formats** → Choose Database Rider
+2. **Existing XML datasets** → Choose DBUnit or Database Rider
+3. **BDD/Cucumber integration** → Choose Database Rider
+4. **JUnit 4/5 or TestNG** → Choose DBUnit, Database Rider, or DbSetup
+5. **Delta assertions** → Choose JDBDT
+6. **Code-only approach** → Choose DbSetup
+7. **Mature, battle-tested solution** → Choose DBUnit
+
+---
+
+## Framework Deep Dive
+
+### DB Tester
+
+**Philosophy:** Convention over configuration with minimal boilerplate.
+
+**Unique Strengths:**
+- Zero-configuration dataset discovery based on test class/method names
+- Scenario filtering allows sharing datasets across multiple test methods
+- YAML-formatted assertion errors for readable debugging output
+- Native Kotest support (only framework with this)
+- SPI for custom extensions
+
+**Architecture:**
+```
+db-tester-api     → Public annotations and interfaces
+db-tester-core    → JDBC implementation (internal)
+db-tester-junit   → JUnit 6 extension
+db-tester-spock   → Spock 2 extension
+db-tester-kotest  → Kotest 6 extension
+```
+
+**Example:**
+```java
+@ExtendWith(DatabaseTestExtension.class)
+@Preparation  // Loads com/example/UserTest/users.csv
+@Expectation  // Verifies against com/example/UserTest/expected/users.csv
+class UserTest {
+    @Test
+    void shouldCreateUser() {
+        // [Scenario] column filters rows for this method
+        repository.create(new User("john", "john@example.com"));
+    }
+}
+```
+
+### DBUnit
+
+**Philosophy:** Comprehensive database state management with extensive customization options.
+
+**Unique Strengths:**
+- Most mature and battle-tested (since 2002)
+- Extensive XML dataset support with schema validation
+- ReplacementDataSet for dynamic placeholders
+- Database export for capturing production-like data
+- Wide IDE and tool integration
+
+**Core Components:**
+- `IDatabaseConnection` - Database connection abstraction
+- `IDataSet` - Collection of tables (FlatXml, Xml, Xls, Query, and others)
+- `DatabaseOperation` - CRUD operations on datasets
+
+**Example:**
+```java
+@Before
+public void setUp() throws Exception {
+    IDatabaseConnection connection = new DatabaseConnection(dataSource.getConnection());
+    IDataSet dataSet = new FlatXmlDataSetBuilder().build(new File("dataset.xml"));
+    DatabaseOperation.CLEAN_INSERT.execute(connection, dataSet);
+}
+```
+
+### Database Rider
+
+**Philosophy:** Comprehensive DBUnit wrapper with annotation-driven API.
+
+**Unique Strengths:**
+- Widest data format support (YAML, JSON, XML, CSV, Excel)
+- Scriptable datasets with Groovy/JavaScript
+- Regex matching in expected datasets
+- CDI and Cucumber integration
+- Connection leak detection
+- Active development and community
+
+**Configuration Options:**
+```java
+@DataSet(
+    value = "users.yml",
+    strategy = SeedStrategy.CLEAN_INSERT,
+    cleanBefore = true,
+    cleanAfter = true,
+    disableConstraints = true,
+    transactional = true,
+    executeStatementsBefore = "SET FOREIGN_KEY_CHECKS=0",
+    executeStatementsAfter = "SET FOREIGN_KEY_CHECKS=1"
+)
+```
+
+**Example:**
+```java
+@ExtendWith(DBUnitExtension.class)
+class UserTest {
+    @Test
+    @DataSet("users.yml")
+    @ExpectedDataSet(value = "expected.yml", ignoreCols = {"id", "created_at"})
+    void shouldUpdateUser() {
+        repository.update(1L, new User("john.doe"));
+    }
+}
+```
+
+### Spring Test DBUnit
+
+**Philosophy:** Seamless Spring integration for DBUnit.
+
+**Unique Strengths:**
+- Deep Spring TestContext integration
+- Transaction management with Spring
+- Familiar annotation style for Spring developers
+- TestExecutionListener approach
+
+**Limitations:**
+- No active maintenance (last release 2016)
+- No JUnit 5 support
+- Spring-only
+
+**Example:**
+```java
+@RunWith(SpringJUnit4ClassRunner.class)
+@TestExecutionListeners({
+    DependencyInjectionTestExecutionListener.class,
+    TransactionDbUnitTestExecutionListener.class
+})
+@DatabaseSetup("/initial-data.xml")
+@ExpectedDatabase("/expected-data.xml")
+public class UserRepositoryTest {
+    @Test
+    public void shouldUpdateUser() { ... }
+}
+```
+
+### DbSetup
+
+**Philosophy:** Pure code, no external files, fast execution.
+
+**Unique Strengths:**
+- Zero external dependencies
+- Type-safe Java/Kotlin DSL
+- DbSetupTracker for test optimization
+- Value generators for sequences
+- Fast execution
+
+**Limitations:**
+- Setup only, no assertion capabilities
+- No annotation support
+- Requires more boilerplate code
+
+**Example:**
+```java
+private static final Operation DELETE_ALL = deleteAllFrom("users", "orders");
+private static final Operation INSERT_REFERENCE_DATA = sequenceOf(
+    insertInto("users")
+        .columns("id", "name", "email")
+        .values(1L, "john", "john@example.com")
+        .values(2L, "jane", "jane@example.com")
+        .build()
+);
+
+@BeforeEach
+void prepare() {
+    new DbSetup(destination, sequenceOf(DELETE_ALL, INSERT_REFERENCE_DATA)).launch();
+}
+```
+
+**Kotlin DSL:**
+```kotlin
+val operation = dbSetup(to = destination) {
+    deleteAllFrom("users")
+    insertInto("users") {
+        columns("id", "name", "email")
+        values(1L, "john", "john@example.com")
+    }
+}
+operation.launch()
+```
+
+### JDBDT
+
+**Philosophy:** Lightweight delta testing without external dependencies.
+
+**Unique Strengths:**
+- Delta assertions (verify only changes)
+- Self-contained (Java 8 SE only)
+- Programmatic dataset builders
+- CSV import/export
+- Lightweight (~100KB)
+
+**Delta Assertion Concept:**
+```
+Initial State (Snapshot) → Test Execution → Final State
+                                ↓
+                          δ = Final - Initial
+                                ↓
+                    Assert: δ matches expected changes
+```
+
+**Example:**
+```java
+@Before
+public void setup() {
+    // Take snapshot of initial state
+    snapshot = takeSnapshot(userTable);
+}
+
+@Test
+public void testInsertUser() {
+    // Execute code under test
+    repository.insert(new User("john"));
+
+    // Assert only the delta (inserted rows)
+    assertInserted(
+        data(userTable)
+            .row("john", "john@example.com")
+    );
+}
+
+@Test
+public void testQueryDoesNotModify() {
+    repository.findAll();
+
+    // Assert no changes were made
+    assertUnchanged(userTable);
+}
+```
+
+---
+
+## Decision Matrix
+
+### By Use Case
+
+| Use Case | Recommended | Alternatives |
+|----------|-------------|--------------|
+| New JUnit 6 project | DB Tester | - |
+| JUnit 5 project | Database Rider | DbSetup, JDBDT |
+| Spock/Groovy project | DB Tester | DbSetup |
+| Kotest/Kotlin project | DB Tester | DbSetup (Kotlin DSL) |
+| Legacy JUnit 4/5 project | Database Rider | DBUnit |
+| Spring Boot application | DB Tester, Database Rider | Spring Test DBUnit |
+| Jakarta EE / CDI | Database Rider | - |
+| BDD / Cucumber | Database Rider | - |
+| Minimal dependencies | DbSetup, JDBDT | DB Tester |
+| Change verification only | JDBDT | - |
+| Extensive format flexibility | Database Rider | DBUnit |
+
+### By Team Preference
+
+| Preference | Recommended |
+|------------|-------------|
+| Convention over configuration | DB Tester |
+| Annotation-driven | DB Tester, Database Rider |
+| Code-only (no external files) | DbSetup, JDBDT |
+| YAML/JSON datasets | Database Rider |
+| Battle-tested solution | DBUnit, Database Rider |
+| Lightweight | DbSetup, JDBDT, DB Tester |
+
+---
+
+## Migration Guides
+
+### From Database Rider to DB Tester
+
+| Database Rider | DB Tester | Notes |
+|----------------|-----------|-------|
+| `@DataSet("users.yml")` | `@Preparation` | Convert YAML to CSV |
+| `@ExpectedDataSet("expected.yml")` | `@Expectation` | Convert YAML to CSV |
+| `strategy = SeedStrategy.CLEAN_INSERT` | `operation = Operation.CLEAN_INSERT` | Same semantics |
+| `ignoreCols = {"id"}` | `excludeColumns = {"id"}` | Same functionality |
+| `cleanBefore = true` | Default behavior | CLEAN_INSERT is default |
+| `dbunit.yml` config | `@DatabaseTestConfiguration` | Annotation-based |
+
+### From Spring Test DBUnit to DB Tester
+
+| Spring Test DBUnit | DB Tester | Notes |
+|--------------------|-----------|-------|
+| `@DatabaseSetup("/data.xml")` | `@Preparation` | Convert XML to CSV |
+| `@ExpectedDatabase("/expected.xml")` | `@Expectation` | Convert XML to CSV |
+| `DbUnitTestExecutionListener` | `DatabaseTestExtension` | JUnit 6 extension |
+| `@DbUnitConfiguration` | `@DatabaseTestConfiguration` | Similar options |
+
+### From DbSetup to DB Tester
+
+| DbSetup | DB Tester | Notes |
+|---------|-----------|-------|
+| `insertInto("users").columns(...).values(...)` | `users.csv` file | Externalize to file |
+| `deleteAllFrom("users")` | Implicit in CLEAN_INSERT | Default behavior |
+| `DbSetupTracker` | Not needed | Each test has own data |
+| No assertions | `@Expectation` | Add verification |
+
+---
+
+## References
+
+### Official Documentation
+- [DBUnit](https://www.dbunit.org/)
+- [Database Rider](https://database-rider.github.io/database-rider/)
+- [Spring Test DBUnit](https://springtestdbunit.github.io/spring-test-dbunit/)
+- [DbSetup](https://dbsetup.ninja-squad.com/)
+- [JDBDT](https://jdbdt.github.io/)
+
+### Related Tools
+- [Testcontainers](https://testcontainers.com/) - Database containers for integration testing
+- [Flyway](https://flywaydb.org/) - Database migration tool
+- [Liquibase](https://www.liquibase.org/) - Database change management

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -12,7 +12,7 @@ This directory contains technical specifications for the DB Tester framework.
 | [02-architecture.md](02-architecture) | Module structure and dependencies |
 | [03-public-api.md](03-public-api) | Annotations and configuration classes |
 | [04-configuration.md](04-configuration) | Configuration options and conventions |
-| [05-data-formats.md](05-data-formats) | CSV/TSV file structure and parsing |
+| [05-data-formats.md](05-data-formats) | CSV and TSV file structure and parsing |
 | [06-database-operations.md](06-database-operations) | Supported operations and execution flow |
 | [07-test-frameworks.md](07-test-frameworks) | JUnit, Spock, and Kotest integration |
 | [08-spi.md](08-spi) | Service Provider Interface extension points |

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -20,36 +20,30 @@ hero:
       link: https://central.sonatype.com/artifact/io.github.seijikohara/db-tester-junit
 
 features:
-  - icon: 📝
+  - icon:
+      src: /icons/declarative.svg
     title: Declarative Testing
     details: Use @Preparation and @Expectation annotations to define test data setup and verification.
-    link: /03-public-api
-    linkText: View API Reference
-  - icon: 📁
+  - icon:
+      src: /icons/convention.svg
     title: Convention over Configuration
-    details: Automatic dataset discovery based on test class and method names. Just follow the conventions.
-    link: /04-configuration
-    linkText: Learn Conventions
-  - icon: 🔧
+    details: Automatic dataset discovery based on test class and method names. Follow the conventions.
+  - icon:
+      src: /icons/frameworks.svg
     title: Multiple Frameworks
     details: Full support for JUnit Jupiter, Spock, and Kotest with Spring Boot integration.
-    link: /07-test-frameworks
-    linkText: Framework Integration
-  - icon: 📊
+  - icon:
+      src: /icons/data-formats.svg
     title: Flexible Data Formats
     details: CSV and TSV support with scenario filtering for sharing datasets across multiple tests.
-    link: /05-data-formats
-    linkText: Data Format Guide
-  - icon: 🗄️
+  - icon:
+      src: /icons/database.svg
     title: Database Operations
     details: Support for CLEAN_INSERT, INSERT, UPDATE, DELETE, TRUNCATE and more with customizable table ordering.
-    link: /06-database-operations
-    linkText: Operation Reference
-  - icon: 🔌
+  - icon:
+      src: /icons/extensible.svg
     title: Extensible Architecture
     details: Service Provider Interface (SPI) for custom data loaders, comparators, and operation handlers.
-    link: /08-spi
-    linkText: Extension Points
 ---
 
 ## Quick Start
@@ -131,31 +125,108 @@ dependencies {
 
 ### Basic Usage
 
-```java
+::: code-group
+
+```java [JUnit]
+package com.example;
+
 @ExtendWith(DatabaseTestExtension.class)
+@Preparation  // Loads test data from CSV
+@Expectation  // Verifies database state
 class UserRepositoryTest {
 
-    @Preparation  // Loads test data from CSV
-    @Expectation  // Verifies database state
     @Test
     void shouldCreateUser() {
-        // Your test logic here
         userRepository.create(new User("john", "john@example.com"));
+    }
+
+    @Test
+    void shouldUpdateUser() {
+        userRepository.update(1L, new User("john", "john.doe@example.com"));
     }
 }
 ```
 
+```groovy [Spock]
+package com.example
+
+@DatabaseTest
+@Preparation  // Loads test data from CSV
+@Expectation  // Verifies database state
+class UserRepositorySpec extends Specification {
+
+    def "should create user"() {
+        when:
+        userRepository.create(new User("john", "john@example.com"))
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "should update user"() {
+        when:
+        userRepository.update(1L, new User("john", "john.doe@example.com"))
+
+        then:
+        noExceptionThrown()
+    }
+}
+```
+
+```kotlin [Kotest]
+package com.example
+
+@Preparation  // Loads test data from CSV
+@Expectation  // Verifies database state
+class UserRepositorySpec : AnnotationSpec() {
+
+    init {
+        extensions(DatabaseTestExtension(registryProvider = { registry }))
+    }
+
+    @Test
+    fun shouldCreateUser() {
+        userRepository.create(User("john", "john@example.com"))
+    }
+
+    @Test
+    fun shouldUpdateUser() {
+        userRepository.update(1L, User("john", "john.doe@example.com"))
+    }
+}
+```
+
+:::
+
 ### Directory Structure
 
-```
+::: code-group
+
+```text [JUnit]
 src/test/resources/
 └── com/example/UserRepositoryTest/
-    ├── shouldCreateUser/
-    │   └── users.csv           # Preparation data
-    └── shouldCreateUser/
-        └── expected/
-            └── users.csv       # Expected state
+    ├── users.csv              # Preparation data with [Scenario] column
+    └── expected/
+        └── users.csv          # Expected state with [Scenario] column
 ```
+
+```text [Spock]
+src/test/resources/
+└── com/example/UserRepositorySpec/
+    ├── users.csv              # Preparation data with [Scenario] column
+    └── expected/
+        └── users.csv          # Expected state with [Scenario] column
+```
+
+```text [Kotest]
+src/test/resources/
+└── com/example/UserRepositorySpec/
+    ├── users.csv              # Preparation data with [Scenario] column
+    └── expected/
+        └── users.csv          # Expected state with [Scenario] column
+```
+
+:::
 
 ### Validation Output
 

--- a/docs/specs/ja/02-architecture.md
+++ b/docs/specs/ja/02-architecture.md
@@ -53,7 +53,7 @@ graph TD
 | モジュール | 責務 |
 |------------|------|
 | `db-tester-bom` | バージョン管理と依存関係の整合 |
-| `db-tester-api` | パブリックアノテーション、設定、SPIインターフェース |
+| `db-tester-api` | パブリックアノテーション、設定、ドメインモデル、SPIインターフェース |
 | `db-tester-core` | JDBC操作、フォーマット解析、SPI実装 |
 | `db-tester-junit` | JUnit Jupiter BeforeEach/AfterEachコールバック |
 | `db-tester-spock` | Spockアノテーション駆動型拡張とインターセプター |
@@ -64,162 +64,55 @@ graph TD
 
 ## モジュール依存関係
 
-### APIモジュール（`db-tester-api`）
+依存関係は各モジュールの`build.gradle.kts`で定義されています。現在の依存関係についてはソースファイルを参照してください。
 
-APIモジュールは内部依存関係を持ちません。外部依存関係は以下の通りです。
+| モジュール | ビルド設定 |
+|------------|-----------|
+| `db-tester-api` | [build.gradle.kts](https://github.com/seijikohara/db-tester/blob/main/db-tester-api/build.gradle.kts) |
+| `db-tester-core` | [build.gradle.kts](https://github.com/seijikohara/db-tester/blob/main/db-tester-core/build.gradle.kts) |
+| `db-tester-junit` | [build.gradle.kts](https://github.com/seijikohara/db-tester/blob/main/db-tester-junit/build.gradle.kts) |
+| `db-tester-spock` | [build.gradle.kts](https://github.com/seijikohara/db-tester/blob/main/db-tester-spock/build.gradle.kts) |
+| `db-tester-kotest` | [build.gradle.kts](https://github.com/seijikohara/db-tester/blob/main/db-tester-kotest/build.gradle.kts) |
+| `db-tester-junit-spring-boot-starter` | [build.gradle.kts](https://github.com/seijikohara/db-tester/blob/main/db-tester-junit-spring-boot-starter/build.gradle.kts) |
+| `db-tester-spock-spring-boot-starter` | [build.gradle.kts](https://github.com/seijikohara/db-tester/blob/main/db-tester-spock-spring-boot-starter/build.gradle.kts) |
+| `db-tester-kotest-spring-boot-starter` | [build.gradle.kts](https://github.com/seijikohara/db-tester/blob/main/db-tester-kotest-spring-boot-starter/build.gradle.kts) |
 
-| 依存関係 | 目的 |
-|----------|------|
-| `org.jspecify:jspecify` | Nullセーフティアノテーション |
-| `java.sql` | `DataSource`インターフェース |
-
-### Coreモジュール（`db-tester-core`）
-
-| 依存関係 | スコープ | 目的 |
-|----------|----------|------|
-| `db-tester-api` | Compile | パブリックAPIクラス |
-| `org.jspecify:jspecify` | Compile | Nullセーフティアノテーション |
-| `org.slf4j:slf4j-api` | Compile | ロギング抽象化 |
-
-### テストフレームワークモジュール
-
-JUnit、Spock、およびKotestモジュールは、コンパイル時に`db-tester-api`に依存します。`db-tester-core`モジュールはServiceLoader経由でランタイム時に検出されます。
-
-| モジュール | コンパイル依存関係 | ランタイム依存関係 |
-|------------|-------------------|-------------------|
-| `db-tester-junit` | `db-tester-api`, `junit-jupiter-api` | `db-tester-core` |
-| `db-tester-spock` | `db-tester-api`, `spock-core` | `db-tester-core` |
-| `db-tester-kotest` | `db-tester-api`, `kotest-framework-api` | `db-tester-core` |
-
-### Spring Boot Starterモジュール
-
-| モジュール | 依存関係 |
-|------------|----------|
-| `db-tester-junit-spring-boot-starter` | `db-tester-junit`, `db-tester-core`, `spring-boot-autoconfigure` |
-| `db-tester-spock-spring-boot-starter` | `db-tester-spock`, `db-tester-core`, `spring-boot-autoconfigure` |
-| `db-tester-kotest-spring-boot-starter` | `db-tester-kotest`, `db-tester-core`, `spring-boot-autoconfigure` |
+テストフレームワークモジュールはコンパイル時に`db-tester-api`に依存します。`db-tester-core`モジュールはServiceLoader経由でランタイム時に検出されます。
 
 ## パッケージ構成
 
-### APIモジュールパッケージ
+### APIモジュール
 
-```
-io.github.seijikohara.dbtester.api
-├── annotation/
-│   ├── Preparation.java
-│   ├── Expectation.java
-│   └── DataSet.java
-├── assertion/
-│   ├── DatabaseAssertion.java
-│   └── AssertionFailureHandler.java
-├── config/
-│   ├── Configuration.java
-│   ├── ConventionSettings.java
-│   ├── DataFormat.java
-│   ├── DataSourceRegistry.java
-│   ├── OperationDefaults.java
-│   └── TableMergeStrategy.java
-├── context/
-│   └── TestContext.java
-├── dataset/
-│   ├── DataSet.java
-│   ├── Table.java
-│   └── Row.java
-├── domain/
-│   ├── CellValue.java
-│   ├── ColumnName.java
-│   ├── TableName.java
-│   ├── DataSourceName.java
-│   ├── Column.java
-│   ├── Cell.java
-│   ├── ColumnMetadata.java
-│   └── ComparisonStrategy.java
-├── exception/
-│   ├── DatabaseTesterException.java
-│   ├── ConfigurationException.java
-│   ├── DataSetLoadException.java
-│   ├── DataSourceNotFoundException.java
-│   ├── DatabaseOperationException.java
-│   └── ValidationException.java
-├── loader/
-│   └── DataSetLoader.java
-├── operation/
-│   ├── Operation.java
-│   └── TableOrderingStrategy.java
-├── scenario/
-│   ├── ScenarioName.java
-│   └── ScenarioNameResolver.java
-└── spi/
-    ├── AssertionProvider.java
-    ├── DataSetLoaderProvider.java
-    ├── ExpectationProvider.java
-    └── OperationProvider.java
-```
+| パッケージ | 責務 |
+|-----------|------|
+| `annotation` | `@Preparation`, `@Expectation`, `@DataSet`アノテーション |
+| `assertion` | プログラマティックアサーションAPI |
+| `config` | 設定クラスとレジストリ |
+| `context` | テスト実行コンテキスト |
+| `dataset` | DataSet, Table, Rowインターフェース |
+| `domain` | 値オブジェクト（`TableName`, `ColumnName`, `CellValue`） |
+| `exception` | 例外階層 |
+| `loader` | データセットローダーインターフェース |
+| `operation` | Operationenumと戦略 |
+| `scenario` | シナリオフィルタリングインターフェース |
+| `spi` | サービスプロバイダーインターフェース |
 
-### Coreモジュールパッケージ
+ソース: [db-tester-api/src/main/java](https://github.com/seijikohara/db-tester/tree/main/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api)
 
-```
-io.github.seijikohara.dbtester.internal
-├── assertion/
-│   ├── ComparisonResult.java
-│   ├── DataSetComparator.java
-│   └── ExpectationVerifier.java
-├── dataset/
-│   ├── SimpleDataSet.java
-│   ├── SimpleTable.java
-│   ├── SimpleRow.java
-│   ├── ScenarioTable.java
-│   └── TableOrderingResolver.java
-├── domain/
-│   ├── ScenarioMarker.java
-│   ├── SchemaName.java
-│   ├── FileExtension.java
-│   └── StringIdentifier.java
-├── format/
-│   ├── TableOrdering.java
-│   ├── csv/CsvFormatProvider.java
-│   ├── tsv/TsvFormatProvider.java
-│   ├── parser/
-│   │   ├── DelimitedParser.java
-│   │   └── DelimiterConfig.java
-│   └── spi/
-│       ├── FormatProvider.java
-│       └── FormatRegistry.java
-├── jdbc/
-│   ├── Jdbc.java
-│   ├── read/
-│   │   ├── TableReader.java
-│   │   ├── TableOrderResolver.java
-│   │   └── TypeConverter.java
-│   └── write/
-│       ├── OperationExecutor.java
-│       ├── SqlBuilder.java
-│       ├── ParameterBinder.java
-│       ├── TableExecutor.java
-│       ├── InsertExecutor.java
-│       ├── UpdateExecutor.java
-│       ├── DeleteExecutor.java
-│       ├── RefreshExecutor.java
-│       └── TruncateExecutor.java
-├── loader/
-│   ├── TestClassNameBasedDataSetLoader.java
-│   ├── DefaultDataSetLoaderProvider.java
-│   ├── AnnotationResolver.java
-│   ├── DataSetFactory.java
-│   ├── DataSetMerger.java
-│   └── DirectoryResolver.java
-├── scenario/
-│   ├── ScenarioFilter.java
-│   ├── FilteredDataSet.java
-│   └── FilteredTable.java
-├── spi/
-│   ├── DefaultAssertionProvider.java
-│   ├── DefaultExpectationProvider.java
-│   ├── DefaultOperationProvider.java
-│   └── ScenarioNameResolverRegistry.java
-└── util/
-    └── TopologicalSorter.java
-```
+### Coreモジュール
+
+| パッケージ | 責務 |
+|-----------|------|
+| `assertion` | データセット比較と検証 |
+| `dataset` | DataSet, Table, Row実装 |
+| `domain` | 内部値オブジェクト |
+| `format` | CSV/TSV解析とフォーマットプロバイダー |
+| `jdbc` | JDBC読み取り/書き込み操作 |
+| `loader` | 規約ベースのデータセット読み込み |
+| `scenario` | シナリオフィルタリング実装 |
+| `spi` | SPI実装 |
+
+ソース: [db-tester-core/src/main/java](https://github.com/seijikohara/db-tester/tree/main/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal)
 
 ## アーキテクチャパターン
 
@@ -270,9 +163,10 @@ flowchart LR
 
 | 戦略インターフェース | 実装 |
 |---------------------|------|
-| `Operation` enum | NONE, INSERT, UPDATE, DELETE, REFRESH, CLEAN_INSERTなど |
+| `Operation` enum | NONE, INSERT, UPDATE, DELETE, DELETE_ALL, REFRESH, TRUNCATE_TABLE, CLEAN_INSERT, TRUNCATE_INSERT |
 | `ComparisonStrategy` | STRICT, IGNORE, NUMERIC, CASE_INSENSITIVE, TIMESTAMP_FLEXIBLE, NOT_NULL, REGEX |
 | `TableMergeStrategy` | FIRST, LAST, UNION, UNION_ALL |
+| `TableOrderingStrategy` | AUTO, LOAD_ORDER_FILE, FOREIGN_KEY, ALPHABETICAL |
 | `FormatProvider` | CsvFormatProvider, TsvFormatProvider |
 
 ## JPMSサポート

--- a/docs/specs/ja/04-configuration.md
+++ b/docs/specs/ja/04-configuration.md
@@ -87,6 +87,7 @@ src/test/resources/
 └── {test.class.package}/{TestClassName}/
     ├── TABLE1.csv           # 準備データセット
     ├── TABLE2.csv
+    ├── load-order.txt       # テーブル順序（オプション）
     └── expected/            # 期待データセット（サフィックスは設定可能）
         ├── TABLE1.csv
         └── TABLE2.csv
@@ -97,6 +98,7 @@ src/test/resources/
 ```
 {baseDirectory}/
 ├── TABLE1.csv
+├── load-order.txt
 └── expected/
     └── TABLE1.csv
 ```
@@ -286,7 +288,7 @@ static void setup(ExtensionContext context) {
 
 ### 目的
 
-`TestContext`は、テスト実行状態のフレームワーク非依存の表現を提供します。テストフレームワーク拡張（JUnit、Spock）は、ネイティブコンテキストオブジェクトから`TestContext`インスタンスを作成します。
+`TestContext`は、テスト実行状態のフレームワーク非依存の表現を提供します。テストフレームワーク拡張（JUnit、Spock、およびKotest）は、ネイティブコンテキストオブジェクトから`TestContext`インスタンスを作成します。
 
 ### 使用法
 
@@ -308,6 +310,7 @@ List<DataSet> datasets = loader.loadPreparationDataSets(context);
 
 - [概要](01-overview) - フレームワークの目的と主要概念
 - [パブリックAPI](03-public-api) - アノテーションとインターフェース
-- [データフォーマット](05-data-formats) - CSV/TSVファイル構造
+- [データフォーマット](05-data-formats) - CSVおよびTSVファイル構造
 - [データベース操作](06-database-operations) - サポートされる操作
+- [テストフレームワーク](07-test-frameworks) - JUnit、Spock、およびKotestの統合
 - [エラーハンドリング](09-error-handling) - エラーメッセージと例外型

--- a/docs/specs/ja/05-data-formats.md
+++ b/docs/specs/ja/05-data-formats.md
@@ -370,6 +370,7 @@ RFC 4180に拡張機能を追加して準拠:
 
 ## 関連仕様
 
+- [概要](01-overview) - フレームワークの目的と主要概念
 - [設定](04-configuration) - DataFormatとConventionSettings
 - [データベース操作](06-database-operations) - テーブル順序と操作
 - [パブリックAPI](03-public-api) - アノテーション属性

--- a/docs/specs/ja/06-database-operations.md
+++ b/docs/specs/ja/06-database-operations.md
@@ -442,6 +442,7 @@ void testBothPhases() { }
 
 ## 関連仕様
 
+- [概要](01-overview) - フレームワークの目的と主要概念
 - [パブリックAPI](03-public-api) - Operation enumリファレンス
 - [データフォーマット](05-data-formats) - ソースファイル構造
 - [設定](04-configuration) - OperationDefaults

--- a/docs/specs/ja/07-test-frameworks.md
+++ b/docs/specs/ja/07-test-frameworks.md
@@ -232,7 +232,7 @@ def 'should process #status order'() {
 
 ### 拡張クラス
 
-**パッケージ**: `io.github.seijikohara.dbtester.kotest.DatabaseTestExtension`
+**パッケージ**: `io.github.seijikohara.dbtester.kotest.extension.DatabaseTestExtension`
 
 **タイプ**: `TestCaseExtension` - 準備フェーズと期待フェーズのためにテストケース実行をインターセプトします。
 

--- a/docs/specs/ja/08-spi.md
+++ b/docs/specs/ja/08-spi.md
@@ -403,13 +403,13 @@ com.example.CustomScenarioNameResolver
 ```java
 public class XmlFormatProvider implements FormatProvider {
     @Override
-    public boolean canHandle(String fileExtension) {
-        return ".xml".equals(fileExtension);
+    public FileExtension supportedFileExtension() {
+        return new FileExtension("xml");
     }
 
     @Override
-    public DataSet parseDataSet(Path filePath, ConventionSettings conventions) {
-        // XMLファイルを解析
+    public DataSet parse(Path directory) {
+        // ディレクトリ内のすべてのXMLファイルを解析
     }
 }
 ```
@@ -432,11 +432,12 @@ com.example.XmlFormatProvider
 | `AssertionProvider` | 最初に見つかったもの |
 | `ExpectationProvider` | 最初に見つかったもの |
 | `ScenarioNameResolver` | `priority()`でソート、`canResolve()`がtrueを返す最初のもの |
-| `FormatProvider` | `canHandle()`がtrueを返す最初のもの |
+| `FormatProvider` | 一致する`supportedFileExtension()`を持つ最初のもの |
 
 
 ## 関連仕様
 
+- [概要](01-overview) - フレームワークの目的と主要概念
 - [アーキテクチャ](02-architecture) - モジュール構造
 - [設定](04-configuration) - 設定クラス
 - [テストフレームワーク](07-test-frameworks) - フレームワーク統合

--- a/docs/specs/ja/09-error-handling.md
+++ b/docs/specs/ja/09-error-handling.md
@@ -323,6 +323,7 @@ logging.level.io.github.seijikohara.dbtester=DEBUG
 
 ## 関連仕様
 
+- [概要](01-overview) - フレームワークの目的と主要概念
 - [パブリックAPI](03-public-api) - 例外クラス
 - [データベース操作](06-database-operations) - 操作失敗
 - [テストフレームワーク](07-test-frameworks) - テストライフサイクルとエラーハンドリング

--- a/docs/specs/ja/10-comparison.md
+++ b/docs/specs/ja/10-comparison.md
@@ -1,0 +1,506 @@
+# フレームワーク比較
+
+このページでは、DB TesterとJava/JVMエコシステムの他のデータベーステスティングフレームワークを詳細に比較します。
+
+## エグゼクティブサマリー
+
+| フレームワーク | 最適な用途 | トレードオフ |
+|--------------|----------|------------|
+| **DB Tester** | JUnit 6/Spock 2/Kotest 6での規約ベーステスト | データフォーマット制限、新しいプロジェクト |
+| **DBUnit** | 広範なフォーマットサポートとカスタマイズ | 冗長な設定、JUnit 5非対応 |
+| **Database Rider** | 包括的なアノテーション駆動テスト | 複雑な依存関係ツリー |
+| **Spring Test DBUnit** | Spring中心のプロジェクト | Spring専用、古いプロジェクト |
+| **DbSetup** | 外部ファイル不要のコードのみアプローチ | アサーション機能なし |
+| **JDBDT** | インクリメンタルな変更検証 | 小さなコミュニティ |
+
+::: info Testcontainers
+[Testcontainers](https://testcontainers.com/)はこれらのフレームワークを補完するものです。データベースインフラ（Dockerコンテナ）を提供し、上記のフレームワークはテストデータを管理します。併用可能です。
+:::
+
+## 詳細な機能比較
+
+### テストフレームワーク統合
+
+| 機能 | DB Tester | DBUnit | Database Rider | Spring Test DBUnit | DbSetup | JDBDT |
+|-----|:---------:|:------:|:--------------:|:------------------:|:-------:|:-----:|
+| JUnit 6 | Yes | - | - | - | - | - |
+| JUnit 5 | - | - | Yes | - | Yes | Yes |
+| JUnit 4 | - | Yes | Yes | Yes | Yes | Yes |
+| Spock 2 | Yes | - | DSL* | - | Yes | - |
+| Kotest | Yes | - | - | - | - | - |
+| TestNG | - | Yes | - | - | Yes | Yes |
+| Spring Boot | Yes | - | Yes | Yes | - | - |
+| CDI/Jakarta EE | - | - | Yes | - | - | - |
+| Cucumber/BDD | - | - | Yes | - | - | - |
+
+*DSL: アノテーション（`@DataSet`、`@ExpectedDataSet`）は非対応。[RiderDSL](https://database-rider.github.io/database-rider/latest/documentation.html#_rider_dsl)プログラマティックAPIを使用。
+
+**分析:**
+- DB TesterはJUnit 6とKotestをネイティブサポートする唯一のフレームワーク
+- Database RiderはJUnit 5で最も幅広いテストフレームワークをカバーするが、SpockにはプログラマティックAPIが必要
+- DBUnitはJUnit 5/6サポートが欠如
+
+### データフォーマットサポート
+
+| フォーマット | DB Tester | DBUnit | Database Rider | Spring Test DBUnit | DbSetup | JDBDT |
+|------------|:---------:|:------:|:--------------:|:------------------:|:-------:|:-----:|
+| CSV | Yes | Yes | Yes | Yes | - | Yes |
+| TSV | Yes | - | - | - | - | - |
+| Flat XML | - | Yes | Yes | Yes | - | - |
+| Full XML | - | Yes | Yes | Yes | - | - |
+| YAML | - | - | Yes | - | - | - |
+| JSON | - | - | Yes | - | - | - |
+| Excel (XLS/XLSX) | - | Yes | Yes | Yes | - | - |
+| Java DSL | - | - | Yes | - | Yes | Yes |
+| Kotlin DSL | - | - | - | - | Yes | - |
+| SQLスクリプト | - | - | Yes | - | Yes | - |
+
+**分析:**
+- Database Riderは最も多くのフォーマットをサポート（YAML、JSON、XML、CSV、Excel）
+- DB Testerは直接的なデータ管理のためCSV/TSVに集中
+- DbSetupとJDBDTはプログラムによるデータ定義を好む
+
+### 設定アプローチ
+
+| アプローチ | DB Tester | DBUnit | Database Rider | Spring Test DBUnit | DbSetup | JDBDT |
+|----------|:---------:|:------:|:--------------:|:------------------:|:-------:|:-----:|
+| アノテーション | Yes | - | Yes | Yes | - | - |
+| 規約ベース | Yes | - | - | - | - | - |
+| プログラムAPI | Yes | Yes | Yes | Yes | Yes | Yes |
+| 外部設定（YAML/XML） | - | Yes | Yes | Yes | - | - |
+| グローバルデフォルト | Yes | - | Yes | Yes | - | - |
+
+**規約ベース検出（DB Tester独自）:**
+```
+src/test/resources/
+└── com/example/UserRepositoryTest/    ← テストクラスに対応
+    ├── users.csv                       ← テーブル名
+    └── expected/
+        └── users.csv                   ← 期待される状態
+```
+
+### データベース操作
+
+| 操作 | DB Tester | DBUnit | Database Rider | Spring Test DBUnit | DbSetup | JDBDT |
+|-----|:---------:|:------:|:--------------:|:------------------:|:-------:|:-----:|
+| NONE | Yes | Yes | Yes | Yes | - | - |
+| INSERT | Yes | Yes | Yes | Yes | Yes | Yes |
+| UPDATE | Yes | Yes | Yes | Yes | - | - |
+| REFRESH | Yes | Yes | Yes | Yes | - | - |
+| DELETE | Yes | Yes | Yes | Yes | Yes | Yes |
+| DELETE_ALL | Yes | Yes | Yes | Yes | Yes | - |
+| TRUNCATE_TABLE | Yes | Yes | Yes | Yes | Yes | - |
+| CLEAN_INSERT | Yes | Yes | Yes | Yes | Yes | Yes |
+| TRUNCATE_INSERT | Yes | Yes | Yes | Yes | - | - |
+
+### アサーション機能
+
+| 機能 | DB Tester | DBUnit | Database Rider | Spring Test DBUnit | DbSetup | JDBDT |
+|-----|:---------:|:------:|:--------------:|:------------------:|:-------:|:-----:|
+| 完全状態検証 | Yes | Yes | Yes | Yes | - | Yes |
+| 差分アサーション | - | - | - | - | - | Yes |
+| カラム除外 | Yes | Yes | Yes | Yes | - | Yes |
+| 行順序制御 | Yes | Yes | Yes | Yes | - | Yes |
+| 正規表現マッチング | - | - | Yes | - | - | - |
+| スクリプト可能な期待値 | - | - | Yes | - | - | - |
+| シナリオフィルタリング | Yes | - | - | - | - | - |
+| 構造化エラー出力 | Yes (YAML) | - | - | - | - | - |
+
+**差分アサーション（JDBDT独自）:**
+```java
+// 挿入された行のみを検証、未変更データは無視
+assertInserted(expected);
+
+// クエリが副作用を持たないことを検証
+assertUnchanged(dataSource);
+```
+
+**シナリオフィルタリング（DB Tester独自）:**
+```csv
+[Scenario],id,name,email
+shouldCreateUser,1,john,john@example.com
+shouldUpdateUser,1,john,john.updated@example.com
+```
+
+### 高度な機能
+
+| 機能 | DB Tester | DBUnit | Database Rider | Spring Test DBUnit | DbSetup | JDBDT |
+|-----|:---------:|:------:|:--------------:|:------------------:|:-------:|:-----:|
+| 複数DataSource | Yes | Yes | Yes | Yes | Yes | Yes |
+| トランザクション | Yes | Yes | Yes | Yes | Yes | - |
+| FK制約処理 | Yes | Yes | Yes | Yes | Yes | - |
+| シーケンス/IDリセット | - | Yes | Yes | Yes | - | - |
+| データセットエクスポート | - | Yes | Yes | - | - | Yes |
+| 置換/プレースホルダー | - | Yes | Yes | - | - | - |
+| スクリプト可能データセット | - | - | Yes | - | - | - |
+| コネクションリーク検出 | - | - | Yes | - | - | - |
+| SPI拡張性 | Yes | - | - | - | - | - |
+| ログ/診断 | Yes | Yes | Yes | Yes | - | Yes |
+
+**スクリプト可能データセット（Database Rider）:**
+```yaml
+USER:
+  - ID: 1
+    NAME: "js:(new Date()).toString()"
+    CREATED_AT: "groovy:new Date()"
+```
+
+**SPI拡張性（DB Tester）:**
+- カスタム`DataSetLoaderProvider`実装
+- カスタム`OperationProvider`実装
+- カスタム`ExpectationProvider`実装
+
+---
+
+## DB Testerの制限事項
+
+### データフォーマットの制限
+
+| 制限 | 影響 | 回避策 |
+|-----|------|-------|
+| **YAML/JSONサポートなし** | 複雑なネストデータに人間に優しいフォーマットを使用できない | 明確なカラム命名でCSVを使用 |
+| **XMLサポートなし** | 既存のDBUnit XMLデータセットから移行できない | XMLをCSVに手動またはスクリプトで変換 |
+| **Excelサポートなし** | ビジネスユーザーがスプレッドシートでテストデータを管理できない | ExcelをCSVにエクスポート |
+| **プログラムによるデータセットビルダーなし** | コード内で動的テストデータを生成できない | SPIでカスタムDataLoaderを実装 |
+
+### 機能の制限
+
+| 制限 | 影響 | 代替手段 |
+|-----|------|---------|
+| **差分アサーションなし** | テストによる変更のみを検証できない | 完全な期待状態を検証 |
+| **アサーションでの正規表現なし** | UUIDやタイムスタンプなどのパターンをマッチできない | 動的値にはカラム除外を使用 |
+| **スクリプト可能データセットなし** | CSVに動的値を埋め込めない | テスト前にプログラムでデータを準備 |
+| **データセットエクスポートなし** | デバッグ用に現在のDB状態をキャプチャできない | データベースクライアントツールを使用 |
+| **置換/プレースホルダーなし** | データセットで変数を使用できない | シナリオごとに明示的な値を定義 |
+| **シーケンスリセットなし** | 自動インクリメントカウンターをリセットできない | @BeforeEachでSQLを実行 |
+| **コネクションリーク検出なし** | メモリリークが見過ごされる可能性 | 外部監視ツールを使用 |
+
+### エコシステムの制限
+
+| 制限 | 影響 | 考慮事項 |
+|-----|------|---------|
+| **JUnit 4/5サポートなし** | レガシーテストスイートで使用できない | JUnit 6に移行するかDatabase Riderを使用 |
+| **TestNGサポートなし** | TestNGユーザーの選択肢が限られる | DbSetupまたはJDBDTを使用 |
+| **CDI統合なし** | Jakarta EEで自動注入できない | 手動でDataSource登録が必要 |
+| **Cucumberサポートなし** | BDDシナリオで使用できない | BDDにはDatabase Riderを使用 |
+| **新しいプロジェクト** | 小さなコミュニティ、実績が少ない | 本番使用前に十分に評価 |
+| **ドキュメント不足** | 例やチュートリアルが少ない | ソースコードのテストケースを参照 |
+
+### DB Testerを選択すべきでない場合
+
+以下が必要な場合は代替を検討してください：
+
+1. **複数データフォーマット** → Database Riderを選択
+2. **既存のXMLデータセット** → DBUnitまたはDatabase Riderを選択
+3. **BDD/Cucumber統合** → Database Riderを選択
+4. **JUnit 4/5またはTestNG** → DBUnit、Database Rider、またはDbSetupを選択
+5. **差分アサーション** → JDBDTを選択
+6. **コードのみアプローチ** → DbSetupを選択
+7. **成熟した実績のあるソリューション** → DBUnitを選択
+
+---
+
+## フレームワーク詳細
+
+### DB Tester
+
+**哲学:** 最小限のボイラープレートで「設定より規約」を実現。
+
+**独自の強み:**
+- テストクラス/メソッド名に基づくゼロ設定データセット検出
+- シナリオフィルタリングで複数テストメソッド間でデータセットを共有
+- 読みやすいデバッグ出力のためのYAML形式アサーションエラー
+- ネイティブKotestサポート（唯一のフレームワーク）
+- カスタム拡張のためのSPI
+
+**アーキテクチャ:**
+```
+db-tester-api     → パブリックアノテーションとインターフェース
+db-tester-core    → JDBC実装（内部）
+db-tester-junit   → JUnit 6拡張
+db-tester-spock   → Spock 2拡張
+db-tester-kotest  → Kotest 6拡張
+```
+
+**例:**
+```java
+@ExtendWith(DatabaseTestExtension.class)
+@Preparation  // com/example/UserTest/users.csvを読み込み
+@Expectation  // com/example/UserTest/expected/users.csvで検証
+class UserTest {
+    @Test
+    void shouldCreateUser() {
+        // [Scenario]列でこのメソッド用の行をフィルタリング
+        repository.create(new User("john", "john@example.com"));
+    }
+}
+```
+
+### DBUnit
+
+**哲学:** 広範なカスタマイズオプションを持つ包括的なデータベース状態管理。
+
+**独自の強み:**
+- 最も成熟し実績がある（2002年以降）
+- スキーマ検証付きの広範なXMLデータセットサポート
+- 動的プレースホルダー用のReplacementDataSet
+- 本番データのようなデータをキャプチャするデータベースエクスポート
+- 広いIDEとツール統合
+
+**コアコンポーネント:**
+- `IDatabaseConnection` - データベース接続抽象化
+- `IDataSet` - テーブルのコレクション（FlatXml、Xml、Xls、Queryなど）
+- `DatabaseOperation` - データセットへのCRUD操作
+
+**例:**
+```java
+@Before
+public void setUp() throws Exception {
+    IDatabaseConnection connection = new DatabaseConnection(dataSource.getConnection());
+    IDataSet dataSet = new FlatXmlDataSetBuilder().build(new File("dataset.xml"));
+    DatabaseOperation.CLEAN_INSERT.execute(connection, dataSet);
+}
+```
+
+### Database Rider
+
+**哲学:** アノテーション駆動APIを持つ包括的なDBUnitラッパー。
+
+**独自の強み:**
+- 最も幅広いデータフォーマットサポート（YAML、JSON、XML、CSV、Excel）
+- Groovy/JavaScriptによるスクリプト可能データセット
+- 期待データセットでの正規表現マッチング
+- CDIとCucumber統合
+- コネクションリーク検出
+- アクティブな開発とコミュニティ
+
+**設定オプション:**
+```java
+@DataSet(
+    value = "users.yml",
+    strategy = SeedStrategy.CLEAN_INSERT,
+    cleanBefore = true,
+    cleanAfter = true,
+    disableConstraints = true,
+    transactional = true,
+    executeStatementsBefore = "SET FOREIGN_KEY_CHECKS=0",
+    executeStatementsAfter = "SET FOREIGN_KEY_CHECKS=1"
+)
+```
+
+**例:**
+```java
+@ExtendWith(DBUnitExtension.class)
+class UserTest {
+    @Test
+    @DataSet("users.yml")
+    @ExpectedDataSet(value = "expected.yml", ignoreCols = {"id", "created_at"})
+    void shouldUpdateUser() {
+        repository.update(1L, new User("john.doe"));
+    }
+}
+```
+
+### Spring Test DBUnit
+
+**哲学:** DBUnitのシームレスなSpring統合。
+
+**独自の強み:**
+- 深いSpring TestContext統合
+- Springとのトランザクション管理
+- Spring開発者に馴染みのあるアノテーションスタイル
+- TestExecutionListenerアプローチ
+
+**制限:**
+- アクティブなメンテナンスなし（最終リリース2016年）
+- JUnit 5サポートなし
+- Spring専用
+
+**例:**
+```java
+@RunWith(SpringJUnit4ClassRunner.class)
+@TestExecutionListeners({
+    DependencyInjectionTestExecutionListener.class,
+    TransactionDbUnitTestExecutionListener.class
+})
+@DatabaseSetup("/initial-data.xml")
+@ExpectedDatabase("/expected-data.xml")
+public class UserRepositoryTest {
+    @Test
+    public void shouldUpdateUser() { ... }
+}
+```
+
+### DbSetup
+
+**哲学:** 純粋なコード、外部ファイルなし、高速実行。
+
+**独自の強み:**
+- 外部依存関係ゼロ
+- 型安全なJava/Kotlin DSL
+- テスト最適化用のDbSetupTracker
+- シーケンス用の値ジェネレータ
+- 高速な実行
+
+**制限:**
+- セットアップのみ、アサーション機能なし
+- アノテーションサポートなし
+- より多くのボイラープレートコードが必要
+
+**例:**
+```java
+private static final Operation DELETE_ALL = deleteAllFrom("users", "orders");
+private static final Operation INSERT_REFERENCE_DATA = sequenceOf(
+    insertInto("users")
+        .columns("id", "name", "email")
+        .values(1L, "john", "john@example.com")
+        .values(2L, "jane", "jane@example.com")
+        .build()
+);
+
+@BeforeEach
+void prepare() {
+    new DbSetup(destination, sequenceOf(DELETE_ALL, INSERT_REFERENCE_DATA)).launch();
+}
+```
+
+**Kotlin DSL:**
+```kotlin
+val operation = dbSetup(to = destination) {
+    deleteAllFrom("users")
+    insertInto("users") {
+        columns("id", "name", "email")
+        values(1L, "john", "john@example.com")
+    }
+}
+operation.launch()
+```
+
+### JDBDT
+
+**哲学:** 外部依存関係のない軽量な差分テスト。
+
+**独自の強み:**
+- 差分アサーション（変更のみを検証）
+- 自己完結型（Java 8 SEのみ）
+- プログラムによるデータセットビルダー
+- CSVインポート/エクスポート
+- 軽量（約100KB）
+
+**差分アサーションの概念:**
+```
+初期状態（スナップショット） → テスト実行 → 最終状態
+                                ↓
+                          δ = 最終 - 初期
+                                ↓
+                    アサート: δが期待される変更と一致
+```
+
+**例:**
+```java
+@Before
+public void setup() {
+    // 初期状態のスナップショットを取得
+    snapshot = takeSnapshot(userTable);
+}
+
+@Test
+public void testInsertUser() {
+    // テスト対象コードを実行
+    repository.insert(new User("john"));
+
+    // 差分（挿入された行）のみをアサート
+    assertInserted(
+        data(userTable)
+            .row("john", "john@example.com")
+    );
+}
+
+@Test
+public void testQueryDoesNotModify() {
+    repository.findAll();
+
+    // 変更がないことをアサート
+    assertUnchanged(userTable);
+}
+```
+
+---
+
+## 決定マトリクス
+
+### ユースケース別
+
+| ユースケース | 推奨 | 代替 |
+|------------|------|------|
+| 新規JUnit 6プロジェクト | DB Tester | - |
+| JUnit 5プロジェクト | Database Rider | DbSetup、JDBDT |
+| Spock/Groovyプロジェクト | DB Tester | DbSetup |
+| Kotest/Kotlinプロジェクト | DB Tester | DbSetup（Kotlin DSL） |
+| レガシーJUnit 4/5プロジェクト | Database Rider | DBUnit |
+| Spring Bootアプリケーション | DB Tester、Database Rider | Spring Test DBUnit |
+| Jakarta EE / CDI | Database Rider | - |
+| BDD / Cucumber | Database Rider | - |
+| 最小限の依存関係 | DbSetup、JDBDT | DB Tester |
+| 変更検証のみ | JDBDT | - |
+| 広範なフォーマット柔軟性 | Database Rider | DBUnit |
+
+### チームの好み別
+
+| 好み | 推奨 |
+|-----|------|
+| 設定より規約 | DB Tester |
+| アノテーション駆動 | DB Tester、Database Rider |
+| コードのみ（外部ファイルなし） | DbSetup、JDBDT |
+| YAML/JSONデータセット | Database Rider |
+| 実績のあるソリューション | DBUnit、Database Rider |
+| 軽量 | DbSetup、JDBDT、DB Tester |
+
+---
+
+## 移行ガイド
+
+### Database RiderからDB Testerへ
+
+| Database Rider | DB Tester | 備考 |
+|----------------|-----------|------|
+| `@DataSet("users.yml")` | `@Preparation` | YAMLをCSVに変換 |
+| `@ExpectedDataSet("expected.yml")` | `@Expectation` | YAMLをCSVに変換 |
+| `strategy = SeedStrategy.CLEAN_INSERT` | `operation = Operation.CLEAN_INSERT` | 同じセマンティクス |
+| `ignoreCols = {"id"}` | `excludeColumns = {"id"}` | 同じ機能 |
+| `cleanBefore = true` | デフォルト動作 | CLEAN_INSERTがデフォルト |
+| `dbunit.yml`設定 | `@DatabaseTestConfiguration` | アノテーションベース |
+
+### Spring Test DBUnitからDB Testerへ
+
+| Spring Test DBUnit | DB Tester | 備考 |
+|--------------------|-----------|------|
+| `@DatabaseSetup("/data.xml")` | `@Preparation` | XMLをCSVに変換 |
+| `@ExpectedDatabase("/expected.xml")` | `@Expectation` | XMLをCSVに変換 |
+| `DbUnitTestExecutionListener` | `DatabaseTestExtension` | JUnit 6拡張 |
+| `@DbUnitConfiguration` | `@DatabaseTestConfiguration` | 類似オプション |
+
+### DbSetupからDB Testerへ
+
+| DbSetup | DB Tester | 備考 |
+|---------|-----------|------|
+| `insertInto("users").columns(...).values(...)` | `users.csv`ファイル | ファイルに外部化 |
+| `deleteAllFrom("users")` | CLEAN_INSERTに暗黙的 | デフォルト動作 |
+| `DbSetupTracker` | 不要 | 各テストが独自データを持つ |
+| アサーションなし | `@Expectation` | 検証を追加 |
+
+---
+
+## 参考リンク
+
+### 公式ドキュメント
+- [DBUnit](https://www.dbunit.org/)
+- [Database Rider](https://database-rider.github.io/database-rider/)
+- [Spring Test DBUnit](https://springtestdbunit.github.io/spring-test-dbunit/)
+- [DbSetup](https://dbsetup.ninja-squad.com/)
+- [JDBDT](https://jdbdt.github.io/)
+
+### 関連ツール
+- [Testcontainers](https://testcontainers.com/) - 統合テスト用のデータベースコンテナ
+- [Flyway](https://flywaydb.org/) - データベースマイグレーションツール
+- [Liquibase](https://www.liquibase.org/) - データベース変更管理

--- a/docs/specs/ja/index.md
+++ b/docs/specs/ja/index.md
@@ -20,36 +20,30 @@ hero:
       link: https://central.sonatype.com/artifact/io.github.seijikohara/db-tester-junit
 
 features:
-  - icon: 📝
+  - icon:
+      src: /icons/declarative.svg
     title: 宣言的なテスト
     details: "@Preparationと@Expectationアノテーションを使用して、テストデータのセットアップと検証を定義できます。"
-    link: /ja/03-public-api
-    linkText: APIリファレンスを見る
-  - icon: 📁
+  - icon:
+      src: /icons/convention.svg
     title: 設定より規約
-    details: テストクラスとメソッド名に基づいた自動データセット検出。規約に従うだけで動作します。
-    link: /ja/04-configuration
-    linkText: 規約を学ぶ
-  - icon: 🔧
+    details: テストクラスとメソッド名に基づいた自動データセット検出。規約に従えば動作します。
+  - icon:
+      src: /icons/frameworks.svg
     title: 複数フレームワーク対応
     details: JUnit Jupiter、Spock、Kotestを完全サポート。Spring Boot統合も利用可能です。
-    link: /ja/07-test-frameworks
-    linkText: フレームワーク統合
-  - icon: 📊
+  - icon:
+      src: /icons/data-formats.svg
     title: 柔軟なデータフォーマット
     details: CSVとTSVをサポート。シナリオフィルタリングにより複数のテストでデータセットを共有できます。
-    link: /ja/05-data-formats
-    linkText: データフォーマットガイド
-  - icon: 🗄️
+  - icon:
+      src: /icons/database.svg
     title: データベース操作
     details: CLEAN_INSERT、INSERT、UPDATE、DELETE、TRUNCATEなどをサポート。テーブル順序のカスタマイズも可能です。
-    link: /ja/06-database-operations
-    linkText: 操作リファレンス
-  - icon: 🔌
+  - icon:
+      src: /icons/extensible.svg
     title: 拡張可能なアーキテクチャ
     details: カスタムデータローダー、コンパレータ、操作ハンドラー用のサービスプロバイダーインターフェース（SPI）を提供します。
-    link: /ja/08-spi
-    linkText: 拡張ポイント
 ---
 
 ## クイックスタート
@@ -131,31 +125,108 @@ dependencies {
 
 ### 基本的な使い方
 
-```java
+::: code-group
+
+```java [JUnit]
+package com.example;
+
 @ExtendWith(DatabaseTestExtension.class)
+@Preparation  // CSVからテストデータを読み込む
+@Expectation  // データベースの状態を検証
 class UserRepositoryTest {
 
-    @Preparation  // CSVからテストデータを読み込む
-    @Expectation  // データベースの状態を検証
     @Test
     void shouldCreateUser() {
-        // テストロジックをここに記述
         userRepository.create(new User("john", "john@example.com"));
+    }
+
+    @Test
+    void shouldUpdateUser() {
+        userRepository.update(1L, new User("john", "john.doe@example.com"));
     }
 }
 ```
 
+```groovy [Spock]
+package com.example
+
+@DatabaseTest
+@Preparation  // CSVからテストデータを読み込む
+@Expectation  // データベースの状態を検証
+class UserRepositorySpec extends Specification {
+
+    def "should create user"() {
+        when:
+        userRepository.create(new User("john", "john@example.com"))
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "should update user"() {
+        when:
+        userRepository.update(1L, new User("john", "john.doe@example.com"))
+
+        then:
+        noExceptionThrown()
+    }
+}
+```
+
+```kotlin [Kotest]
+package com.example
+
+@Preparation  // CSVからテストデータを読み込む
+@Expectation  // データベースの状態を検証
+class UserRepositorySpec : AnnotationSpec() {
+
+    init {
+        extensions(DatabaseTestExtension(registryProvider = { registry }))
+    }
+
+    @Test
+    fun shouldCreateUser() {
+        userRepository.create(User("john", "john@example.com"))
+    }
+
+    @Test
+    fun shouldUpdateUser() {
+        userRepository.update(1L, User("john", "john.doe@example.com"))
+    }
+}
+```
+
+:::
+
 ### ディレクトリ構造
 
-```
+::: code-group
+
+```text [JUnit]
 src/test/resources/
 └── com/example/UserRepositoryTest/
-    ├── shouldCreateUser/
-    │   └── users.csv           # 準備データ
-    └── shouldCreateUser/
-        └── expected/
-            └── users.csv       # 期待される状態
+    ├── users.csv              # 準備データ（[Scenario]列でフィルタリング）
+    └── expected/
+        └── users.csv          # 期待される状態（[Scenario]列でフィルタリング）
 ```
+
+```text [Spock]
+src/test/resources/
+└── com/example/UserRepositorySpec/
+    ├── users.csv              # 準備データ（[Scenario]列でフィルタリング）
+    └── expected/
+        └── users.csv          # 期待される状態（[Scenario]列でフィルタリング）
+```
+
+```text [Kotest]
+src/test/resources/
+└── com/example/UserRepositorySpec/
+    ├── users.csv              # 準備データ（[Scenario]列でフィルタリング）
+    └── expected/
+        └── users.csv          # 期待される状態（[Scenario]列でフィルタリング）
+```
+
+:::
 
 ### 検証出力
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,6 @@
   "packages": {
     "": {
       "name": "db-tester-docs",
-      "dependencies": {
-        "@catppuccin/vitepress": "^0.1.2"
-      },
       "devDependencies": {
         "mermaid": "^11.12.2",
         "vitepress": "^1.6.4",
@@ -15,16 +12,16 @@
       }
     },
     "node_modules/@algolia/abtesting": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.12.0.tgz",
-      "integrity": "sha512-EfW0bfxjPs+C7ANkJDw2TATntfBKsFiy7APh+KO0pQ8A6HYa5I0NjFuCGCXWfzzzLXNZta3QUl3n5Kmm6aJo9Q==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.12.2.tgz",
+      "integrity": "sha512-oWknd6wpfNrmRcH0vzed3UPX0i17o4kYLM5OMITyMVM2xLgaRbIafoxL0e8mcrNNb0iORCJA0evnNDKRYth5WQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.46.0",
-        "@algolia/requester-browser-xhr": "5.46.0",
-        "@algolia/requester-fetch": "5.46.0",
-        "@algolia/requester-node-http": "5.46.0"
+        "@algolia/client-common": "5.46.2",
+        "@algolia/requester-browser-xhr": "5.46.2",
+        "@algolia/requester-fetch": "5.46.2",
+        "@algolia/requester-node-http": "5.46.2"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -80,41 +77,41 @@
       }
     },
     "node_modules/@algolia/client-abtesting": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.46.0.tgz",
-      "integrity": "sha512-eG5xV8rujK4ZIHXrRshvv9O13NmU/k42Rnd3w43iKH5RaQ2zWuZO6Q7XjaoJjAFVCsJWqRbXzbYyPGrbF3wGNg==",
+      "version": "5.46.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.46.2.tgz",
+      "integrity": "sha512-oRSUHbylGIuxrlzdPA8FPJuwrLLRavOhAmFGgdAvMcX47XsyM+IOGa9tc7/K5SPvBqn4nhppOCEz7BrzOPWc4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.46.0",
-        "@algolia/requester-browser-xhr": "5.46.0",
-        "@algolia/requester-fetch": "5.46.0",
-        "@algolia/requester-node-http": "5.46.0"
+        "@algolia/client-common": "5.46.2",
+        "@algolia/requester-browser-xhr": "5.46.2",
+        "@algolia/requester-fetch": "5.46.2",
+        "@algolia/requester-node-http": "5.46.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.46.0.tgz",
-      "integrity": "sha512-AYh2uL8IUW9eZrbbT+wZElyb7QkkeV3US2NEKY7doqMlyPWE8lErNfkVN1NvZdVcY4/SVic5GDbeDz2ft8YIiQ==",
+      "version": "5.46.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.46.2.tgz",
+      "integrity": "sha512-EPBN2Oruw0maWOF4OgGPfioTvd+gmiNwx0HmD9IgmlS+l75DatcBkKOPNJN+0z3wBQWUO5oq602ATxIfmTQ8bA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.46.0",
-        "@algolia/requester-browser-xhr": "5.46.0",
-        "@algolia/requester-fetch": "5.46.0",
-        "@algolia/requester-node-http": "5.46.0"
+        "@algolia/client-common": "5.46.2",
+        "@algolia/requester-browser-xhr": "5.46.2",
+        "@algolia/requester-fetch": "5.46.2",
+        "@algolia/requester-node-http": "5.46.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.46.0.tgz",
-      "integrity": "sha512-0emZTaYOeI9WzJi0TcNd2k3SxiN6DZfdWc2x2gHt855Jl9jPUOzfVTL6gTvCCrOlT4McvpDGg5nGO+9doEjjig==",
+      "version": "5.46.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.46.2.tgz",
+      "integrity": "sha512-Hj8gswSJNKZ0oyd0wWissqyasm+wTz1oIsv5ZmLarzOZAp3vFEda8bpDQ8PUhO+DfkbiLyVnAxsPe4cGzWtqkg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -122,151 +119,151 @@
       }
     },
     "node_modules/@algolia/client-insights": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.46.0.tgz",
-      "integrity": "sha512-wrBJ8fE+M0TDG1As4DDmwPn2TXajrvmvAN72Qwpuv8e2JOKNohF7+JxBoF70ZLlvP1A1EiH8DBu+JpfhBbNphQ==",
+      "version": "5.46.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.46.2.tgz",
+      "integrity": "sha512-6dBZko2jt8FmQcHCbmNLB0kCV079Mx/DJcySTL3wirgDBUH7xhY1pOuUTLMiGkqM5D8moVZTvTdRKZUJRkrwBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.46.0",
-        "@algolia/requester-browser-xhr": "5.46.0",
-        "@algolia/requester-fetch": "5.46.0",
-        "@algolia/requester-node-http": "5.46.0"
+        "@algolia/client-common": "5.46.2",
+        "@algolia/requester-browser-xhr": "5.46.2",
+        "@algolia/requester-fetch": "5.46.2",
+        "@algolia/requester-node-http": "5.46.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.46.0.tgz",
-      "integrity": "sha512-LnkeX4p0ENt0DoftDJJDzQQJig/sFQmD1eQifl/iSjhUOGUIKC/7VTeXRcKtQB78naS8njUAwpzFvxy1CDDXDQ==",
+      "version": "5.46.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.46.2.tgz",
+      "integrity": "sha512-1waE2Uqh/PHNeDXGn/PM/WrmYOBiUGSVxAWqiJIj73jqPqvfzZgzdakHscIVaDl6Cp+j5dwjsZ5LCgaUr6DtmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.46.0",
-        "@algolia/requester-browser-xhr": "5.46.0",
-        "@algolia/requester-fetch": "5.46.0",
-        "@algolia/requester-node-http": "5.46.0"
+        "@algolia/client-common": "5.46.2",
+        "@algolia/requester-browser-xhr": "5.46.2",
+        "@algolia/requester-fetch": "5.46.2",
+        "@algolia/requester-node-http": "5.46.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.46.0.tgz",
-      "integrity": "sha512-aF9tc4ex/smypXw+W3lBPB1jjKoaGHpZezTqofvDOI/oK1dR2sdTpFpK2Ru+7IRzYgwtRqHF3znmTlyoNs9dpA==",
+      "version": "5.46.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.46.2.tgz",
+      "integrity": "sha512-EgOzTZkyDcNL6DV0V/24+oBJ+hKo0wNgyrOX/mePBM9bc9huHxIY2352sXmoZ648JXXY2x//V1kropF/Spx83w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.46.0",
-        "@algolia/requester-browser-xhr": "5.46.0",
-        "@algolia/requester-fetch": "5.46.0",
-        "@algolia/requester-node-http": "5.46.0"
+        "@algolia/client-common": "5.46.2",
+        "@algolia/requester-browser-xhr": "5.46.2",
+        "@algolia/requester-fetch": "5.46.2",
+        "@algolia/requester-node-http": "5.46.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.46.0.tgz",
-      "integrity": "sha512-22SHEEVNjZfFWkFks3P6HilkR3rS7a6GjnCIqR22Zz4HNxdfT0FG+RE7efTcFVfLUkTTMQQybvaUcwMrHXYa7Q==",
+      "version": "5.46.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.46.2.tgz",
+      "integrity": "sha512-ZsOJqu4HOG5BlvIFnMU0YKjQ9ZI6r3C31dg2jk5kMWPSdhJpYL9xa5hEe7aieE+707dXeMI4ej3diy6mXdZpgA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.46.0",
-        "@algolia/requester-browser-xhr": "5.46.0",
-        "@algolia/requester-fetch": "5.46.0",
-        "@algolia/requester-node-http": "5.46.0"
+        "@algolia/client-common": "5.46.2",
+        "@algolia/requester-browser-xhr": "5.46.2",
+        "@algolia/requester-fetch": "5.46.2",
+        "@algolia/requester-node-http": "5.46.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/ingestion": {
-      "version": "1.46.0",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.46.0.tgz",
-      "integrity": "sha512-2LT0/Z+/sFwEpZLH6V17WSZ81JX2uPjgvv5eNlxgU7rPyup4NXXfuMbtCJ+6uc4RO/LQpEJd3Li59ke3wtyAsA==",
+      "version": "1.46.2",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.46.2.tgz",
+      "integrity": "sha512-1Uw2OslTWiOFDtt83y0bGiErJYy5MizadV0nHnOoHFWMoDqWW0kQoMFI65pXqRSkVvit5zjXSLik2xMiyQJDWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.46.0",
-        "@algolia/requester-browser-xhr": "5.46.0",
-        "@algolia/requester-fetch": "5.46.0",
-        "@algolia/requester-node-http": "5.46.0"
+        "@algolia/client-common": "5.46.2",
+        "@algolia/requester-browser-xhr": "5.46.2",
+        "@algolia/requester-fetch": "5.46.2",
+        "@algolia/requester-node-http": "5.46.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/monitoring": {
-      "version": "1.46.0",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.46.0.tgz",
-      "integrity": "sha512-uivZ9wSWZ8mz2ZU0dgDvQwvVZV8XBv6lYBXf8UtkQF3u7WeTqBPeU8ZoeTyLpf0jAXCYOvc1mAVmK0xPLuEwOQ==",
+      "version": "1.46.2",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.46.2.tgz",
+      "integrity": "sha512-xk9f+DPtNcddWN6E7n1hyNNsATBCHIqAvVGG2EAGHJc4AFYL18uM/kMTiOKXE/LKDPyy1JhIerrh9oYb7RBrgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.46.0",
-        "@algolia/requester-browser-xhr": "5.46.0",
-        "@algolia/requester-fetch": "5.46.0",
-        "@algolia/requester-node-http": "5.46.0"
+        "@algolia/client-common": "5.46.2",
+        "@algolia/requester-browser-xhr": "5.46.2",
+        "@algolia/requester-fetch": "5.46.2",
+        "@algolia/requester-node-http": "5.46.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.46.0.tgz",
-      "integrity": "sha512-O2BB8DuySuddgOAbhyH4jsGbL+KyDGpzJRtkDZkv091OMomqIA78emhhMhX9d/nIRrzS1wNLWB/ix7Hb2eV5rg==",
+      "version": "5.46.2",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.46.2.tgz",
+      "integrity": "sha512-NApbTPj9LxGzNw4dYnZmj2BoXiAc8NmbbH6qBNzQgXklGklt/xldTvu+FACN6ltFsTzoNU6j2mWNlHQTKGC5+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.46.0",
-        "@algolia/requester-browser-xhr": "5.46.0",
-        "@algolia/requester-fetch": "5.46.0",
-        "@algolia/requester-node-http": "5.46.0"
+        "@algolia/client-common": "5.46.2",
+        "@algolia/requester-browser-xhr": "5.46.2",
+        "@algolia/requester-fetch": "5.46.2",
+        "@algolia/requester-node-http": "5.46.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.46.0.tgz",
-      "integrity": "sha512-eW6xyHCyYrJD0Kjk9Mz33gQ40LfWiEA51JJTVfJy3yeoRSw/NXhAL81Pljpa0qslTs6+LO/5DYPZddct6HvISQ==",
+      "version": "5.46.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.46.2.tgz",
+      "integrity": "sha512-ekotpCwpSp033DIIrsTpYlGUCF6momkgupRV/FA3m62SreTSZUKjgK6VTNyG7TtYfq9YFm/pnh65bATP/ZWJEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.46.0"
+        "@algolia/client-common": "5.46.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-fetch": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.46.0.tgz",
-      "integrity": "sha512-Vn2+TukMGHy4PIxmdvP667tN/MhS7MPT8EEvEhS6JyFLPx3weLcxSa1F9gVvrfHWCUJhLWoMVJVB2PT8YfRGcw==",
+      "version": "5.46.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.46.2.tgz",
+      "integrity": "sha512-gKE+ZFi/6y7saTr34wS0SqYFDcjHW4Wminv8PDZEi0/mE99+hSrbKgJWxo2ztb5eqGirQTgIh1AMVacGGWM1iw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.46.0"
+        "@algolia/client-common": "5.46.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.46.0.tgz",
-      "integrity": "sha512-xaqXyna5yBZ+r1SJ9my/DM6vfTqJg9FJgVydRJ0lnO+D5NhqGW/qaRG/iBGKr/d4fho34el6WakV7BqJvrl/HQ==",
+      "version": "5.46.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.46.2.tgz",
+      "integrity": "sha512-ciPihkletp7ttweJ8Zt+GukSVLp2ANJHU+9ttiSxsJZThXc4Y2yJ8HGVWesW5jN1zrsZsezN71KrMx/iZsOYpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.46.0"
+        "@algolia/client-common": "5.46.2"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -342,15 +339,6 @@
       "integrity": "sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@catppuccin/vitepress": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@catppuccin/vitepress/-/vitepress-0.1.2.tgz",
-      "integrity": "sha512-dqhgo6U6GWbgh3McAgwemUC8Y2Aj48rRcQx/9iuPzBPAgo7NA3yi7ZcR0wolAENMmoOMAHBV+rz/5DfiGxtZLA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      }
     },
     "node_modules/@chevrotain/cst-dts-gen": {
       "version": "11.0.3",
@@ -910,9 +898,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.3.tgz",
-      "integrity": "sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.54.0.tgz",
+      "integrity": "sha512-OywsdRHrFvCdvsewAInDKCNyR3laPA2mc9bRYJ6LBp5IyvF3fvXbbNR0bSzHlZVFtn6E0xw2oZlyjg4rKCVcng==",
       "cpu": [
         "arm"
       ],
@@ -924,9 +912,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.3.tgz",
-      "integrity": "sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.54.0.tgz",
+      "integrity": "sha512-Skx39Uv+u7H224Af+bDgNinitlmHyQX1K/atIA32JP3JQw6hVODX5tkbi2zof/E69M1qH2UoN3Xdxgs90mmNYw==",
       "cpu": [
         "arm64"
       ],
@@ -938,9 +926,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.3.tgz",
-      "integrity": "sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.54.0.tgz",
+      "integrity": "sha512-k43D4qta/+6Fq+nCDhhv9yP2HdeKeP56QrUUTW7E6PhZP1US6NDqpJj4MY0jBHlJivVJD5P8NxrjuobZBJTCRw==",
       "cpu": [
         "arm64"
       ],
@@ -952,9 +940,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.3.tgz",
-      "integrity": "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.54.0.tgz",
+      "integrity": "sha512-cOo7biqwkpawslEfox5Vs8/qj83M/aZCSSNIWpVzfU2CYHa2G3P1UN5WF01RdTHSgCkri7XOlTdtk17BezlV3A==",
       "cpu": [
         "x64"
       ],
@@ -966,9 +954,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.3.tgz",
-      "integrity": "sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.54.0.tgz",
+      "integrity": "sha512-miSvuFkmvFbgJ1BevMa4CPCFt5MPGw094knM64W9I0giUIMMmRYcGW/JWZDriaw/k1kOBtsWh1z6nIFV1vPNtA==",
       "cpu": [
         "arm64"
       ],
@@ -980,9 +968,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.3.tgz",
-      "integrity": "sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.54.0.tgz",
+      "integrity": "sha512-KGXIs55+b/ZfZsq9aR026tmr/+7tq6VG6MsnrvF4H8VhwflTIuYh+LFUlIsRdQSgrgmtM3fVATzEAj4hBQlaqQ==",
       "cpu": [
         "x64"
       ],
@@ -994,9 +982,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.3.tgz",
-      "integrity": "sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.54.0.tgz",
+      "integrity": "sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==",
       "cpu": [
         "arm"
       ],
@@ -1008,9 +996,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.3.tgz",
-      "integrity": "sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.54.0.tgz",
+      "integrity": "sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==",
       "cpu": [
         "arm"
       ],
@@ -1022,9 +1010,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.3.tgz",
-      "integrity": "sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.54.0.tgz",
+      "integrity": "sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==",
       "cpu": [
         "arm64"
       ],
@@ -1036,9 +1024,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.3.tgz",
-      "integrity": "sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.54.0.tgz",
+      "integrity": "sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==",
       "cpu": [
         "arm64"
       ],
@@ -1050,9 +1038,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.3.tgz",
-      "integrity": "sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.54.0.tgz",
+      "integrity": "sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==",
       "cpu": [
         "loong64"
       ],
@@ -1064,9 +1052,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.3.tgz",
-      "integrity": "sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.54.0.tgz",
+      "integrity": "sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==",
       "cpu": [
         "ppc64"
       ],
@@ -1078,9 +1066,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.3.tgz",
-      "integrity": "sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.54.0.tgz",
+      "integrity": "sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1092,9 +1080,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.3.tgz",
-      "integrity": "sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.54.0.tgz",
+      "integrity": "sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==",
       "cpu": [
         "riscv64"
       ],
@@ -1106,9 +1094,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.3.tgz",
-      "integrity": "sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.54.0.tgz",
+      "integrity": "sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==",
       "cpu": [
         "s390x"
       ],
@@ -1120,9 +1108,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.3.tgz",
-      "integrity": "sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.54.0.tgz",
+      "integrity": "sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==",
       "cpu": [
         "x64"
       ],
@@ -1134,9 +1122,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.3.tgz",
-      "integrity": "sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.54.0.tgz",
+      "integrity": "sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==",
       "cpu": [
         "x64"
       ],
@@ -1148,9 +1136,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.3.tgz",
-      "integrity": "sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.54.0.tgz",
+      "integrity": "sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==",
       "cpu": [
         "arm64"
       ],
@@ -1162,9 +1150,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.3.tgz",
-      "integrity": "sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.54.0.tgz",
+      "integrity": "sha512-c2V0W1bsKIKfbLMBu/WGBz6Yci8nJ/ZJdheE0EwB73N3MvHYKiKGs3mVilX4Gs70eGeDaMqEob25Tw2Gb9Nqyw==",
       "cpu": [
         "arm64"
       ],
@@ -1176,9 +1164,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.3.tgz",
-      "integrity": "sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.54.0.tgz",
+      "integrity": "sha512-woEHgqQqDCkAzrDhvDipnSirm5vxUXtSKDYTVpZG3nUdW/VVB5VdCYA2iReSj/u3yCZzXID4kuKG7OynPnB3WQ==",
       "cpu": [
         "ia32"
       ],
@@ -1190,9 +1178,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.3.tgz",
-      "integrity": "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.54.0.tgz",
+      "integrity": "sha512-dzAc53LOuFvHwbCEOS0rPbXp6SIhAf2txMP5p6mGyOXXw5mWY8NGGbPMPrs4P1WItkfApDathBj/NzMLUZ9rtQ==",
       "cpu": [
         "x64"
       ],
@@ -1204,9 +1192,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.3.tgz",
-      "integrity": "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.54.0.tgz",
+      "integrity": "sha512-hYT5d3YNdSh3mbCU1gwQyPgQd3T2ne0A3KG8KSBdav5TiBg6eInVmV+TeR5uHufiIgSFg0XsOWGW5/RhNcSvPg==",
       "cpu": [
         "x64"
       ],
@@ -1691,42 +1679,42 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.25",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.25.tgz",
-      "integrity": "sha512-vay5/oQJdsNHmliWoZfHPoVZZRmnSWhug0BYT34njkYTPqClh3DNWLkZNJBVSjsNMrg0CCrBfoKkjZQPM/QVUw==",
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.26.tgz",
+      "integrity": "sha512-vXyI5GMfuoBCnv5ucIT7jhHKl55Y477yxP6fc4eUswjP8FG3FFVFd41eNDArR+Uk3QKn2Z85NavjaxLxOC19/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.5",
-        "@vue/shared": "3.5.25",
-        "entities": "^4.5.0",
+        "@vue/shared": "3.5.26",
+        "entities": "^7.0.0",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.25",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.25.tgz",
-      "integrity": "sha512-4We0OAcMZsKgYoGlMjzYvaoErltdFI2/25wqanuTu+S4gismOTRTBPi4IASOjxWdzIwrYSjnqONfKvuqkXzE2Q==",
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.26.tgz",
+      "integrity": "sha512-y1Tcd3eXs834QjswshSilCBnKGeQjQXB6PqFn/1nxcQw4pmG42G8lwz+FZPAZAby6gZeHSt/8LMPfZ4Rb+Bd/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.25",
-        "@vue/shared": "3.5.25"
+        "@vue/compiler-core": "3.5.26",
+        "@vue/shared": "3.5.26"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.25",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.25.tgz",
-      "integrity": "sha512-PUgKp2rn8fFsI++lF2sO7gwO2d9Yj57Utr5yEsDf3GNaQcowCLKL7sf+LvVFvtJDXUp/03+dC6f2+LCv5aK1ag==",
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.26.tgz",
+      "integrity": "sha512-egp69qDTSEZcf4bGOSsprUr4xI73wfrY5oRs6GSgXFTiHrWj4Y3X5Ydtip9QMqiCMCPVwLglB9GBxXtTadJ3mA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.5",
-        "@vue/compiler-core": "3.5.25",
-        "@vue/compiler-dom": "3.5.25",
-        "@vue/compiler-ssr": "3.5.25",
-        "@vue/shared": "3.5.25",
+        "@vue/compiler-core": "3.5.26",
+        "@vue/compiler-dom": "3.5.26",
+        "@vue/compiler-ssr": "3.5.26",
+        "@vue/shared": "3.5.26",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
         "postcss": "^8.5.6",
@@ -1734,14 +1722,14 @@
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.25",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.25.tgz",
-      "integrity": "sha512-ritPSKLBcParnsKYi+GNtbdbrIE1mtuFEJ4U1sWeuOMlIziK5GtOL85t5RhsNy4uWIXPgk+OUdpnXiTdzn8o3A==",
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.26.tgz",
+      "integrity": "sha512-lZT9/Y0nSIRUPVvapFJEVDbEXruZh2IYHMk2zTtEgJSlP5gVOqeWXH54xDKAaFS4rTnDeDBQUYDtxKyoW9FwDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.25",
-        "@vue/shared": "3.5.25"
+        "@vue/compiler-dom": "3.5.26",
+        "@vue/shared": "3.5.26"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -1781,57 +1769,57 @@
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.5.25",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.25.tgz",
-      "integrity": "sha512-5xfAypCQepv4Jog1U4zn8cZIcbKKFka3AgWHEFQeK65OW+Ys4XybP6z2kKgws4YB43KGpqp5D/K3go2UPPunLA==",
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.26.tgz",
+      "integrity": "sha512-9EnYB1/DIiUYYnzlnUBgwU32NNvLp/nhxLXeWRhHUEeWNTn1ECxX8aGO7RTXeX6PPcxe3LLuNBFoJbV4QZ+CFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.5.25"
+        "@vue/shared": "3.5.26"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.25",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.25.tgz",
-      "integrity": "sha512-Z751v203YWwYzy460bzsYQISDfPjHTl+6Zzwo/a3CsAf+0ccEjQ8c+0CdX1WsumRTHeywvyUFtW6KvNukT/smA==",
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.26.tgz",
+      "integrity": "sha512-xJWM9KH1kd201w5DvMDOwDHYhrdPTrAatn56oB/LRG4plEQeZRQLw0Bpwih9KYoqmzaxF0OKSn6swzYi84e1/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.25",
-        "@vue/shared": "3.5.25"
+        "@vue/reactivity": "3.5.26",
+        "@vue/shared": "3.5.26"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.25",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.25.tgz",
-      "integrity": "sha512-a4WrkYFbb19i9pjkz38zJBg8wa/rboNERq3+hRRb0dHiJh13c+6kAbgqCPfMaJ2gg4weWD3APZswASOfmKwamA==",
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.26.tgz",
+      "integrity": "sha512-XLLd/+4sPC2ZkN/6+V4O4gjJu6kSDbHAChvsyWgm1oGbdSO3efvGYnm25yCjtFm/K7rrSDvSfPDgN1pHgS4VNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.25",
-        "@vue/runtime-core": "3.5.25",
-        "@vue/shared": "3.5.25",
-        "csstype": "^3.1.3"
+        "@vue/reactivity": "3.5.26",
+        "@vue/runtime-core": "3.5.26",
+        "@vue/shared": "3.5.26",
+        "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.25",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.25.tgz",
-      "integrity": "sha512-UJaXR54vMG61i8XNIzTSf2Q7MOqZHpp8+x3XLGtE3+fL+nQd+k7O5+X3D/uWrnQXOdMw5VPih+Uremcw+u1woQ==",
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.26.tgz",
+      "integrity": "sha512-TYKLXmrwWKSodyVuO1WAubucd+1XlLg4set0YoV+Hu8Lo79mp/YMwWV5mC5FgtsDxX3qo1ONrxFaTP1OQgy1uA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.25",
-        "@vue/shared": "3.5.25"
+        "@vue/compiler-ssr": "3.5.26",
+        "@vue/shared": "3.5.26"
       },
       "peerDependencies": {
-        "vue": "3.5.25"
+        "vue": "3.5.26"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.25",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.25.tgz",
-      "integrity": "sha512-AbOPdQQnAnzs58H2FrrDxYj/TJfmeS2jdfEEhgiKINy+bnOANmVizIEgq1r+C5zsbs6l1CCQxtcj71rwNQ4jWg==",
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.26.tgz",
+      "integrity": "sha512-7Z6/y3uFI5PRoKeorTOSXKcDj0MSasfNNltcslbFrPpcw6aXRUALq4IfJlaTRspiWIUOEZbrpM+iQGmCOiWe4A==",
       "dev": true,
       "license": "MIT"
     },
@@ -1955,26 +1943,26 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.46.0.tgz",
-      "integrity": "sha512-7ML6fa2K93FIfifG3GMWhDEwT5qQzPTmoHKCTvhzGEwdbQ4n0yYUWZlLYT75WllTGJCJtNUI0C1ybN4BCegqvg==",
+      "version": "5.46.2",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.46.2.tgz",
+      "integrity": "sha512-qqAXW9QvKf2tTyhpDA4qXv1IfBwD2eduSW6tUEBFIfCeE9gn9HQ9I5+MaKoenRuHrzk5sQoNh1/iof8mY7uD6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/abtesting": "1.12.0",
-        "@algolia/client-abtesting": "5.46.0",
-        "@algolia/client-analytics": "5.46.0",
-        "@algolia/client-common": "5.46.0",
-        "@algolia/client-insights": "5.46.0",
-        "@algolia/client-personalization": "5.46.0",
-        "@algolia/client-query-suggestions": "5.46.0",
-        "@algolia/client-search": "5.46.0",
-        "@algolia/ingestion": "1.46.0",
-        "@algolia/monitoring": "1.46.0",
-        "@algolia/recommend": "5.46.0",
-        "@algolia/requester-browser-xhr": "5.46.0",
-        "@algolia/requester-fetch": "5.46.0",
-        "@algolia/requester-node-http": "5.46.0"
+        "@algolia/abtesting": "1.12.2",
+        "@algolia/client-abtesting": "5.46.2",
+        "@algolia/client-analytics": "5.46.2",
+        "@algolia/client-common": "5.46.2",
+        "@algolia/client-insights": "5.46.2",
+        "@algolia/client-personalization": "5.46.2",
+        "@algolia/client-query-suggestions": "5.46.2",
+        "@algolia/client-search": "5.46.2",
+        "@algolia/ingestion": "1.46.2",
+        "@algolia/monitoring": "1.46.2",
+        "@algolia/recommend": "5.46.2",
+        "@algolia/requester-browser-xhr": "5.46.2",
+        "@algolia/requester-fetch": "5.46.2",
+        "@algolia/requester-node-http": "5.46.2"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -2712,9 +2700,9 @@
       "license": "MIT"
     },
     "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.0.tgz",
+      "integrity": "sha512-FDWG5cmEYf2Z00IkYRhbFrwIwvdFKH07uV8dvNy0omp/Qb1xcyCWp2UDtcwJF4QZZvk0sLudP6/hAu42TaqVhQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -2771,9 +2759,9 @@
       "license": "MIT"
     },
     "node_modules/focus-trap": {
-      "version": "7.6.6",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.6.tgz",
-      "integrity": "sha512-v/Z8bvMCajtx4mEXmOo7QEsIzlIOqRXTIwgUfsFOF9gEsespdbD0AkPIka1bSXZ8Y8oZ+2IVDQZePkTfEHZl7Q==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.7.0.tgz",
+      "integrity": "sha512-DJJDHpEgoSbP8ZE1MNeU2IzCpfFyFdNZZRilqmfH2XiQsPK6PtD8AfJqWzEBudUQB2yHwZc5iq54rjTaGQ+ljw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3294,9 +3282,9 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.28.0",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.0.tgz",
-      "integrity": "sha512-rytDAoiXr3+t6OIP3WGlDd0ouCUG1iCWzkcY3++Nreuoi17y6T5i/zRhe6uYfoVcxq6YU+sBtJouuRDsq8vvqA==",
+      "version": "10.28.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.1.tgz",
+      "integrity": "sha512-u1/ixq/lVQI0CakKNvLDEcW5zfCjUQfZdK9qqWuIJtsezuyG6pk9TWj75GMuI/EzRSZB/VAE43sNWWZfiy8psw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3357,9 +3345,9 @@
       "license": "Unlicense"
     },
     "node_modules/rollup": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
-      "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.54.0.tgz",
+      "integrity": "sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3373,28 +3361,28 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.53.3",
-        "@rollup/rollup-android-arm64": "4.53.3",
-        "@rollup/rollup-darwin-arm64": "4.53.3",
-        "@rollup/rollup-darwin-x64": "4.53.3",
-        "@rollup/rollup-freebsd-arm64": "4.53.3",
-        "@rollup/rollup-freebsd-x64": "4.53.3",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.53.3",
-        "@rollup/rollup-linux-arm-musleabihf": "4.53.3",
-        "@rollup/rollup-linux-arm64-gnu": "4.53.3",
-        "@rollup/rollup-linux-arm64-musl": "4.53.3",
-        "@rollup/rollup-linux-loong64-gnu": "4.53.3",
-        "@rollup/rollup-linux-ppc64-gnu": "4.53.3",
-        "@rollup/rollup-linux-riscv64-gnu": "4.53.3",
-        "@rollup/rollup-linux-riscv64-musl": "4.53.3",
-        "@rollup/rollup-linux-s390x-gnu": "4.53.3",
-        "@rollup/rollup-linux-x64-gnu": "4.53.3",
-        "@rollup/rollup-linux-x64-musl": "4.53.3",
-        "@rollup/rollup-openharmony-arm64": "4.53.3",
-        "@rollup/rollup-win32-arm64-msvc": "4.53.3",
-        "@rollup/rollup-win32-ia32-msvc": "4.53.3",
-        "@rollup/rollup-win32-x64-gnu": "4.53.3",
-        "@rollup/rollup-win32-x64-msvc": "4.53.3",
+        "@rollup/rollup-android-arm-eabi": "4.54.0",
+        "@rollup/rollup-android-arm64": "4.54.0",
+        "@rollup/rollup-darwin-arm64": "4.54.0",
+        "@rollup/rollup-darwin-x64": "4.54.0",
+        "@rollup/rollup-freebsd-arm64": "4.54.0",
+        "@rollup/rollup-freebsd-x64": "4.54.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.54.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.54.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.54.0",
+        "@rollup/rollup-linux-arm64-musl": "4.54.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.54.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.54.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.54.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.54.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.54.0",
+        "@rollup/rollup-linux-x64-gnu": "4.54.0",
+        "@rollup/rollup-linux-x64-musl": "4.54.0",
+        "@rollup/rollup-openharmony-arm64": "4.54.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.54.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.54.0",
+        "@rollup/rollup-win32-x64-gnu": "4.54.0",
+        "@rollup/rollup-win32-x64-msvc": "4.54.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -3552,20 +3540,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.10"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/ufo": {
@@ -3864,17 +3838,17 @@
       "license": "MIT"
     },
     "node_modules/vue": {
-      "version": "3.5.25",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.25.tgz",
-      "integrity": "sha512-YLVdgv2K13WJ6n+kD5owehKtEXwdwXuj2TTyJMsO7pSeKw2bfRNZGjhB7YzrpbMYj5b5QsUebHpOqR3R3ziy/g==",
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.26.tgz",
+      "integrity": "sha512-SJ/NTccVyAoNUJmkM9KUqPcYlY+u8OVL1X5EW9RIs3ch5H2uERxyyIUI4MRxVCSOiEcupX9xNGde1tL9ZKpimA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.25",
-        "@vue/compiler-sfc": "3.5.25",
-        "@vue/runtime-dom": "3.5.25",
-        "@vue/server-renderer": "3.5.25",
-        "@vue/shared": "3.5.25"
+        "@vue/compiler-dom": "3.5.26",
+        "@vue/compiler-sfc": "3.5.26",
+        "@vue/runtime-dom": "3.5.26",
+        "@vue/server-renderer": "3.5.26",
+        "@vue/shared": "3.5.26"
       },
       "peerDependencies": {
         "typescript": "*"

--- a/package.json
+++ b/package.json
@@ -13,8 +13,5 @@
     "mermaid": "^11.12.2",
     "vitepress": "^1.6.4",
     "vitepress-plugin-mermaid": "^2.0.17"
-  },
-  "dependencies": {
-    "@catppuccin/vitepress": "^0.1.2"
   }
 }


### PR DESCRIPTION
## Summary
- Simplify architecture documentation by removing detailed class listings and replacing with package-level tables and GitHub repository links
- Add framework comparison page (10-comparison.md) for both English and Japanese versions
- Apply technical writing standards compliance (remove prohibited words, fix SPI names, correct JUnit version references)
- Add VitePress theme enhancements (language detector, custom feature icons)
- Update favicon and improve landing page with feature highlights

## Test plan
- [ ] Verify VitePress documentation builds successfully
- [ ] Check framework comparison page renders correctly in both languages
- [ ] Confirm all internal links work properly