### PR TITLE
feat: add annotation-based column exclusion for @ExpectedDataSet

### DIFF
--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/annotation/DataSetSource.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/annotation/DataSetSource.java
@@ -71,4 +71,32 @@ public @interface DataSetSource {
    * @return scenario names to keep, or an empty array to fall back to the test method name
    */
   String[] scenarioNames() default {};
+
+  /**
+   * Lists the column names to exclude from assertion verification.
+   *
+   * <p>Columns listed here are ignored during database state comparison. This is useful for
+   * excluding auto-generated columns (timestamps, version numbers, auto-increment IDs) that cannot
+   * be predicted in test data.
+   *
+   * <p>Column name matching is case-insensitive. For example, specifying {@code "CREATED_AT"} will
+   * exclude columns named {@code "created_at"}, {@code "CREATED_AT"}, or {@code "Created_At"}.
+   *
+   * <p>This attribute only applies to expectation verification (when used within {@link
+   * ExpectedDataSet#dataSets()}). It has no effect when used within {@link DataSet#dataSets()} for
+   * preparation.
+   *
+   * <p>Example usage:
+   *
+   * <pre>{@code
+   * @ExpectedDataSet(dataSets = @DataSetSource(
+   *     excludeColumns = {"CREATED_AT", "UPDATED_AT", "VERSION"}
+   * ))
+   * void testUserCreation() { }
+   * }</pre>
+   *
+   * @return column names to exclude from verification, or an empty array for no exclusions
+   * @see io.github.seijikohara.dbtester.api.assertion.DatabaseAssertion#assertEqualsIgnoreColumns
+   */
+  String[] excludeColumns() default {};
 }

--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/config/ConventionSettings.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/config/ConventionSettings.java
@@ -1,5 +1,6 @@
 package io.github.seijikohara.dbtester.api.config;
 
+import java.util.Set;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -14,6 +15,7 @@ import org.jspecify.annotations.Nullable;
  * @param tableMergeStrategy the strategy for merging tables when multiple DataSets contain the same
  *     table
  * @param loadOrderFileName the file name used to specify table loading order in dataset directories
+ * @param globalExcludeColumns column names to exclude from all expectation verifications globally
  */
 public record ConventionSettings(
     @Nullable String baseDirectory,
@@ -21,7 +23,8 @@ public record ConventionSettings(
     String scenarioMarker,
     DataFormat dataFormat,
     TableMergeStrategy tableMergeStrategy,
-    String loadOrderFileName) {
+    String loadOrderFileName,
+    Set<String> globalExcludeColumns) {
 
   /**
    * Default base directory for dataset resolution.
@@ -62,12 +65,15 @@ public record ConventionSettings(
    */
   public static final String DEFAULT_LOAD_ORDER_FILE_NAME = "load-order.txt";
 
+  /** Default global exclude columns (empty set). */
+  private static final Set<String> DEFAULT_GLOBAL_EXCLUDE_COLUMNS = Set.of();
+
   /**
    * Creates a convention instance populated with the framework defaults.
    *
    * @return conventions using classpath-relative discovery, {@value #DEFAULT_EXPECTATION_SUFFIX}
-   *     suffix, {@value #DEFAULT_SCENARIO_MARKER} marker, CSV format, UNION_ALL merge strategy, and
-   *     {@value #DEFAULT_LOAD_ORDER_FILE_NAME} load order file
+   *     suffix, {@value #DEFAULT_SCENARIO_MARKER} marker, CSV format, UNION_ALL merge strategy,
+   *     {@value #DEFAULT_LOAD_ORDER_FILE_NAME} load order file, and no global exclude columns
    */
   public static ConventionSettings standard() {
     return new ConventionSettings(
@@ -76,7 +82,8 @@ public record ConventionSettings(
         DEFAULT_SCENARIO_MARKER,
         DEFAULT_DATA_FORMAT,
         DEFAULT_TABLE_MERGE_STRATEGY,
-        DEFAULT_LOAD_ORDER_FILE_NAME);
+        DEFAULT_LOAD_ORDER_FILE_NAME,
+        DEFAULT_GLOBAL_EXCLUDE_COLUMNS);
   }
 
   /**
@@ -92,7 +99,8 @@ public record ConventionSettings(
         this.scenarioMarker,
         dataFormat,
         this.tableMergeStrategy,
-        this.loadOrderFileName);
+        this.loadOrderFileName,
+        this.globalExcludeColumns);
   }
 
   /**
@@ -108,7 +116,8 @@ public record ConventionSettings(
         this.scenarioMarker,
         this.dataFormat,
         tableMergeStrategy,
-        this.loadOrderFileName);
+        this.loadOrderFileName,
+        this.globalExcludeColumns);
   }
 
   /**
@@ -124,6 +133,30 @@ public record ConventionSettings(
         this.scenarioMarker,
         this.dataFormat,
         this.tableMergeStrategy,
-        loadOrderFileName);
+        loadOrderFileName,
+        this.globalExcludeColumns);
+  }
+
+  /**
+   * Creates a new ConventionSettings with the specified global exclude columns.
+   *
+   * <p>Columns listed here are excluded from all expectation verifications. This is useful for
+   * excluding auto-generated columns (timestamps, version numbers) across all tests without
+   * repeating the exclusion in each annotation.
+   *
+   * <p>Column name matching is case-insensitive.
+   *
+   * @param globalExcludeColumns the column names to exclude globally
+   * @return a new ConventionSettings with the specified global exclude columns
+   */
+  public ConventionSettings withGlobalExcludeColumns(final Set<String> globalExcludeColumns) {
+    return new ConventionSettings(
+        this.baseDirectory,
+        this.expectationSuffix,
+        this.scenarioMarker,
+        this.dataFormat,
+        this.tableMergeStrategy,
+        this.loadOrderFileName,
+        globalExcludeColumns);
   }
 }

--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/loader/DataSetLoader.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/loader/DataSetLoader.java
@@ -3,6 +3,7 @@ package io.github.seijikohara.dbtester.api.loader;
 import io.github.seijikohara.dbtester.api.context.TestContext;
 import io.github.seijikohara.dbtester.api.dataset.TableSet;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Strategy SPI that resolves {@link TableSet} instances for each test phase.
@@ -43,4 +44,27 @@ public interface DataSetLoader {
    * @return immutable list of datasets to validate against the database
    */
   List<TableSet> loadExpectationDataSets(final TestContext context);
+
+  /**
+   * Loads datasets for validating the database state with column exclusion metadata.
+   *
+   * <p>This method extends {@link #loadExpectationDataSets(TestContext)} to include column
+   * exclusion information from annotations ({@link
+   * io.github.seijikohara.dbtester.api.annotation.DataSetSource#excludeColumns()}) and global
+   * settings ({@link
+   * io.github.seijikohara.dbtester.api.config.ConventionSettings#globalExcludeColumns()}).
+   *
+   * <p>The default implementation wraps results from {@link #loadExpectationDataSets(TestContext)}
+   * with global exclude columns only. Implementations should override this method to also include
+   * annotation-level exclusions.
+   *
+   * @param context the test execution context containing test metadata and configuration
+   * @return immutable list of expected table sets with column exclusion metadata
+   */
+  default List<ExpectedTableSet> loadExpectationDataSetsWithExclusions(final TestContext context) {
+    final var globalExcludeColumns = context.configuration().conventions().globalExcludeColumns();
+    return loadExpectationDataSets(context).stream()
+        .map(tableSet -> ExpectedTableSet.of(tableSet, globalExcludeColumns))
+        .collect(Collectors.toUnmodifiableList());
+  }
 }

--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/loader/ExpectedTableSet.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/loader/ExpectedTableSet.java
@@ -1,0 +1,51 @@
+package io.github.seijikohara.dbtester.api.loader;
+
+import io.github.seijikohara.dbtester.api.dataset.TableSet;
+import java.util.Set;
+
+/**
+ * Associates a {@link TableSet} with column exclusion metadata for expectation verification.
+ *
+ * <p>This record combines the expected dataset with a set of column names to exclude during
+ * verification. The exclusion set is derived from both annotation-level exclusions ({@link
+ * io.github.seijikohara.dbtester.api.annotation.DataSetSource#excludeColumns()}) and global
+ * exclusions ({@link
+ * io.github.seijikohara.dbtester.api.config.ConventionSettings#globalExcludeColumns()}).
+ *
+ * <p>Column name matching during exclusion is case-insensitive.
+ *
+ * @param tableSet the expected dataset to verify against the database
+ * @param excludeColumns column names to exclude from verification (case-insensitive matching)
+ */
+public record ExpectedTableSet(TableSet tableSet, Set<String> excludeColumns) {
+
+  /**
+   * Creates an ExpectedTableSet with no column exclusions.
+   *
+   * @param tableSet the expected dataset
+   * @return an ExpectedTableSet with an empty exclusion set
+   */
+  public static ExpectedTableSet of(final TableSet tableSet) {
+    return new ExpectedTableSet(tableSet, Set.of());
+  }
+
+  /**
+   * Creates an ExpectedTableSet with specified column exclusions.
+   *
+   * @param tableSet the expected dataset
+   * @param excludeColumns column names to exclude from verification
+   * @return an ExpectedTableSet with the specified exclusions
+   */
+  public static ExpectedTableSet of(final TableSet tableSet, final Set<String> excludeColumns) {
+    return new ExpectedTableSet(tableSet, Set.copyOf(excludeColumns));
+  }
+
+  /**
+   * Checks if there are any columns to exclude.
+   *
+   * @return true if the exclusion set is non-empty
+   */
+  public boolean hasExclusions() {
+    return !excludeColumns.isEmpty();
+  }
+}

--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/spi/ExpectationProvider.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/spi/ExpectationProvider.java
@@ -1,6 +1,7 @@
 package io.github.seijikohara.dbtester.api.spi;
 
 import io.github.seijikohara.dbtester.api.dataset.TableSet;
+import java.util.Collection;
 import javax.sql.DataSource;
 
 /**
@@ -41,4 +42,36 @@ public interface ExpectationProvider {
    *     table structure mismatch)
    */
   void verifyExpectation(TableSet expectedTableSet, DataSource dataSource);
+
+  /**
+   * Verifies that the database state matches the expected dataset, excluding specified columns.
+   *
+   * <p>This method extends {@link #verifyExpectation(TableSet, DataSource)} with column exclusion
+   * support. Excluded columns are ignored during the comparison, which is useful for auto-generated
+   * columns (timestamps, version numbers, auto-increment IDs) that cannot be predicted in test
+   * data.
+   *
+   * <p>Column name matching is case-insensitive. For example, excluding {@code "CREATED_AT"} will
+   * ignore columns named {@code "created_at"}, {@code "CREATED_AT"}, or {@code "Created_At"}.
+   *
+   * <p>The default implementation delegates to {@link #verifyExpectation(TableSet, DataSource)}
+   * when no columns are excluded. Implementations should override this method to support column
+   * exclusion.
+   *
+   * @param expectedTableSet the expected dataset containing expected table data
+   * @param dataSource the database connection source for retrieving actual data
+   * @param excludeColumns column names to exclude from comparison (case-insensitive matching)
+   * @throws AssertionError if verification fails (row count mismatch, column value mismatch, or
+   *     table structure mismatch)
+   */
+  default void verifyExpectation(
+      final TableSet expectedTableSet,
+      final DataSource dataSource,
+      final Collection<String> excludeColumns) {
+    // Default implementation delegates to the basic verifyExpectation method.
+    // Implementations should override this method to support column exclusion.
+    // Note: excludeColumns is intentionally ignored in the default implementation
+    // for backward compatibility with existing providers.
+    verifyExpectation(expectedTableSet, dataSource);
+  }
 }

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/assertion/ExpectationVerifier.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/assertion/ExpectationVerifier.java
@@ -2,7 +2,12 @@ package io.github.seijikohara.dbtester.internal.assertion;
 
 import io.github.seijikohara.dbtester.api.dataset.TableSet;
 import io.github.seijikohara.dbtester.internal.jdbc.read.TableReader;
+import java.util.Collection;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.sql.DataSource;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,7 +73,36 @@ public final class ExpectationVerifier {
    * @throws AssertionError if verification fails
    */
   public void verifyExpectation(final TableSet expectedTableSet, final DataSource dataSource) {
+    verifyExpectation(expectedTableSet, dataSource, null);
+  }
+
+  /**
+   * Verifies database state matches expected dataset, excluding specified columns.
+   *
+   * <p>This method extends {@link #verifyExpectation(TableSet, DataSource)} with column exclusion
+   * support. Excluded columns are ignored during the comparison, which is useful for auto-generated
+   * columns (timestamps, version numbers, auto-increment IDs) that cannot be predicted in test
+   * data.
+   *
+   * <p>Column name matching is case-insensitive.
+   *
+   * @param expectedTableSet the expected dataset containing expected table data
+   * @param dataSource the database connection source for retrieving actual data
+   * @param excludeColumns column names to exclude from comparison, or null/empty for no exclusions
+   * @throws AssertionError if verification fails
+   */
+  public void verifyExpectation(
+      final TableSet expectedTableSet,
+      final DataSource dataSource,
+      final @Nullable Collection<String> excludeColumns) {
     logger.debug("Verifying expectation for {} tables", expectedTableSet.getTables().size());
+
+    // Normalize exclude columns to uppercase for case-insensitive matching
+    final var normalizedExcludeColumns = normalizeExcludeColumns(excludeColumns);
+
+    if (!normalizedExcludeColumns.isEmpty()) {
+      logger.debug("Excluding columns from verification: {}", normalizedExcludeColumns);
+    }
 
     expectedTableSet
         .getTables()
@@ -90,11 +124,31 @@ public final class ExpectationVerifier {
                   expectedTable.getRowCount(),
                   actualTable.getRowCount());
 
-              // Compare
-              comparator.assertEquals(expectedTable, actualTable, null);
+              // Compare with or without column exclusion
+              if (normalizedExcludeColumns.isEmpty()) {
+                comparator.assertEquals(expectedTable, actualTable, null);
+              } else {
+                comparator.assertEqualsIgnoreColumns(
+                    expectedTable, actualTable, normalizedExcludeColumns);
+              }
             });
 
     logger.debug(
         "Successfully verified expectation for {} tables", expectedTableSet.getTables().size());
+  }
+
+  /**
+   * Normalizes exclude column names for case-insensitive matching.
+   *
+   * @param excludeColumns the column names to normalize, may be null or empty
+   * @return set of uppercase column names, empty set if input is null or empty
+   */
+  private Set<String> normalizeExcludeColumns(final @Nullable Collection<String> excludeColumns) {
+    if (excludeColumns == null || excludeColumns.isEmpty()) {
+      return Set.of();
+    }
+    return excludeColumns.stream()
+        .map(column -> column.toUpperCase(Locale.ROOT))
+        .collect(Collectors.toUnmodifiableSet());
   }
 }

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/loader/AnnotationResolver.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/loader/AnnotationResolver.java
@@ -10,7 +10,9 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -114,6 +116,24 @@ public final class AnnotationResolver {
     return Optional.of(annotation.dataSourceName())
         .filter(Predicate.not(String::isEmpty))
         .map(DataSourceName::new);
+  }
+
+  /**
+   * Resolves exclude columns from a {@link DataSetSource} annotation.
+   *
+   * <p>This method extracts column names to exclude from expectation verification. Column names are
+   * normalized by trimming whitespace and filtering empty strings. The returned set uses
+   * case-insensitive matching by converting column names to uppercase.
+   *
+   * @param annotation the dataset source annotation
+   * @return set of column names to exclude (uppercase for case-insensitive matching)
+   */
+  Set<String> resolveExcludeColumns(final DataSetSource annotation) {
+    return Stream.of(annotation.excludeColumns())
+        .map(String::trim)
+        .filter(Predicate.not(String::isEmpty))
+        .map(String::toUpperCase)
+        .collect(Collectors.toUnmodifiableSet());
   }
 
   /**

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/spi/DefaultExpectationProvider.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/spi/DefaultExpectationProvider.java
@@ -3,6 +3,7 @@ package io.github.seijikohara.dbtester.internal.spi;
 import io.github.seijikohara.dbtester.api.dataset.TableSet;
 import io.github.seijikohara.dbtester.api.spi.ExpectationProvider;
 import io.github.seijikohara.dbtester.internal.assertion.ExpectationVerifier;
+import java.util.Collection;
 import javax.sql.DataSource;
 
 /**
@@ -35,5 +36,13 @@ public final class DefaultExpectationProvider implements ExpectationProvider {
   @Override
   public void verifyExpectation(final TableSet expectedTableSet, final DataSource dataSource) {
     expectationVerifier.verifyExpectation(expectedTableSet, dataSource);
+  }
+
+  @Override
+  public void verifyExpectation(
+      final TableSet expectedTableSet,
+      final DataSource dataSource,
+      final Collection<String> excludeColumns) {
+    expectationVerifier.verifyExpectation(expectedTableSet, dataSource, excludeColumns);
   }
 }

--- a/db-tester-core/src/test/java/io/github/seijikohara/dbtester/api/config/ConventionSettingsTest.java
+++ b/db-tester-core/src/test/java/io/github/seijikohara/dbtester/api/config/ConventionSettingsTest.java
@@ -3,7 +3,9 @@ package io.github.seijikohara.dbtester.api.config;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
@@ -58,7 +60,11 @@ class ConventionSettingsTest {
               assertEquals(
                   ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME,
                   settings.loadOrderFileName(),
-                  "loadOrderFileName should be default"));
+                  "loadOrderFileName should be default"),
+          () ->
+              assertTrue(
+                  settings.globalExcludeColumns().isEmpty(),
+                  "globalExcludeColumns should be empty by default"));
     }
 
     /** Verifies that standard returns consistent instances. */
@@ -98,7 +104,8 @@ class ConventionSettingsTest {
 
       // When
       final var settings =
-          new ConventionSettings(baseDir, suffix, marker, format, strategy, loadOrderFileName);
+          new ConventionSettings(
+              baseDir, suffix, marker, format, strategy, loadOrderFileName, Set.of());
 
       // Then
       assertAll(
@@ -131,7 +138,8 @@ class ConventionSettingsTest {
               ConventionSettings.DEFAULT_SCENARIO_MARKER,
               DataFormat.CSV,
               TableMergeStrategy.UNION_ALL,
-              ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME);
+              ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME,
+              Set.of());
 
       // Then
       assertNull(settings.baseDirectory(), "baseDirectory should be null");
@@ -144,7 +152,8 @@ class ConventionSettingsTest {
     void should_accept_empty_strings_for_suffix_and_marker() {
       // Given & When
       final var settings =
-          new ConventionSettings(null, "", "", DataFormat.CSV, TableMergeStrategy.UNION_ALL, "");
+          new ConventionSettings(
+              null, "", "", DataFormat.CSV, TableMergeStrategy.UNION_ALL, "", Set.of());
 
       // Then
       assertAll(
@@ -177,7 +186,8 @@ class ConventionSettingsTest {
               ConventionSettings.DEFAULT_SCENARIO_MARKER,
               DataFormat.CSV,
               TableMergeStrategy.UNION_ALL,
-              ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME);
+              ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME,
+              Set.of());
       final var settings2 =
           new ConventionSettings(
               "/base",
@@ -185,7 +195,8 @@ class ConventionSettingsTest {
               ConventionSettings.DEFAULT_SCENARIO_MARKER,
               DataFormat.CSV,
               TableMergeStrategy.UNION_ALL,
-              ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME);
+              ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME,
+              Set.of());
 
       // When & Then
       assertAll(
@@ -207,7 +218,8 @@ class ConventionSettingsTest {
               ConventionSettings.DEFAULT_SCENARIO_MARKER,
               DataFormat.CSV,
               TableMergeStrategy.UNION_ALL,
-              ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME);
+              ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME,
+              Set.of());
       final var settings2 =
           new ConventionSettings(
               null,
@@ -215,7 +227,8 @@ class ConventionSettingsTest {
               ConventionSettings.DEFAULT_SCENARIO_MARKER,
               DataFormat.CSV,
               TableMergeStrategy.UNION_ALL,
-              ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME);
+              ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME,
+              Set.of());
 
       // When & Then
       assertEquals(settings1, settings2, "should be equal with null baseDirectory");

--- a/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/loader/TestClassNameBasedDataSetLoaderTest.java
+++ b/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/loader/TestClassNameBasedDataSetLoaderTest.java
@@ -16,6 +16,7 @@ import io.github.seijikohara.dbtester.api.config.OperationDefaults;
 import io.github.seijikohara.dbtester.api.config.TableMergeStrategy;
 import io.github.seijikohara.dbtester.api.context.TestContext;
 import io.github.seijikohara.dbtester.api.operation.Operation;
+import java.util.Set;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -53,7 +54,8 @@ class TestClassNameBasedDataSetLoaderTest {
             "SCENARIO",
             DataFormat.CSV,
             TableMergeStrategy.UNION_ALL,
-            ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME);
+            ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME,
+            Set.of());
     final var operationDefaults = new OperationDefaults(Operation.CLEAN_INSERT, Operation.NONE);
     final var loader = new TestClassNameBasedDataSetLoader();
     configuration = new Configuration(conventions, operationDefaults, loader);

--- a/db-tester-junit-spring-boot-starter/src/main/java/io/github/seijikohara/dbtester/junit/spring/boot/autoconfigure/DbTesterJUnitAutoConfiguration.java
+++ b/db-tester-junit-spring-boot-starter/src/main/java/io/github/seijikohara/dbtester/junit/spring/boot/autoconfigure/DbTesterJUnitAutoConfiguration.java
@@ -77,7 +77,8 @@ public class DbTesterJUnitAutoConfiguration {
             conventionProps.getScenarioMarker(),
             conventionProps.getDataFormat(),
             conventionProps.getTableMergeStrategy(),
-            conventionProps.getLoadOrderFileName());
+            conventionProps.getLoadOrderFileName(),
+            conventionProps.getGlobalExcludeColumns());
 
     final OperationDefaults operations =
         new OperationDefaults(operationProps.getPreparation(), operationProps.getExpectation());

--- a/db-tester-junit-spring-boot-starter/src/main/java/io/github/seijikohara/dbtester/junit/spring/boot/autoconfigure/DbTesterProperties.java
+++ b/db-tester-junit-spring-boot-starter/src/main/java/io/github/seijikohara/dbtester/junit/spring/boot/autoconfigure/DbTesterProperties.java
@@ -4,6 +4,7 @@ import io.github.seijikohara.dbtester.api.config.ConventionSettings;
 import io.github.seijikohara.dbtester.api.config.DataFormat;
 import io.github.seijikohara.dbtester.api.config.TableMergeStrategy;
 import io.github.seijikohara.dbtester.api.operation.Operation;
+import java.util.Set;
 import org.jspecify.annotations.Nullable;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
@@ -137,6 +138,8 @@ public class DbTesterProperties {
    *       UNION_ALL)
    *   <li>{@code db-tester.convention.load-order-file-name} - File name for table loading order
    *       (default: {@value ConventionSettings#DEFAULT_LOAD_ORDER_FILE_NAME})
+   *   <li>{@code db-tester.convention.global-exclude-columns} - Column names to exclude globally
+   *       from expectation verifications (default: empty)
    * </ul>
    */
   public static class ConventionProperties {
@@ -175,6 +178,12 @@ public class DbTesterProperties {
      * ConventionSettings#DEFAULT_LOAD_ORDER_FILE_NAME}.
      */
     private String loadOrderFileName = ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME;
+
+    /**
+     * Column names to exclude globally from all expectation verifications. Useful for excluding
+     * auto-generated columns such as timestamps, version numbers, or auto-increment IDs.
+     */
+    private Set<String> globalExcludeColumns = Set.of();
 
     /**
      * Returns the base directory for dataset resolution.
@@ -282,6 +291,24 @@ public class DbTesterProperties {
      */
     public void setLoadOrderFileName(final String loadOrderFileName) {
       this.loadOrderFileName = loadOrderFileName;
+    }
+
+    /**
+     * Returns the global exclude columns.
+     *
+     * @return the column names to exclude globally
+     */
+    public Set<String> getGlobalExcludeColumns() {
+      return globalExcludeColumns;
+    }
+
+    /**
+     * Sets the global exclude columns.
+     *
+     * @param globalExcludeColumns the column names to exclude globally
+     */
+    public void setGlobalExcludeColumns(final Set<String> globalExcludeColumns) {
+      this.globalExcludeColumns = globalExcludeColumns;
     }
   }
 

--- a/db-tester-junit/src/test/java/io/github/seijikohara/dbtester/junit/jupiter/extension/DatabaseTestExtensionTest.java
+++ b/db-tester-junit/src/test/java/io/github/seijikohara/dbtester/junit/jupiter/extension/DatabaseTestExtensionTest.java
@@ -14,6 +14,7 @@ import io.github.seijikohara.dbtester.api.config.DataFormat;
 import io.github.seijikohara.dbtester.api.config.DataSourceRegistry;
 import io.github.seijikohara.dbtester.api.config.TableMergeStrategy;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -147,7 +148,8 @@ class DatabaseTestExtensionTest {
                   "[Test]",
                   DataFormat.CSV,
                   TableMergeStrategy.UNION_ALL,
-                  ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME));
+                  ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME,
+                  Set.of()));
       final var rootContext = mock(ExtensionContext.class);
 
       when(mockContext.getTestClass()).thenReturn(Optional.of(TestClass.class));

--- a/db-tester-junit/src/test/java/io/github/seijikohara/dbtester/junit/jupiter/lifecycle/ExpectationVerifierTest.java
+++ b/db-tester-junit/src/test/java/io/github/seijikohara/dbtester/junit/jupiter/lifecycle/ExpectationVerifierTest.java
@@ -77,7 +77,8 @@ class ExpectationVerifierTest {
       final var mockRegistry = mock(DataSourceRegistry.class);
 
       when(mockConfiguration.loader()).thenReturn(mockLoader);
-      when(mockLoader.loadExpectationDataSets(org.mockito.ArgumentMatchers.any(TestContext.class)))
+      when(mockLoader.loadExpectationDataSetsWithExclusions(
+              org.mockito.ArgumentMatchers.any(TestContext.class)))
           .thenReturn(Collections.emptyList());
 
       final var testClass = TestClass.class;

--- a/db-tester-kotest-spring-boot-starter/src/main/kotlin/io/github/seijikohara/dbtester/kotest/spring/boot/autoconfigure/DbTesterKotestAutoConfiguration.kt
+++ b/db-tester-kotest-spring-boot-starter/src/main/kotlin/io/github/seijikohara/dbtester/kotest/spring/boot/autoconfigure/DbTesterKotestAutoConfiguration.kt
@@ -62,6 +62,7 @@ class DbTesterKotestAutoConfiguration {
                     conventionProps.dataFormat,
                     conventionProps.tableMergeStrategy,
                     conventionProps.loadOrderFileName,
+                    conventionProps.globalExcludeColumns,
                 )
             }.let { conventions ->
                 OperationDefaults(

--- a/db-tester-kotest-spring-boot-starter/src/main/kotlin/io/github/seijikohara/dbtester/kotest/spring/boot/autoconfigure/DbTesterProperties.kt
+++ b/db-tester-kotest-spring-boot-starter/src/main/kotlin/io/github/seijikohara/dbtester/kotest/spring/boot/autoconfigure/DbTesterProperties.kt
@@ -62,6 +62,9 @@ class DbTesterProperties {
 
         /** File name for specifying table loading order in dataset directories. */
         var loadOrderFileName: String = ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME
+
+        /** Column names to exclude globally from all expectation verifications. */
+        var globalExcludeColumns: Set<String> = emptySet()
     }
 
     /**

--- a/db-tester-kotest/src/test/kotlin/io/github/seijikohara/dbtester/kotest/lifecycle/KotestExpectationVerifierSpec.kt
+++ b/db-tester-kotest/src/test/kotlin/io/github/seijikohara/dbtester/kotest/lifecycle/KotestExpectationVerifierSpec.kt
@@ -64,6 +64,7 @@ class KotestExpectationVerifierSpec : AnnotationSpec() {
                     .also { loader ->
                         every { loader.loadPreparationDataSets(any()) } returns emptyList()
                         every { loader.loadExpectationDataSets(any()) } returns emptyList()
+                        every { loader.loadExpectationDataSetsWithExclusions(any()) } returns emptyList()
                     }.let { loader ->
                         Configuration(
                             ConventionSettings.standard(),

--- a/db-tester-kotest/src/test/kotlin/io/github/seijikohara/dbtester/kotest/lifecycle/KotestPreparationExecutorSpec.kt
+++ b/db-tester-kotest/src/test/kotlin/io/github/seijikohara/dbtester/kotest/lifecycle/KotestPreparationExecutorSpec.kt
@@ -65,6 +65,7 @@ class KotestPreparationExecutorSpec : AnnotationSpec() {
                     .also { loader ->
                         every { loader.loadPreparationDataSets(any()) } returns emptyList()
                         every { loader.loadExpectationDataSets(any()) } returns emptyList()
+                        every { loader.loadExpectationDataSetsWithExclusions(any()) } returns emptyList()
                     }.let { loader ->
                         Configuration(
                             ConventionSettings.standard(),

--- a/db-tester-spock-spring-boot-starter/src/main/groovy/io/github/seijikohara/dbtester/spock/spring/boot/autoconfigure/DbTesterProperties.groovy
+++ b/db-tester-spock-spring-boot-starter/src/main/groovy/io/github/seijikohara/dbtester/spock/spring/boot/autoconfigure/DbTesterProperties.groovy
@@ -85,6 +85,9 @@ class DbTesterProperties {
 
 		/** File name for specifying table loading order in dataset directories. Defaults to "load-order.txt". */
 		String loadOrderFileName = ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME
+
+		/** Column names to exclude globally from all expectation verifications. Defaults to empty set. */
+		Set<String> globalExcludeColumns = Set.of()
 	}
 
 	/**

--- a/db-tester-spock-spring-boot-starter/src/main/groovy/io/github/seijikohara/dbtester/spock/spring/boot/autoconfigure/DbTesterSpockAutoConfiguration.groovy
+++ b/db-tester-spock-spring-boot-starter/src/main/groovy/io/github/seijikohara/dbtester/spock/spring/boot/autoconfigure/DbTesterSpockAutoConfiguration.groovy
@@ -60,7 +60,8 @@ class DbTesterSpockAutoConfiguration {
 				conventionProps.scenarioMarker,
 				conventionProps.dataFormat,
 				conventionProps.tableMergeStrategy,
-				conventionProps.loadOrderFileName
+				conventionProps.loadOrderFileName,
+				conventionProps.globalExcludeColumns
 				)
 
 		def operations = new OperationDefaults(

--- a/db-tester-spock/src/test/groovy/io/github/seijikohara/dbtester/spock/lifecycle/SpockExpectationVerifierSpec.groovy
+++ b/db-tester-spock/src/test/groovy/io/github/seijikohara/dbtester/spock/lifecycle/SpockExpectationVerifierSpec.groovy
@@ -106,6 +106,11 @@ class SpockExpectationVerifierSpec extends Specification {
 					List loadExpectationDataSets(TestContext ctx) {
 						return []
 					}
+
+					@Override
+					List loadExpectationDataSetsWithExclusions(TestContext ctx) {
+						return []
+					}
 				}
 		def configuration = new Configuration(
 				ConventionSettings.standard(),

--- a/docs/specs/03-public-api.md
+++ b/docs/specs/03-public-api.md
@@ -92,6 +92,7 @@ Configures individual dataset parameters within `@DataSet` or `@ExpectedDataSet`
 | `resourceLocation` | `String` | `""` | Dataset directory path; empty uses convention-based discovery |
 | `dataSourceName` | `String` | `""` | Named DataSource identifier; empty uses default |
 | `scenarioNames` | `String[]` | `{}` | Scenario filters; empty uses test method name |
+| `excludeColumns` | `String[]` | `{}` | Column names to exclude from verification (case-insensitive); only effective in `@ExpectedDataSet` |
 
 **Resource Location Formats**:
 
@@ -113,7 +114,18 @@ void testMultipleDataSources() { }
 
 @DataSet(sources = @DataSetSource(scenarioNames = {"scenario1", "scenario2"}))
 void testMultipleScenarios() { }
+
+@ExpectedDataSet(sources = @DataSetSource(
+    excludeColumns = {"CREATED_AT", "UPDATED_AT", "VERSION"}
+))
+void testWithExcludedColumns() { }
 ```
+
+**Column Exclusion Behavior**:
+
+- Column names are normalized to uppercase for comparison
+- Per-dataset exclusions are combined with global exclusions from `ConventionSettings`
+- Exclusions apply only to `@ExpectedDataSet` verification, not `@DataSet` preparation
 
 ## TableSet Interfaces
 

--- a/docs/specs/04-configuration.md
+++ b/docs/specs/04-configuration.md
@@ -66,6 +66,7 @@ Defines naming conventions for dataset discovery and scenario filtering.
 | `dataFormat` | `DataFormat` | `CSV` | File format for dataset files |
 | `tableMergeStrategy` | `TableMergeStrategy` | `UNION_ALL` | Strategy for merging duplicate tables |
 | `loadOrderFileName` | `String` | `"load-order.txt"` | File name for table loading order specification |
+| `globalExcludeColumns` | `Set<String>` | `Set.of()` | Column names to exclude from all verifications (case-insensitive) |
 
 ### Factory Methods
 
@@ -75,6 +76,7 @@ Defines naming conventions for dataset discovery and scenario filtering.
 | `withDataFormat(DataFormat)` | Creates copy with specified format |
 | `withTableMergeStrategy(TableMergeStrategy)` | Creates copy with specified merge strategy |
 | `withLoadOrderFileName(String)` | Creates copy with specified load order file name |
+| `withGlobalExcludeColumns(Set<String>)` | Creates copy with specified global exclude columns |
 
 ### Directory Resolution
 

--- a/docs/specs/ja/03-public-api.md
+++ b/docs/specs/ja/03-public-api.md
@@ -95,6 +95,7 @@ void testWithAlphabeticalOrdering() { }
 | `resourceLocation` | `String` | `""` | データセットディレクトリパス。空の場合は規約ベースの検出を使用 |
 | `dataSourceName` | `String` | `""` | 名前付きDataSource識別子。空の場合はデフォルトを使用 |
 | `scenarioNames` | `String[]` | `{}` | シナリオフィルタ。空の場合はテストメソッド名を使用 |
+| `excludeColumns` | `String[]` | `{}` | 検証から除外するカラム名（大文字小文字を区別しない）。`@ExpectedDataSet`でのみ有効 |
 
 **リソースロケーション形式**:
 
@@ -116,7 +117,18 @@ void testMultipleDataSources() { }
 
 @DataSet(sources = @DataSetSource(scenarioNames = {"scenario1", "scenario2"}))
 void testMultipleScenarios() { }
+
+@ExpectedDataSet(sources = @DataSetSource(
+    excludeColumns = {"CREATED_AT", "UPDATED_AT", "VERSION"}
+))
+void testWithExcludedColumns() { }
 ```
+
+**カラム除外の動作**:
+
+- カラム名は比較のために大文字に正規化されます
+- データセットごとの除外は`ConventionSettings`のグローバル除外と結合されます
+- 除外は`@ExpectedDataSet`の検証にのみ適用され、`@DataSet`の準備には適用されません
 
 
 ## TableSetインターフェース

--- a/docs/specs/ja/04-configuration.md
+++ b/docs/specs/ja/04-configuration.md
@@ -68,6 +68,7 @@ static void setup(ExtensionContext context) {
 | `dataFormat` | `DataFormat` | `CSV` | データセットファイルのファイル形式 |
 | `tableMergeStrategy` | `TableMergeStrategy` | `UNION_ALL` | 重複テーブルのマージ戦略 |
 | `loadOrderFileName` | `String` | `"load-order.txt"` | テーブル読み込み順序指定用ファイル名 |
+| `globalExcludeColumns` | `Set<String>` | `Set.of()` | すべての検証から除外するカラム名（大文字小文字を区別しない） |
 
 ### ファクトリメソッド
 
@@ -77,6 +78,7 @@ static void setup(ExtensionContext context) {
 | `withDataFormat(DataFormat)` | 指定した形式でコピーを作成 |
 | `withTableMergeStrategy(TableMergeStrategy)` | 指定したマージ戦略でコピーを作成 |
 | `withLoadOrderFileName(String)` | 指定した読み込み順序ファイル名でコピーを作成 |
+| `withGlobalExcludeColumns(Set<String>)` | 指定したグローバル除外カラムでコピーを作成 |
 
 ### ディレクトリ解決
 

--- a/examples/db-tester-example-junit/src/test/java/example/feature/ConfigurationCustomizationTest.java
+++ b/examples/db-tester-example-junit/src/test/java/example/feature/ConfigurationCustomizationTest.java
@@ -13,6 +13,7 @@ import io.github.seijikohara.dbtester.junit.jupiter.extension.DatabaseTestExtens
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 import javax.sql.DataSource;
 import org.h2.jdbcx.JdbcDataSource;
@@ -78,7 +79,8 @@ public final class ConfigurationCustomizationTest {
                 "[TestCase]", // custom scenario marker
                 DataFormat.CSV, // use CSV format (default)
                 TableMergeStrategy.UNION_ALL, // use UNION_ALL merge strategy (default)
-                ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME));
+                ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME,
+                Set.of()));
     DatabaseTestExtension.setConfiguration(context, customConfig);
 
     final var testRegistry = DatabaseTestExtension.getRegistry(context);

--- a/examples/db-tester-example-junit/src/test/java/example/feature/DataFormatTest.java
+++ b/examples/db-tester-example-junit/src/test/java/example/feature/DataFormatTest.java
@@ -14,6 +14,7 @@ import io.github.seijikohara.dbtester.junit.jupiter.extension.DatabaseTestExtens
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 import javax.sql.DataSource;
 import org.h2.jdbcx.JdbcDataSource;
@@ -133,7 +134,8 @@ public final class DataFormatTest {
                   "[Scenario]", // default scenario marker
                   DataFormat.CSV, // CSV format
                   TableMergeStrategy.UNION_ALL,
-                  ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME));
+                  ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME,
+                  Set.of()));
       DatabaseTestExtension.setConfiguration(context, csvConfig);
 
       final var registry = DatabaseTestExtension.getRegistry(context);
@@ -232,7 +234,8 @@ public final class DataFormatTest {
                   "[Scenario]", // default scenario marker
                   DataFormat.TSV, // TSV format
                   TableMergeStrategy.UNION_ALL,
-                  ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME));
+                  ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME,
+                  Set.of()));
       DatabaseTestExtension.setConfiguration(context, tsvConfig);
 
       final var registry = DatabaseTestExtension.getRegistry(context);

--- a/examples/db-tester-example-junit/src/test/java/example/feature/TableMergeStrategyTest.java
+++ b/examples/db-tester-example-junit/src/test/java/example/feature/TableMergeStrategyTest.java
@@ -14,6 +14,7 @@ import io.github.seijikohara.dbtester.junit.jupiter.extension.DatabaseTestExtens
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 import javax.sql.DataSource;
 import org.h2.jdbcx.JdbcDataSource;
@@ -134,7 +135,8 @@ public final class TableMergeStrategyTest {
                   "[Scenario]",
                   DataFormat.CSV,
                   TableMergeStrategy.FIRST, // FIRST strategy
-                  ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME));
+                  ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME,
+                  Set.of()));
       DatabaseTestExtension.setConfiguration(context, config);
 
       final var registry = DatabaseTestExtension.getRegistry(context);
@@ -220,7 +222,8 @@ public final class TableMergeStrategyTest {
                   "[Scenario]",
                   DataFormat.CSV,
                   TableMergeStrategy.LAST, // LAST strategy
-                  ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME));
+                  ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME,
+                  Set.of()));
       DatabaseTestExtension.setConfiguration(context, config);
 
       final var registry = DatabaseTestExtension.getRegistry(context);
@@ -306,7 +309,8 @@ public final class TableMergeStrategyTest {
                   "[Scenario]",
                   DataFormat.CSV,
                   TableMergeStrategy.UNION, // UNION strategy
-                  ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME));
+                  ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME,
+                  Set.of()));
       DatabaseTestExtension.setConfiguration(context, config);
 
       final var registry = DatabaseTestExtension.getRegistry(context);
@@ -392,7 +396,8 @@ public final class TableMergeStrategyTest {
                   "[Scenario]",
                   DataFormat.CSV,
                   TableMergeStrategy.UNION_ALL, // UNION_ALL strategy (default)
-                  ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME));
+                  ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME,
+                  Set.of()));
       DatabaseTestExtension.setConfiguration(context, config);
 
       final var registry = DatabaseTestExtension.getRegistry(context);

--- a/examples/db-tester-example-kotest/src/test/kotlin/example/feature/ConfigurationCustomizationSpec.kt
+++ b/examples/db-tester-example-kotest/src/test/kotlin/example/feature/ConfigurationCustomizationSpec.kt
@@ -49,6 +49,7 @@ class ConfigurationCustomizationSpec : AnnotationSpec() {
                     DataFormat.CSV, // use CSV format (default)
                     TableMergeStrategy.UNION_ALL, // use UNION_ALL merge strategy (default)
                     ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME,
+                    emptySet(),
                 ),
             )
 

--- a/examples/db-tester-example-kotest/src/test/kotlin/example/feature/DataFormatSpec.kt
+++ b/examples/db-tester-example-kotest/src/test/kotlin/example/feature/DataFormatSpec.kt
@@ -51,6 +51,7 @@ class CsvFormatSpec : AnnotationSpec() {
                     DataFormat.CSV,
                     TableMergeStrategy.UNION_ALL,
                     ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME,
+                    emptySet(),
                 ),
             )
 
@@ -181,6 +182,7 @@ class TsvFormatSpec : AnnotationSpec() {
                     DataFormat.TSV,
                     TableMergeStrategy.UNION_ALL,
                     ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME,
+                    emptySet(),
                 ),
             )
 

--- a/examples/db-tester-example-kotest/src/test/kotlin/example/feature/TableMergeStrategySpec.kt
+++ b/examples/db-tester-example-kotest/src/test/kotlin/example/feature/TableMergeStrategySpec.kt
@@ -49,6 +49,7 @@ class FirstStrategySpec : AnnotationSpec() {
                     DataFormat.CSV,
                     TableMergeStrategy.FIRST,
                     ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME,
+                    emptySet(),
                 ),
             )
 
@@ -165,6 +166,7 @@ class LastStrategySpec : AnnotationSpec() {
                     DataFormat.CSV,
                     TableMergeStrategy.LAST,
                     ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME,
+                    emptySet(),
                 ),
             )
 
@@ -277,6 +279,7 @@ class UnionStrategySpec : AnnotationSpec() {
                     DataFormat.CSV,
                     TableMergeStrategy.UNION,
                     ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME,
+                    emptySet(),
                 ),
             )
 
@@ -393,6 +396,7 @@ class UnionAllStrategySpec : AnnotationSpec() {
                     DataFormat.CSV,
                     TableMergeStrategy.UNION_ALL,
                     ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME,
+                    emptySet(),
                 ),
             )
 

--- a/examples/db-tester-example-spock/src/test/groovy/example/feature/ConfigurationCustomizationSpec.groovy
+++ b/examples/db-tester-example-spock/src/test/groovy/example/feature/ConfigurationCustomizationSpec.groovy
@@ -62,7 +62,8 @@ class ConfigurationCustomizationSpec extends Specification {
 	'[TestCase]',               // custom scenario marker
 	DataFormat.CSV,             // use CSV format (default)
 	TableMergeStrategy.UNION_ALL, // use UNION_ALL merge strategy (default)
-	ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME
+	ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME,
+	Set.of()
 	)
 	)
 

--- a/examples/db-tester-example-spock/src/test/groovy/example/feature/DataFormatSpec.groovy
+++ b/examples/db-tester-example-spock/src/test/groovy/example/feature/DataFormatSpec.groovy
@@ -84,7 +84,8 @@ class DataFormatSpec extends Specification {
 					'[Scenario]', // default scenario marker
 					DataFormat.CSV, // CSV format
 					TableMergeStrategy.UNION_ALL,
-					ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME
+					ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME,
+					Set.of()
 					)
 					)
 		}
@@ -204,7 +205,8 @@ class DataFormatSpec extends Specification {
 					'[Scenario]', // default scenario marker
 					DataFormat.TSV, // TSV format
 					TableMergeStrategy.UNION_ALL,
-					ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME
+					ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME,
+					Set.of()
 					)
 					)
 		}

--- a/examples/db-tester-example-spock/src/test/groovy/example/feature/TableMergeStrategySpec.groovy
+++ b/examples/db-tester-example-spock/src/test/groovy/example/feature/TableMergeStrategySpec.groovy
@@ -81,7 +81,7 @@ class TableMergeStrategySpec extends Specification {
 					'[Scenario]',
 					DataFormat.CSV,
 					TableMergeStrategy.FIRST,
-					ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME
+					ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME, Set.of()
 					)
 					)
 		}
@@ -180,7 +180,7 @@ class TableMergeStrategySpec extends Specification {
 					'[Scenario]',
 					DataFormat.CSV,
 					TableMergeStrategy.LAST,
-					ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME
+					ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME, Set.of()
 					)
 					)
 		}
@@ -279,7 +279,7 @@ class TableMergeStrategySpec extends Specification {
 					'[Scenario]',
 					DataFormat.CSV,
 					TableMergeStrategy.UNION,
-					ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME
+					ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME, Set.of()
 					)
 					)
 		}
@@ -378,7 +378,7 @@ class TableMergeStrategySpec extends Specification {
 					'[Scenario]',
 					DataFormat.CSV,
 					TableMergeStrategy.UNION_ALL,
-					ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME
+					ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME, Set.of()
 					)
 					)
 		}


### PR DESCRIPTION
## Summary

- Add `@DataSetSource.excludeColumns` attribute for per-dataset column exclusion
- Add `ConventionSettings.globalExcludeColumns` for global column exclusion
- Add Spring Boot auto-configuration property `db-tester.convention.global-exclude-columns`

## Motivation

When verifying database state with `@ExpectedDataSet`, auto-generated columns like timestamps (`CREATED_AT`, `UPDATED_AT`) and version columns often need to be excluded from comparison. This feature provides annotation-based column exclusion without requiring programmatic assertions.

## Changes

### API Module (`db-tester-api`)
- `DataSetSource.java` - Added `excludeColumns()` attribute
- `ConventionSettings.java` - Added `globalExcludeColumns` field and `withGlobalExcludeColumns()` method
- `DataSetLoader.java` - Added `loadExpectationDataSetsWithExclusions()` method
- `ExpectationProvider.java` - Added overloaded `verifyExpectation()` with `excludeColumns` parameter
- **New**: `ExpectedTableSet.java` - Record combining `TableSet` with exclusion metadata

### Core Module (`db-tester-core`)
- `AnnotationResolver.java` - Added `resolveExcludeColumns()` method
- `TestClassNameBasedDataSetLoader.java` - Implemented exclusion loading
- `ExpectationVerifier.java` - Added exclusion support to verification
- `DefaultExpectationProvider.java` - Implemented the new SPI method

### Test Framework Modules
- Updated JUnit, Spock, and Kotest expectation verifiers to use exclusion feature

### Spring Boot Starters
- Added `globalExcludeColumns` property support to all three starters

### Documentation
- Updated README.md with column exclusion examples
- Updated specification docs (English and Japanese)

## Usage

**Per-dataset exclusion**:
```java
@ExpectedDataSet(dataSets = @DataSetSource(
    excludeColumns = {"CREATED_AT", "UPDATED_AT", "VERSION"}
))
void testUserCreation() { }
```

**Global exclusion**:
```java
ConventionSettings.standard()
    .withGlobalExcludeColumns(Set.of("CREATED_AT", "UPDATED_AT"));
```

**Spring Boot**:
```properties
db-tester.convention.global-exclude-columns=CREATED_AT,UPDATED_AT,VERSION
```

## Notes

- Column names are case-insensitive (normalized to uppercase)
- Per-dataset exclusions are combined with global exclusions
- Exclusions apply only to `@ExpectedDataSet` verification

Closes #40