### PR TITLE
docs: fix documentation references and release workflow consistency

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -38,9 +38,9 @@ See @README.md for project details.
 
 ## Documentation
 
-- Technical Specifications: @docs/specs/01-overview.md
-- Architecture: @docs/specs/02-architecture.md
-- Public API: @docs/specs/03-public-api.md
+- Technical Specifications: @docs/specs/overview.md
+- Architecture: @docs/specs/architecture.md
+- Public API: @docs/specs/public-api.md
 - Code Style Guides: [.claude/rules/](.claude/rules/)
 
 ## Git Workflow

--- a/.claude/rules/release/publishing.md
+++ b/.claude/rules/release/publishing.md
@@ -8,7 +8,9 @@ The following modules are published to Maven Central:
 
 | Module | Artifact ID | Description |
 |--------|-------------|-------------|
-| `db-tester-core` | `db-tester-core` | Public API and pure JDBC implementation |
+| `db-tester-api` | `db-tester-api` | Public API (annotations, configuration, SPI) |
+| `db-tester-core` | `db-tester-core` | Internal implementation (SPI providers, JDBC operations) |
+| `db-tester-spring-support` | `db-tester-spring-support` | Common Spring utilities |
 | `db-tester-junit` | `db-tester-junit` | JUnit extension |
 | `db-tester-spock` | `db-tester-spock` | Spock extension |
 | `db-tester-kotest` | `db-tester-kotest` | Kotest AnnotationSpec extension |
@@ -115,7 +117,6 @@ Alternatively, set as environment variables (for CI):
 ```bash
 export ORG_GRADLE_PROJECT_mavenCentralUsername="your-username"
 export ORG_GRADLE_PROJECT_mavenCentralPassword="your-token"
-export ORG_GRADLE_PROJECT_signingInMemoryKeyId="ABCD1234"
 export ORG_GRADLE_PROJECT_signingInMemoryKeyPassword="your-passphrase"
 export ORG_GRADLE_PROJECT_signingInMemoryKey="$(gpg --armor --export-secret-keys ABCD1234)"
 ```
@@ -151,7 +152,6 @@ The recommended way to release is using the GitHub Actions workflow, which provi
    |--------|-------------|
    | `GPG_PRIVATE_KEY` | GPG private key (ASCII armor format: `gpg --armor --export-secret-keys KEY_ID`) |
    | `GPG_PASSPHRASE` | GPG key passphrase |
-   | `GPG_KEY_ID` | GPG key ID (short format, e.g., `ABCD1234`) |
    | `MAVEN_CENTRAL_USERNAME` | Maven Central username from step 2 |
    | `MAVEN_CENTRAL_TOKEN` | Maven Central token from step 2 |
 

--- a/.claude/rules/release/workflow.md
+++ b/.claude/rules/release/workflow.md
@@ -42,7 +42,7 @@ The GitHub Actions workflow provides:
 
 See [publishing.md](publishing.md#option-1-github-actions-release-recommended) for one-time setup:
 - GitHub Environment (`maven-central`) with required reviewers
-- GitHub Secrets (`GPG_PRIVATE_KEY`, `GPG_PASSPHRASE`, `GPG_KEY_ID`, `MAVEN_CENTRAL_USERNAME`, `MAVEN_CENTRAL_TOKEN`)
+- GitHub Secrets (`GPG_PRIVATE_KEY`, `GPG_PASSPHRASE`, `MAVEN_CENTRAL_USERNAME`, `MAVEN_CENTRAL_TOKEN`)
 
 ### Release Process
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,6 @@ jobs:
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
         run: |
           # Check if secrets are set (without importing the key)
           if [[ -z "$GPG_PRIVATE_KEY" ]]; then
@@ -103,10 +102,6 @@ jobs:
           fi
           if [[ -z "$GPG_PASSPHRASE" ]]; then
             echo "::error::GPG_PASSPHRASE secret is not set"
-            exit 1
-          fi
-          if [[ -z "$GPG_KEY_ID" ]]; then
-            echo "::error::GPG_KEY_ID secret is not set"
             exit 1
           fi
           echo "✅ All GPG secrets are configured"

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ db-tester.convention.expectation-suffix=/expected
 db-tester.operation.preparation=CLEAN_INSERT
 ```
 
-See the [Configuration](https://seijikohara.github.io/db-tester/specs/04-configuration) documentation for all options.
+See the [Configuration](https://seijikohara.github.io/db-tester/configuration) documentation for all options.
 
 ---
 


### PR DESCRIPTION
## Summary

- Fix CLAUDE.md spec file references to match actual filenames (`overview.md`, `architecture.md`, `public-api.md` without numeric prefixes)
- Fix README.md broken VitePress link (`/configuration` instead of `/specs/04-configuration`)
- Update publishing.md Published Modules table to include `db-tester-api` and `db-tester-spring-support`, and correct `db-tester-core` description
- Remove unused `GPG_KEY_ID` from release.yml validation step, publishing.md secrets table, workflow.md prerequisites, and CI environment variable examples

## Test plan

- [x] Verify `./gradlew build` passes
- [x] Verify CLAUDE.md `@` references resolve to existing files
- [x] Verify README.md Configuration link resolves to correct VitePress page
- [x] Verify release.yml GPG validation step works without `GPG_KEY_ID`

Closes #92, Closes #93, Closes #94