### PR TITLE
fix(ci): add codecov.yml for path mapping in multi-module project

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,28 @@
+# Codecov configuration
+# https://docs.codecov.com/docs/codecov-yaml
+
+coverage:
+  status:
+    project:
+      default:
+        target: 70%
+    patch:
+      default:
+        target: 70%
+
+# Path fixes for multi-module Gradle project
+# JaCoCo reports contain paths like: io/github/seijikohara/dbtester/...
+# Actual source files are in: <module>/src/main/java/io/github/seijikohara/dbtester/...
+fixes:
+  - "io/github/seijikohara/dbtester/api/::db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/"
+  - "io/github/seijikohara/dbtester/internal/::db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/"
+  - "io/github/seijikohara/dbtester/junit/::db-tester-junit/src/main/java/io/github/seijikohara/dbtester/junit/"
+  - "io/github/seijikohara/dbtester/spock/::db-tester-spock/src/main/groovy/io/github/seijikohara/dbtester/spock/"
+  - "io/github/seijikohara/dbtester/kotest/::db-tester-kotest/src/main/kotlin/io/github/seijikohara/dbtester/kotest/"
+  - "io/github/seijikohara/dbtester/spring/autoconfigure/junit/::db-tester-junit-spring-boot-starter/src/main/java/io/github/seijikohara/dbtester/spring/autoconfigure/junit/"
+  - "io/github/seijikohara/dbtester/spring/autoconfigure/spock/::db-tester-spock-spring-boot-starter/src/main/groovy/io/github/seijikohara/dbtester/spring/autoconfigure/spock/"
+  - "io/github/seijikohara/dbtester/spring/autoconfigure/kotest/::db-tester-kotest-spring-boot-starter/src/main/kotlin/io/github/seijikohara/dbtester/spring/autoconfigure/kotest/"
+
+# Ignore example modules from coverage
+ignore:
+  - "examples/**/*"


### PR DESCRIPTION
## Summary
- Add `codecov.yml` configuration file to fix path mapping for multi-module Gradle project
- JaCoCo reports contain paths like `io/github/seijikohara/dbtester/internal/...` but actual source files are in `db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/...`
- Configure path fixes for all modules (api, core, junit, spock, kotest, spring boot starters)
- Set 70% coverage threshold for project and patch
- Exclude example modules from coverage

Follow-up fix for #72 (coverage badge was showing 0.00% due to path mismatch)

Related: #82

## Test plan
- [ ] Verify CI passes
- [ ] Verify Codecov receives the configuration
- [ ] Verify coverage percentage displays correctly (not 0.00%)
- [ ] Verify Code tree/File list shows source files