### PR TITLE
docs(core): fix SqlIdentifier Javadoc to match implementation

### DIFF
--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/jdbc/SqlIdentifier.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/jdbc/SqlIdentifier.java
@@ -3,19 +3,15 @@ package io.github.seijikohara.dbtester.internal.jdbc;
 import java.util.regex.Pattern;
 
 /**
- * Validates and quotes SQL identifiers to prevent SQL injection.
+ * Validates SQL identifiers to prevent SQL injection.
  *
  * <p>This utility class provides methods to validate table names and column names before
  * interpolating them into SQL statements. While the framework primarily receives identifiers from
  * trusted test code, validation prevents accidental SQL injection from malformed inputs.
  *
- * <p>The class supports two approaches:
- *
- * <ul>
- *   <li><strong>Validation</strong>: Ensures identifiers match a safe pattern (alphanumeric and
- *       underscore only)
- *   <li><strong>Quoting</strong>: Escapes identifiers using standard SQL double-quote syntax
- * </ul>
+ * <p>Identifiers must match a safe pattern: start with a letter or underscore, contain only
+ * letters, digits, and underscores, and optionally include a schema prefix (e.g., {@code
+ * schema.table}).
  *
  * <p>This class is stateless and thread-safe.
  */


### PR DESCRIPTION
## Summary
- Remove misleading "and quotes" and "Quoting" references from `SqlIdentifier` class Javadoc
- The class only provides validation via `validate()`; no quoting/escaping functionality exists
- This documentation-code mismatch was identified during Issue triage

## Context
The `SqlIdentifier` Javadoc stated "Validates **and quotes** SQL identifiers" and listed both "Validation" and "Quoting" as supported approaches. However, the implementation only provides `validate()` — no `quote()` or escape method exists.

This fix aligns the documentation with the actual implementation.

## Test plan
- [x] `./gradlew build` passes (all tests, spotless, DocLint)
- [x] No functional changes — documentation only

Closes #79