### PR TITLE
refactor(core): consolidate duplicated BASE64_PREFIX constant

### DIFF
--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/domain/InternalConstants.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/domain/InternalConstants.java
@@ -1,0 +1,24 @@
+package io.github.seijikohara.dbtester.internal.domain;
+
+/**
+ * Internal constants used across the framework.
+ *
+ * <p>This class provides shared constant values that are used by multiple internal classes. It is
+ * not part of the public API and should not be used by external code.
+ *
+ * <p>This class cannot be instantiated.
+ */
+public final class InternalConstants {
+
+  /** Prefix for Base64-encoded binary data in CSV/TSV files. */
+  public static final String BASE64_PREFIX = "[BASE64]";
+
+  /**
+   * Private constructor to prevent instantiation.
+   *
+   * @throws UnsupportedOperationException always
+   */
+  private InternalConstants() {
+    throw new UnsupportedOperationException("Utility class cannot be instantiated");
+  }
+}

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/jdbc/read/TypeConverter.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/jdbc/read/TypeConverter.java
@@ -1,5 +1,7 @@
 package io.github.seijikohara.dbtester.internal.jdbc.read;
 
+import static io.github.seijikohara.dbtester.internal.domain.InternalConstants.BASE64_PREFIX;
+
 import io.github.seijikohara.dbtester.api.exception.DatabaseTesterException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -23,9 +25,6 @@ import org.jspecify.annotations.Nullable;
  * <p>This class is stateless and thread-safe.
  */
 public final class TypeConverter {
-
-  /** Prefix for Base64-encoded blob data. */
-  private static final String BASE64_PREFIX = "[BASE64]";
 
   /** Creates a new type converter. */
   public TypeConverter() {

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/jdbc/write/ParameterBinder.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/jdbc/write/ParameterBinder.java
@@ -1,5 +1,7 @@
 package io.github.seijikohara.dbtester.internal.jdbc.write;
 
+import static io.github.seijikohara.dbtester.internal.domain.InternalConstants.BASE64_PREFIX;
+
 import io.github.seijikohara.dbtester.api.dataset.Row;
 import io.github.seijikohara.dbtester.api.domain.CellValue;
 import io.github.seijikohara.dbtester.api.domain.ColumnName;
@@ -41,9 +43,6 @@ import java.util.stream.IntStream;
  * <p>This class is stateless and thread-safe.
  */
 public final class ParameterBinder {
-
-  /** Prefix for Base64-encoded blob data in CSV files. */
-  private static final String BASE64_PREFIX = "[BASE64]";
 
   /** Creates a new parameter binder. */
   public ParameterBinder() {}


### PR DESCRIPTION
## Summary

Consolidate the duplicated `BASE64_PREFIX` constant into a shared `InternalConstants` class.

Closes #35

## Changes

- Add `InternalConstants` class in `internal.domain` package with shared constant
- Update `ParameterBinder` to use the shared constant via static import
- Update `TypeConverter` to use the shared constant via static import

## Before

```java
// ParameterBinder.java
private static final String BASE64_PREFIX = "[BASE64]";

// TypeConverter.java
private static final String BASE64_PREFIX = "[BASE64]";
```

## After

```java
// InternalConstants.java
public static final String BASE64_PREFIX = "[BASE64]";

// ParameterBinder.java & TypeConverter.java
import static io.github.seijikohara.dbtester.internal.domain.InternalConstants.BASE64_PREFIX;
```

## Benefits

- DRY principle: Single source of truth for the constant
- Reduced risk: Changes to the prefix format only need to be made in one place
- Maintainability: Easier to locate and modify the constant value

## Test Plan

- [x] All existing tests pass
- [x] Build successful