### PR TITLE
test(api): add DatabaseAssertion tests and DataSourceRegistry concurrency tests

### DIFF
--- a/db-tester-api/src/test/java/io/github/seijikohara/dbtester/api/assertion/DatabaseAssertionTest.java
+++ b/db-tester-api/src/test/java/io/github/seijikohara/dbtester/api/assertion/DatabaseAssertionTest.java
@@ -1,0 +1,610 @@
+package io.github.seijikohara.dbtester.api.assertion;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+
+import io.github.seijikohara.dbtester.api.config.ColumnStrategyMapping;
+import io.github.seijikohara.dbtester.api.dataset.Table;
+import io.github.seijikohara.dbtester.api.dataset.TableSet;
+import java.util.List;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link DatabaseAssertion}.
+ *
+ * <p>These tests verify that each static method correctly delegates to the underlying {@link
+ * io.github.seijikohara.dbtester.api.spi.AssertionProvider} loaded via {@link
+ * java.util.ServiceLoader}. A test stub ({@link TestAssertionProvider}) is registered via {@code
+ * META-INF/services/} and records all invocations for inspection.
+ */
+@DisplayName("DatabaseAssertion")
+class DatabaseAssertionTest {
+
+  /** Tests for the DatabaseAssertion class. */
+  DatabaseAssertionTest() {}
+
+  /** Clears recorded invocations before each test. */
+  @BeforeEach
+  void setUp() {
+    TestAssertionProvider.reset();
+  }
+
+  /** Tests for assertEquals(TableSet, TableSet) method. */
+  @Nested
+  @DisplayName("assertEquals(TableSet, TableSet)")
+  class AssertEqualsTableSetTest {
+
+    /** Tests for assertEquals(TableSet, TableSet) method. */
+    AssertEqualsTableSetTest() {}
+
+    /** Verifies that assertEquals delegates to provider with TableSet arguments. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should delegate to provider with TableSet arguments")
+    void shouldDelegateToProvider_withTableSetArguments() {
+      // Given
+      final var expected = mock(TableSet.class);
+      final var actual = mock(TableSet.class);
+
+      // When
+      DatabaseAssertion.assertEquals(expected, actual);
+
+      // Then
+      final var invocation = TestAssertionProvider.getLastInvocation();
+      assertAll(
+          "should delegate assertEquals(TableSet,TableSet) to provider",
+          () ->
+              assertEquals(
+                  "assertEquals(TableSet,TableSet)",
+                  invocation.methodName(),
+                  "should call assertEquals(TableSet,TableSet)"),
+          () ->
+              assertSame(
+                  expected,
+                  invocation.arguments().get(0),
+                  "should pass expected as first argument"),
+          () ->
+              assertSame(
+                  actual, invocation.arguments().get(1), "should pass actual as second argument"));
+    }
+  }
+
+  /** Tests for assertEquals(TableSet, TableSet, AssertionFailureHandler) method. */
+  @Nested
+  @DisplayName("assertEquals(TableSet, TableSet, AssertionFailureHandler)")
+  class AssertEqualsTableSetWithHandlerTest {
+
+    /** Tests for assertEquals(TableSet, TableSet, AssertionFailureHandler) method. */
+    AssertEqualsTableSetWithHandlerTest() {}
+
+    /** Verifies that assertEquals delegates to provider with custom failure handler. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should delegate to provider with custom failure handler")
+    void shouldDelegateToProvider_withCustomFailureHandler() {
+      // Given
+      final var expected = mock(TableSet.class);
+      final var actual = mock(TableSet.class);
+      final AssertionFailureHandler handler = (msg, exp, act) -> {};
+
+      // When
+      DatabaseAssertion.assertEquals(expected, actual, handler);
+
+      // Then
+      final var invocation = TestAssertionProvider.getLastInvocation();
+      assertAll(
+          "should delegate assertEquals with handler to provider",
+          () ->
+              assertEquals(
+                  "assertEquals(TableSet,TableSet,AssertionFailureHandler)",
+                  invocation.methodName(),
+                  "should call assertEquals(TableSet,TableSet,AssertionFailureHandler)"),
+          () ->
+              assertSame(
+                  handler, invocation.arguments().get(2), "should pass handler as argument"));
+    }
+
+    /** Verifies that assertEquals delegates null failure handler to provider. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should delegate null failure handler to provider")
+    void shouldDelegateNullHandler_toProvider() {
+      // Given
+      final var expected = mock(TableSet.class);
+      final var actual = mock(TableSet.class);
+
+      // When
+      DatabaseAssertion.assertEquals(expected, actual, null);
+
+      // Then
+      final var invocation = TestAssertionProvider.getLastInvocation();
+      assertEquals(
+          "<<null>>", invocation.arguments().get(2), "should pass null sentinel for null handler");
+    }
+  }
+
+  /** Tests for assertEquals(Table, Table) method. */
+  @Nested
+  @DisplayName("assertEquals(Table, Table)")
+  class AssertEqualsTableTest {
+
+    /** Tests for assertEquals(Table, Table) method. */
+    AssertEqualsTableTest() {}
+
+    /** Verifies that assertEquals delegates to provider with Table arguments. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should delegate to provider with Table arguments")
+    void shouldDelegateToProvider_withTableArguments() {
+      // Given
+      final var expected = mock(Table.class);
+      final var actual = mock(Table.class);
+
+      // When
+      DatabaseAssertion.assertEquals(expected, actual);
+
+      // Then
+      final var invocation = TestAssertionProvider.getLastInvocation();
+      assertAll(
+          "should delegate assertEquals(Table,Table) to provider",
+          () ->
+              assertEquals(
+                  "assertEquals(Table,Table)",
+                  invocation.methodName(),
+                  "should call assertEquals(Table,Table)"),
+          () ->
+              assertSame(
+                  expected,
+                  invocation.arguments().get(0),
+                  "should pass expected as first argument"),
+          () ->
+              assertSame(
+                  actual, invocation.arguments().get(1), "should pass actual as second argument"));
+    }
+  }
+
+  /** Tests for assertEquals(Table, Table, Collection) method. */
+  @Nested
+  @DisplayName("assertEquals(Table, Table, Collection)")
+  class AssertEqualsTableWithColumnsTest {
+
+    /** Tests for assertEquals(Table, Table, Collection) method. */
+    AssertEqualsTableWithColumnsTest() {}
+
+    /** Verifies that assertEquals with collection delegates to provider. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should delegate to provider with additional column names collection")
+    void shouldDelegateToProvider_withAdditionalColumnNamesCollection() {
+      // Given
+      final var expected = mock(Table.class);
+      final var actual = mock(Table.class);
+      final var columns = List.of("COL_A", "COL_B");
+
+      // When
+      DatabaseAssertion.assertEquals(expected, actual, columns);
+
+      // Then
+      final var invocation = TestAssertionProvider.getLastInvocation();
+      assertAll(
+          "should delegate assertEquals(Table,Table,Collection) to provider",
+          () ->
+              assertEquals(
+                  "assertEquals(Table,Table,Collection)",
+                  invocation.methodName(),
+                  "should call assertEquals(Table,Table,Collection)"),
+          () ->
+              assertEquals(
+                  columns, invocation.arguments().get(2), "should pass column names as argument"));
+    }
+
+    /** Verifies that varargs overload converts arguments to List and delegates. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should convert varargs to List and delegate to collection overload")
+    void shouldConvertVarargs_toListAndDelegate() {
+      // Given
+      final var expected = mock(Table.class);
+      final var actual = mock(Table.class);
+
+      // When
+      DatabaseAssertion.assertEquals(expected, actual, "COL_X", "COL_Y");
+
+      // Then
+      final var invocation = TestAssertionProvider.getLastInvocation();
+      assertAll(
+          "should convert varargs to collection and delegate",
+          () ->
+              assertEquals(
+                  "assertEquals(Table,Table,Collection)",
+                  invocation.methodName(),
+                  "should call collection overload"),
+          () ->
+              assertEquals(
+                  List.of("COL_X", "COL_Y"),
+                  invocation.arguments().get(2),
+                  "should convert varargs to list"));
+    }
+  }
+
+  /** Tests for assertEquals(Table, Table, AssertionFailureHandler) method. */
+  @Nested
+  @DisplayName("assertEquals(Table, Table, AssertionFailureHandler)")
+  class AssertEqualsTableWithHandlerTest {
+
+    /** Tests for assertEquals(Table, Table, AssertionFailureHandler) method. */
+    AssertEqualsTableWithHandlerTest() {}
+
+    /** Verifies that assertEquals with handler delegates to provider. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should delegate to provider with Table arguments and failure handler")
+    void shouldDelegateToProvider_withTableAndHandler() {
+      // Given
+      final var expected = mock(Table.class);
+      final var actual = mock(Table.class);
+      final AssertionFailureHandler handler = (msg, exp, act) -> {};
+
+      // When
+      DatabaseAssertion.assertEquals(expected, actual, handler);
+
+      // Then
+      final var invocation = TestAssertionProvider.getLastInvocation();
+      assertAll(
+          "should delegate assertEquals(Table,Table,AssertionFailureHandler) to provider",
+          () ->
+              assertEquals(
+                  "assertEquals(Table,Table,AssertionFailureHandler)",
+                  invocation.methodName(),
+                  "should call assertEquals(Table,Table,AssertionFailureHandler)"),
+          () ->
+              assertSame(
+                  handler, invocation.arguments().get(2), "should pass handler as argument"));
+    }
+  }
+
+  /** Tests for assertEqualsIgnoreColumns(TableSet, TableSet, String, Collection) method. */
+  @Nested
+  @DisplayName("assertEqualsIgnoreColumns(TableSet)")
+  class AssertEqualsIgnoreColumnsTableSetTest {
+
+    /** Tests for assertEqualsIgnoreColumns(TableSet) method. */
+    AssertEqualsIgnoreColumnsTableSetTest() {}
+
+    /** Verifies that assertEqualsIgnoreColumns with collection delegates to provider. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should delegate to provider with collection of column names")
+    void shouldDelegateToProvider_withCollectionOfColumnNames() {
+      // Given
+      final var expected = mock(TableSet.class);
+      final var actual = mock(TableSet.class);
+      final var ignoreColumns = List.of("CREATED_AT", "UPDATED_AT");
+
+      // When
+      DatabaseAssertion.assertEqualsIgnoreColumns(expected, actual, "USERS", ignoreColumns);
+
+      // Then
+      final var invocation = TestAssertionProvider.getLastInvocation();
+      assertAll(
+          "should delegate assertEqualsIgnoreColumns(TableSet) to provider",
+          () ->
+              assertEquals(
+                  "assertEqualsIgnoreColumns(TableSet,TableSet,String,Collection)",
+                  invocation.methodName(),
+                  "should call assertEqualsIgnoreColumns(TableSet,TableSet,String,Collection)"),
+          () ->
+              assertEquals(
+                  "USERS", invocation.arguments().get(2), "should pass table name as argument"),
+          () ->
+              assertEquals(
+                  ignoreColumns,
+                  invocation.arguments().get(3),
+                  "should pass ignore columns as argument"));
+    }
+
+    /** Verifies that varargs overload converts arguments and delegates. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should convert varargs to List and delegate to collection overload")
+    void shouldConvertVarargs_toListAndDelegate() {
+      // Given
+      final var expected = mock(TableSet.class);
+      final var actual = mock(TableSet.class);
+
+      // When
+      DatabaseAssertion.assertEqualsIgnoreColumns(expected, actual, "ORDERS", "ID", "VERSION");
+
+      // Then
+      final var invocation = TestAssertionProvider.getLastInvocation();
+      assertAll(
+          "should convert varargs to collection and delegate",
+          () ->
+              assertEquals(
+                  "assertEqualsIgnoreColumns(TableSet,TableSet,String,Collection)",
+                  invocation.methodName(),
+                  "should call collection overload"),
+          () ->
+              assertEquals(
+                  List.of("ID", "VERSION"),
+                  invocation.arguments().get(3),
+                  "should convert varargs to list"));
+    }
+  }
+
+  /** Tests for assertEqualsIgnoreColumns(Table, Table, Collection) method. */
+  @Nested
+  @DisplayName("assertEqualsIgnoreColumns(Table)")
+  class AssertEqualsIgnoreColumnsTableTest {
+
+    /** Tests for assertEqualsIgnoreColumns(Table) method. */
+    AssertEqualsIgnoreColumnsTableTest() {}
+
+    /** Verifies that assertEqualsIgnoreColumns with collection delegates to provider. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should delegate to provider with collection of column names")
+    void shouldDelegateToProvider_withCollectionOfColumnNames() {
+      // Given
+      final var expected = mock(Table.class);
+      final var actual = mock(Table.class);
+      final var ignoreColumns = List.of("TIMESTAMP");
+
+      // When
+      DatabaseAssertion.assertEqualsIgnoreColumns(expected, actual, ignoreColumns);
+
+      // Then
+      final var invocation = TestAssertionProvider.getLastInvocation();
+      assertAll(
+          "should delegate assertEqualsIgnoreColumns(Table) to provider",
+          () ->
+              assertEquals(
+                  "assertEqualsIgnoreColumns(Table,Table,Collection)",
+                  invocation.methodName(),
+                  "should call assertEqualsIgnoreColumns(Table,Table,Collection)"),
+          () ->
+              assertEquals(
+                  ignoreColumns,
+                  invocation.arguments().get(2),
+                  "should pass ignore columns as argument"));
+    }
+
+    /** Verifies that varargs overload converts arguments and delegates. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should convert varargs to List and delegate to collection overload")
+    void shouldConvertVarargs_toListAndDelegate() {
+      // Given
+      final var expected = mock(Table.class);
+      final var actual = mock(Table.class);
+
+      // When
+      DatabaseAssertion.assertEqualsIgnoreColumns(expected, actual, "COL_A", "COL_B");
+
+      // Then
+      final var invocation = TestAssertionProvider.getLastInvocation();
+      assertEquals(
+          List.of("COL_A", "COL_B"),
+          invocation.arguments().get(2),
+          "should convert varargs to list");
+    }
+  }
+
+  /** Tests for assertEqualsWithStrategies method. */
+  @Nested
+  @DisplayName("assertEqualsWithStrategies")
+  class AssertEqualsWithStrategiesTest {
+
+    /** Tests for assertEqualsWithStrategies method. */
+    AssertEqualsWithStrategiesTest() {}
+
+    /** Verifies that assertEqualsWithStrategies with collection delegates to provider. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should delegate to provider with collection of strategies")
+    void shouldDelegateToProvider_withCollectionOfStrategies() {
+      // Given
+      final var expected = mock(Table.class);
+      final var actual = mock(Table.class);
+      final var strategies = List.of(ColumnStrategyMapping.ignore("CREATED_AT"));
+
+      // When
+      DatabaseAssertion.assertEqualsWithStrategies(expected, actual, strategies);
+
+      // Then
+      final var invocation = TestAssertionProvider.getLastInvocation();
+      assertAll(
+          "should delegate assertEqualsWithStrategies to provider",
+          () ->
+              assertEquals(
+                  "assertEqualsWithStrategies(Table,Table,Collection)",
+                  invocation.methodName(),
+                  "should call assertEqualsWithStrategies(Table,Table,Collection)"),
+          () ->
+              assertEquals(
+                  strategies, invocation.arguments().get(2), "should pass strategies as argument"));
+    }
+
+    /** Verifies that varargs overload converts arguments and delegates. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should convert varargs to List and delegate to collection overload")
+    void shouldConvertVarargs_toListAndDelegate() {
+      // Given
+      final var expected = mock(Table.class);
+      final var actual = mock(Table.class);
+      final var strategy1 = ColumnStrategyMapping.ignore("COL_A");
+      final var strategy2 = ColumnStrategyMapping.strict("COL_B");
+
+      // When
+      DatabaseAssertion.assertEqualsWithStrategies(expected, actual, strategy1, strategy2);
+
+      // Then
+      final var invocation = TestAssertionProvider.getLastInvocation();
+      assertEquals(
+          List.of(strategy1, strategy2),
+          invocation.arguments().get(2),
+          "should convert varargs to list");
+    }
+  }
+
+  /** Tests for assertEqualsByQuery(TableSet, ...) method. */
+  @Nested
+  @DisplayName("assertEqualsByQuery(TableSet)")
+  class AssertEqualsByQueryTableSetTest {
+
+    /** Tests for assertEqualsByQuery(TableSet) method. */
+    AssertEqualsByQueryTableSetTest() {}
+
+    /** Verifies that assertEqualsByQuery with TableSet delegates to provider. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should delegate to provider with TableSet and query parameters")
+    void shouldDelegateToProvider_withTableSetAndQueryParameters() {
+      // Given
+      final var expected = mock(TableSet.class);
+      final var dataSource = mock(DataSource.class);
+      final var ignoreColumns = List.of("ID");
+
+      // When
+      DatabaseAssertion.assertEqualsByQuery(
+          expected, dataSource, "USERS", "SELECT * FROM USERS", ignoreColumns);
+
+      // Then
+      final var invocation = TestAssertionProvider.getLastInvocation();
+      assertAll(
+          "should delegate assertEqualsByQuery(TableSet) to provider",
+          () ->
+              assertEquals(
+                  "assertEqualsByQuery(TableSet,DataSource,String,String,Collection)",
+                  invocation.methodName(),
+                  "should call assertEqualsByQuery(TableSet,DataSource,String,String,Collection)"),
+          () ->
+              assertSame(
+                  dataSource, invocation.arguments().get(1), "should pass dataSource as argument"),
+          () ->
+              assertEquals(
+                  "SELECT * FROM USERS",
+                  invocation.arguments().get(3),
+                  "should pass SQL query as argument"));
+    }
+
+    /** Verifies that varargs overload converts arguments and delegates. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should convert varargs to List and delegate to collection overload")
+    void shouldConvertVarargs_toListAndDelegate() {
+      // Given
+      final var expected = mock(TableSet.class);
+      final var dataSource = mock(DataSource.class);
+
+      // When
+      DatabaseAssertion.assertEqualsByQuery(
+          expected, dataSource, "USERS", "SELECT * FROM USERS", "ID", "VERSION");
+
+      // Then
+      final var invocation = TestAssertionProvider.getLastInvocation();
+      assertEquals(
+          List.of("ID", "VERSION"),
+          invocation.arguments().get(4),
+          "should convert varargs to list");
+    }
+  }
+
+  /** Tests for assertEqualsByQuery(Table, ...) method. */
+  @Nested
+  @DisplayName("assertEqualsByQuery(Table)")
+  class AssertEqualsByQueryTableTest {
+
+    /** Tests for assertEqualsByQuery(Table) method. */
+    AssertEqualsByQueryTableTest() {}
+
+    /** Verifies that assertEqualsByQuery with Table delegates to provider. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should delegate to provider with Table and query parameters")
+    void shouldDelegateToProvider_withTableAndQueryParameters() {
+      // Given
+      final var expected = mock(Table.class);
+      final var dataSource = mock(DataSource.class);
+      final var ignoreColumns = List.of("TIMESTAMP");
+
+      // When
+      DatabaseAssertion.assertEqualsByQuery(
+          expected, dataSource, "ORDERS", "SELECT * FROM ORDERS", ignoreColumns);
+
+      // Then
+      final var invocation = TestAssertionProvider.getLastInvocation();
+      assertAll(
+          "should delegate assertEqualsByQuery(Table) to provider",
+          () ->
+              assertEquals(
+                  "assertEqualsByQuery(Table,DataSource,String,String,Collection)",
+                  invocation.methodName(),
+                  "should call assertEqualsByQuery(Table,DataSource,String,String,Collection)"),
+          () ->
+              assertSame(
+                  expected,
+                  invocation.arguments().get(0),
+                  "should pass expected table as argument"),
+          () ->
+              assertEquals(
+                  ignoreColumns,
+                  invocation.arguments().get(4),
+                  "should pass ignore columns as argument"));
+    }
+
+    /** Verifies that varargs overload converts arguments and delegates. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should convert varargs to List and delegate to collection overload")
+    void shouldConvertVarargs_toListAndDelegate() {
+      // Given
+      final var expected = mock(Table.class);
+      final var dataSource = mock(DataSource.class);
+
+      // When
+      DatabaseAssertion.assertEqualsByQuery(
+          expected, dataSource, "ORDERS", "SELECT * FROM ORDERS", "COL1", "COL2");
+
+      // Then
+      final var invocation = TestAssertionProvider.getLastInvocation();
+      assertEquals(
+          List.of("COL1", "COL2"), invocation.arguments().get(4), "should convert varargs to list");
+    }
+  }
+
+  /** Tests for ServiceLoader integration. */
+  @Nested
+  @DisplayName("ServiceLoader integration")
+  class ServiceLoaderTest {
+
+    /** Tests for ServiceLoader integration. */
+    ServiceLoaderTest() {}
+
+    /** Verifies that multiple calls use the same provider instance. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should use same provider instance across multiple calls")
+    void shouldUseSameProviderInstance_acrossMultipleCalls() {
+      // Given
+      final var expected = mock(TableSet.class);
+      final var actual = mock(TableSet.class);
+
+      // When
+      DatabaseAssertion.assertEquals(expected, actual);
+      DatabaseAssertion.assertEquals(expected, actual);
+
+      // Then
+      final var invocations = TestAssertionProvider.getInvocations();
+      assertEquals(2, invocations.size(), "should record two invocations from same provider");
+    }
+  }
+}

--- a/db-tester-api/src/test/java/io/github/seijikohara/dbtester/api/assertion/TestAssertionProvider.java
+++ b/db-tester-api/src/test/java/io/github/seijikohara/dbtester/api/assertion/TestAssertionProvider.java
@@ -1,0 +1,176 @@
+package io.github.seijikohara.dbtester.api.assertion;
+
+import io.github.seijikohara.dbtester.api.config.ColumnStrategyMapping;
+import io.github.seijikohara.dbtester.api.dataset.Table;
+import io.github.seijikohara.dbtester.api.dataset.TableSet;
+import io.github.seijikohara.dbtester.api.spi.AssertionProvider;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import javax.sql.DataSource;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Test stub implementation of {@link AssertionProvider} that records method invocations.
+ *
+ * <p>This provider records each method call with its arguments, enabling tests to verify that
+ * {@link DatabaseAssertion} correctly delegates to the underlying provider. The recorded
+ * invocations can be inspected via {@link #getInvocations()} and cleared via {@link #reset()}.
+ *
+ * <p>This class is loaded via {@link java.util.ServiceLoader} using the corresponding service
+ * configuration file in {@code META-INF/services/}.
+ */
+public final class TestAssertionProvider implements AssertionProvider {
+
+  /** Recorded method invocations. */
+  private static final List<Invocation> INVOCATIONS =
+      Collections.synchronizedList(new ArrayList<>());
+
+  /** Creates a new TestAssertionProvider instance. */
+  public TestAssertionProvider() {}
+
+  /**
+   * Returns an unmodifiable view of the recorded invocations.
+   *
+   * @return list of recorded invocations
+   */
+  static List<Invocation> getInvocations() {
+    return List.copyOf(INVOCATIONS);
+  }
+
+  /**
+   * Returns the most recent invocation.
+   *
+   * @return the last recorded invocation
+   * @throws IllegalStateException if no invocations have been recorded
+   */
+  static Invocation getLastInvocation() {
+    if (INVOCATIONS.isEmpty()) {
+      throw new IllegalStateException("No invocations recorded");
+    }
+    return INVOCATIONS.get(INVOCATIONS.size() - 1);
+  }
+
+  /** Clears all recorded invocations. */
+  static void reset() {
+    INVOCATIONS.clear();
+  }
+
+  @Override
+  public void assertEquals(final TableSet expected, final TableSet actual) {
+    INVOCATIONS.add(new Invocation("assertEquals(TableSet,TableSet)", List.of(expected, actual)));
+  }
+
+  @Override
+  public void assertEquals(
+      final TableSet expected,
+      final TableSet actual,
+      final @Nullable AssertionFailureHandler failureHandler) {
+    INVOCATIONS.add(
+        new Invocation(
+            "assertEquals(TableSet,TableSet,AssertionFailureHandler)",
+            List.of(expected, actual, wrapNullable(failureHandler))));
+  }
+
+  @Override
+  public void assertEquals(final Table expected, final Table actual) {
+    INVOCATIONS.add(new Invocation("assertEquals(Table,Table)", List.of(expected, actual)));
+  }
+
+  @Override
+  public void assertEquals(
+      final Table expected, final Table actual, final Collection<String> additionalColumnNames) {
+    INVOCATIONS.add(
+        new Invocation(
+            "assertEquals(Table,Table,Collection)",
+            List.of(expected, actual, additionalColumnNames)));
+  }
+
+  @Override
+  public void assertEquals(
+      final Table expected,
+      final Table actual,
+      final @Nullable AssertionFailureHandler failureHandler) {
+    INVOCATIONS.add(
+        new Invocation(
+            "assertEquals(Table,Table,AssertionFailureHandler)",
+            List.of(expected, actual, wrapNullable(failureHandler))));
+  }
+
+  @Override
+  public void assertEqualsIgnoreColumns(
+      final TableSet expected,
+      final TableSet actual,
+      final String tableName,
+      final Collection<String> ignoreColumnNames) {
+    INVOCATIONS.add(
+        new Invocation(
+            "assertEqualsIgnoreColumns(TableSet,TableSet,String,Collection)",
+            List.of(expected, actual, tableName, ignoreColumnNames)));
+  }
+
+  @Override
+  public void assertEqualsIgnoreColumns(
+      final Table expected, final Table actual, final Collection<String> ignoreColumnNames) {
+    INVOCATIONS.add(
+        new Invocation(
+            "assertEqualsIgnoreColumns(Table,Table,Collection)",
+            List.of(expected, actual, ignoreColumnNames)));
+  }
+
+  @Override
+  public void assertEqualsWithStrategies(
+      final Table expected,
+      final Table actual,
+      final Collection<ColumnStrategyMapping> columnStrategies) {
+    INVOCATIONS.add(
+        new Invocation(
+            "assertEqualsWithStrategies(Table,Table,Collection)",
+            List.of(expected, actual, columnStrategies)));
+  }
+
+  @Override
+  public void assertEqualsByQuery(
+      final TableSet expected,
+      final DataSource dataSource,
+      final String tableName,
+      final String sqlQuery,
+      final Collection<String> ignoreColumnNames) {
+    INVOCATIONS.add(
+        new Invocation(
+            "assertEqualsByQuery(TableSet,DataSource,String,String,Collection)",
+            List.of(expected, dataSource, tableName, sqlQuery, ignoreColumnNames)));
+  }
+
+  @Override
+  public void assertEqualsByQuery(
+      final Table expected,
+      final DataSource dataSource,
+      final String tableName,
+      final String sqlQuery,
+      final Collection<String> ignoreColumnNames) {
+    INVOCATIONS.add(
+        new Invocation(
+            "assertEqualsByQuery(Table,DataSource,String,String,Collection)",
+            List.of(expected, dataSource, tableName, sqlQuery, ignoreColumnNames)));
+  }
+
+  /**
+   * Wraps a nullable value in a sentinel object for recording.
+   *
+   * @param value the nullable value
+   * @return the value itself if non-null, or a sentinel string indicating null
+   */
+  private static Object wrapNullable(final @Nullable Object value) {
+    return value != null ? value : "<<null>>";
+  }
+
+  /**
+   * Represents a recorded method invocation.
+   *
+   * @param methodName the method signature
+   * @param arguments the arguments passed to the method
+   */
+  record Invocation(String methodName, List<Object> arguments) {}
+}

--- a/db-tester-api/src/test/java/io/github/seijikohara/dbtester/api/assertion/package-info.java
+++ b/db-tester-api/src/test/java/io/github/seijikohara/dbtester/api/assertion/package-info.java
@@ -1,0 +1,5 @@
+/** Unit tests for assertion types in the DB Tester API. */
+@NullMarked
+package io.github.seijikohara.dbtester.api.assertion;
+
+import org.jspecify.annotations.NullMarked;

--- a/db-tester-api/src/test/java/io/github/seijikohara/dbtester/api/config/DataSourceRegistryTest.java
+++ b/db-tester-api/src/test/java/io/github/seijikohara/dbtester/api/config/DataSourceRegistryTest.java
@@ -1,6 +1,7 @@
 package io.github.seijikohara.dbtester.api.config;
 
 import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -9,10 +10,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import io.github.seijikohara.dbtester.api.exception.DataSourceNotFoundException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -376,6 +384,182 @@ class DataSourceRegistryTest {
 
       assertNotNull(newRegistry);
       assertFalse(newRegistry.hasDefault());
+    }
+  }
+
+  /** Tests for concurrent access to DataSourceRegistry. */
+  @Nested
+  @DisplayName("concurrency")
+  class ConcurrencyTest {
+
+    /** Tests for concurrent access to DataSourceRegistry. */
+    ConcurrencyTest() {}
+
+    /** Thread count for concurrent tests. */
+    private static final int THREAD_COUNT = 16;
+
+    /**
+     * Verifies that concurrent registerDefault calls do not throw exceptions.
+     *
+     * @throws InterruptedException if the latch or executor is interrupted
+     */
+    @RepeatedTest(10)
+    @Tag("normal")
+    @DisplayName("concurrent registerDefault calls complete without error")
+    void shouldCompleteWithoutError_whenRegisterDefaultCalledConcurrently()
+        throws InterruptedException {
+      // Given
+      final var latch = new CountDownLatch(1);
+      final var executor = Executors.newFixedThreadPool(THREAD_COUNT);
+
+      try {
+        // When
+        final var futures =
+            IntStream.range(0, THREAD_COUNT)
+                .mapToObj(
+                    i ->
+                        executor.submit(
+                            () -> {
+                              awaitLatch(latch);
+                              registry.registerDefault(mock(DataSource.class));
+                            }))
+                .toList();
+        latch.countDown();
+        awaitAllFutures(futures);
+        executor.shutdown();
+        final var completed = executor.awaitTermination(10, TimeUnit.SECONDS);
+
+        // Then
+        assertTrue(completed, "all threads should complete within timeout");
+        assertTrue(registry.hasDefault(), "default data source should be registered");
+      } finally {
+        shutdownExecutor(executor);
+      }
+    }
+
+    /**
+     * Verifies that concurrent register and get calls do not throw unexpected exceptions.
+     *
+     * @throws InterruptedException if the latch or executor is interrupted
+     */
+    @RepeatedTest(10)
+    @Tag("normal")
+    @DisplayName("concurrent register and get calls complete without error")
+    void shouldCompleteWithoutError_whenRegisterAndGetCalledConcurrently()
+        throws InterruptedException {
+      // Given
+      final var latch = new CountDownLatch(1);
+      final var executor = Executors.newFixedThreadPool(THREAD_COUNT);
+      registry.registerDefault(mock(DataSource.class));
+
+      try {
+        // When
+        final var futures =
+            IntStream.range(0, THREAD_COUNT)
+                .mapToObj(
+                    i ->
+                        executor.submit(
+                            () -> {
+                              awaitLatch(latch);
+                              final var name = "db" + i;
+                              registry.register(name, mock(DataSource.class));
+                              assertDoesNotThrow(
+                                  () -> registry.get(name),
+                                  "get should not throw for registered data source");
+                            }))
+                .toList();
+        latch.countDown();
+        awaitAllFutures(futures);
+        executor.shutdown();
+        final var completed = executor.awaitTermination(10, TimeUnit.SECONDS);
+
+        // Then
+        assertTrue(completed, "all threads should complete within timeout");
+      } finally {
+        shutdownExecutor(executor);
+      }
+    }
+
+    /**
+     * Verifies that concurrent register and clear calls do not throw unexpected exceptions.
+     *
+     * @throws InterruptedException if the latch or executor is interrupted
+     */
+    @RepeatedTest(10)
+    @Tag("normal")
+    @DisplayName("concurrent register and clear calls complete without error")
+    void shouldCompleteWithoutError_whenRegisterAndClearCalledConcurrently()
+        throws InterruptedException {
+      // Given
+      final var latch = new CountDownLatch(1);
+      final var executor = Executors.newFixedThreadPool(THREAD_COUNT);
+
+      try {
+        // When
+        final var futures =
+            IntStream.range(0, THREAD_COUNT)
+                .mapToObj(
+                    i ->
+                        executor.submit(
+                            () -> {
+                              awaitLatch(latch);
+                              if (i % 2 == 0) {
+                                registry.register("db" + i, mock(DataSource.class));
+                              } else {
+                                registry.clear();
+                              }
+                            }))
+                .toList();
+        latch.countDown();
+        awaitAllFutures(futures);
+        executor.shutdown();
+        final var completed = executor.awaitTermination(10, TimeUnit.SECONDS);
+
+        // Then
+        assertTrue(completed, "all threads should complete within timeout");
+      } finally {
+        shutdownExecutor(executor);
+      }
+    }
+
+    /**
+     * Awaits completion of all futures, ignoring exceptions.
+     *
+     * @param futures the futures to await
+     */
+    private void awaitAllFutures(final java.util.List<? extends Future<?>> futures) {
+      futures.forEach(
+          future -> {
+            try {
+              future.get(10, TimeUnit.SECONDS);
+            } catch (final Exception ignored) {
+              // Exceptions from individual tasks are acceptable in concurrency tests
+            }
+          });
+    }
+
+    /**
+     * Awaits the countdown latch, wrapping InterruptedException.
+     *
+     * @param latch the latch to await
+     */
+    private void awaitLatch(final CountDownLatch latch) {
+      try {
+        latch.await();
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+
+    /**
+     * Shuts down the executor service forcefully if still running.
+     *
+     * @param executor the executor service to shut down
+     */
+    private void shutdownExecutor(final ExecutorService executor) {
+      if (!executor.isShutdown()) {
+        executor.shutdownNow();
+      }
     }
   }
 }

--- a/db-tester-api/src/test/resources/META-INF/services/io.github.seijikohara.dbtester.api.spi.AssertionProvider
+++ b/db-tester-api/src/test/resources/META-INF/services/io.github.seijikohara.dbtester.api.spi.AssertionProvider
@@ -1,0 +1,1 @@
+io.github.seijikohara.dbtester.api.assertion.TestAssertionProvider


### PR DESCRIPTION
## Summary

- Add unit tests for `DatabaseAssertion` verifying SPI delegation via `ServiceLoader`
- Introduce `TestAssertionProvider` as a test stub SPI implementation that records invocations
- Add concurrency tests for `DataSourceRegistry` using `CountDownLatch` and `@RepeatedTest`
- JaCoCo threshold remains at 70% (lowest module: `db-tester-junit-spring-boot-starter` at 71.4%)

### New test files

| File | Description |
|------|-------------|
| `TestAssertionProvider.java` | Stub `AssertionProvider` that records method calls |
| `DatabaseAssertionTest.java` | 20 tests verifying delegation for all public methods |
| `META-INF/services/...AssertionProvider` | ServiceLoader configuration for test stub |
| `package-info.java` | `@NullMarked` annotation for test assertion package |

### Modified test files

| File | Change |
|------|--------|
| `DataSourceRegistryTest.java` | Add `ConcurrencyTest` nested class (3 × `@RepeatedTest(10)`) |

### Coverage analysis

| Module | Instruction Coverage |
|--------|---------------------|
| `db-tester-api` | 91.0% |
| `db-tester-core` | 78.6% |
| `db-tester-junit` | 98.5% |
| `db-tester-junit-spring-boot-starter` | 71.4% |

## Test plan

- [x] `./gradlew :db-tester-api:test` passes
- [x] `./gradlew build` passes (all modules)
- [x] JaCoCo coverage verification passes
- [x] Concurrency tests run 10 repetitions without flakiness

Closes #95