### PR TITLE
fix(core): improve REGEX error message with column context and reduce Strategy method visibility

### DIFF
--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/annotation/Strategy.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/annotation/Strategy.java
@@ -99,13 +99,13 @@ public enum Strategy {
   /**
    * Converts this annotation strategy to the corresponding runtime {@link ComparisonStrategy}.
    *
-   * <p>For {@link #REGEX} strategy, use {@link #toComparisonStrategy(String)} instead to provide
-   * the pattern.
+   * <p>This method handles all strategies except {@link #REGEX}. For REGEX, use {@link
+   * #toComparisonStrategy(String)} with a pattern.
    *
    * @return the corresponding ComparisonStrategy instance
-   * @throws IllegalStateException if called on REGEX without a pattern (use the overloaded method)
+   * @throws IllegalStateException if called on REGEX (REGEX requires a pattern)
    */
-  public ComparisonStrategy toComparisonStrategy() {
+  private ComparisonStrategy toComparisonStrategy() {
     return switch (this) {
       case STRICT -> ComparisonStrategy.STRICT;
       case IGNORE -> ComparisonStrategy.IGNORE;

--- a/db-tester-api/src/test/java/io/github/seijikohara/dbtester/api/annotation/StrategyTest.java
+++ b/db-tester-api/src/test/java/io/github/seijikohara/dbtester/api/annotation/StrategyTest.java
@@ -18,13 +18,13 @@ class StrategyTest {
   /** Tests for Strategy enum. */
   StrategyTest() {}
 
-  /** Tests for toComparisonStrategy method. */
+  /** Tests for toComparisonStrategy(String) with non-REGEX strategies (pattern is ignored). */
   @Nested
-  @DisplayName("toComparisonStrategy()")
-  class ToComparisonStrategyTests {
+  @DisplayName("toComparisonStrategy(String) for non-REGEX strategies")
+  class ToComparisonStrategyNonRegexTests {
 
-    /** Tests for toComparisonStrategy method. */
-    ToComparisonStrategyTests() {}
+    /** Tests for toComparisonStrategy with non-REGEX strategies. */
+    ToComparisonStrategyNonRegexTests() {}
 
     /** Verifies that STRICT converts to ComparisonStrategy.STRICT. */
     @Test
@@ -32,7 +32,7 @@ class StrategyTest {
     @DisplayName("should convert STRICT to ComparisonStrategy.STRICT")
     void shouldConvertStrict_toComparisonStrategy() {
       // When
-      final ComparisonStrategy result = Strategy.STRICT.toComparisonStrategy();
+      final ComparisonStrategy result = Strategy.STRICT.toComparisonStrategy("");
 
       // Then
       assertSame(ComparisonStrategy.STRICT, result, "should be STRICT strategy");
@@ -45,7 +45,7 @@ class StrategyTest {
     @DisplayName("should convert IGNORE to ComparisonStrategy.IGNORE")
     void shouldConvertIgnore_toComparisonStrategy() {
       // When
-      final ComparisonStrategy result = Strategy.IGNORE.toComparisonStrategy();
+      final ComparisonStrategy result = Strategy.IGNORE.toComparisonStrategy("");
 
       // Then
       assertSame(ComparisonStrategy.IGNORE, result, "should be IGNORE strategy");
@@ -58,7 +58,7 @@ class StrategyTest {
     @DisplayName("should convert NUMERIC to ComparisonStrategy.NUMERIC")
     void shouldConvertNumeric_toComparisonStrategy() {
       // When
-      final ComparisonStrategy result = Strategy.NUMERIC.toComparisonStrategy();
+      final ComparisonStrategy result = Strategy.NUMERIC.toComparisonStrategy("");
 
       // Then
       assertSame(ComparisonStrategy.NUMERIC, result, "should be NUMERIC strategy");
@@ -71,7 +71,7 @@ class StrategyTest {
     @DisplayName("should convert CASE_INSENSITIVE to ComparisonStrategy.CASE_INSENSITIVE")
     void shouldConvertCaseInsensitive_toComparisonStrategy() {
       // When
-      final ComparisonStrategy result = Strategy.CASE_INSENSITIVE.toComparisonStrategy();
+      final ComparisonStrategy result = Strategy.CASE_INSENSITIVE.toComparisonStrategy("");
 
       // Then
       assertSame(
@@ -88,7 +88,7 @@ class StrategyTest {
     @DisplayName("should convert TIMESTAMP_FLEXIBLE to ComparisonStrategy.TIMESTAMP_FLEXIBLE")
     void shouldConvertTimestampFlexible_toComparisonStrategy() {
       // When
-      final ComparisonStrategy result = Strategy.TIMESTAMP_FLEXIBLE.toComparisonStrategy();
+      final ComparisonStrategy result = Strategy.TIMESTAMP_FLEXIBLE.toComparisonStrategy("");
 
       // Then
       assertSame(
@@ -105,29 +105,11 @@ class StrategyTest {
     @DisplayName("should convert NOT_NULL to ComparisonStrategy.NOT_NULL")
     void shouldConvertNotNull_toComparisonStrategy() {
       // When
-      final ComparisonStrategy result = Strategy.NOT_NULL.toComparisonStrategy();
+      final ComparisonStrategy result = Strategy.NOT_NULL.toComparisonStrategy("");
 
       // Then
       assertSame(ComparisonStrategy.NOT_NULL, result, "should be NOT_NULL strategy");
       assertEquals(ComparisonStrategy.Type.NOT_NULL, result.getType(), "should have NOT_NULL type");
-    }
-
-    /** Verifies that REGEX throws exception without pattern. */
-    @Test
-    @Tag("error")
-    @DisplayName("should throw IllegalStateException when REGEX called without pattern")
-    void shouldThrowException_whenRegexCalledWithoutPattern() {
-      // When & Then
-      final IllegalStateException exception =
-          assertThrows(
-              IllegalStateException.class,
-              () -> Strategy.REGEX.toComparisonStrategy(),
-              "should throw IllegalStateException");
-
-      final String message = exception.getMessage();
-      assertTrue(
-          message != null && message.contains("pattern"),
-          "exception message should mention pattern requirement");
     }
   }
 

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/loader/AnnotationResolver.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/loader/AnnotationResolver.java
@@ -180,10 +180,19 @@ public final class AnnotationResolver {
    *
    * @param columnStrategy the column strategy annotation
    * @return the corresponding ColumnStrategyMapping
+   * @throws IllegalArgumentException if REGEX strategy is used with an empty pattern
    */
   private ColumnStrategyMapping toColumnStrategyMapping(final ColumnStrategy columnStrategy) {
-    final var strategy = columnStrategy.strategy().toComparisonStrategy(columnStrategy.pattern());
-    return ColumnStrategyMapping.of(columnStrategy.name(), strategy);
+    try {
+      final var strategy = columnStrategy.strategy().toComparisonStrategy(columnStrategy.pattern());
+      return ColumnStrategyMapping.of(columnStrategy.name(), strategy);
+    } catch (final IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "@ColumnStrategy for column '%s' uses %s strategy but pattern is empty",
+              columnStrategy.name(), columnStrategy.strategy()),
+          e);
+    }
   }
 
   /**

--- a/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/loader/AnnotationResolverTest.java
+++ b/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/loader/AnnotationResolverTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.seijikohara.dbtester.api.annotation.ColumnStrategy;
@@ -692,6 +693,35 @@ class AnnotationResolverTest {
     }
 
     /**
+     * Verifies that resolveColumnStrategies throws exception with column name when REGEX has empty
+     * pattern.
+     *
+     * @throws NoSuchMethodException if method cannot be found
+     */
+    @Test
+    @Tag("error")
+    @DisplayName("should throw exception with column name when REGEX pattern is empty")
+    void shouldThrowExceptionWithColumnName_whenRegexPatternIsEmpty() throws NoSuchMethodException {
+      // Given
+      final var testMethod = TestClassWithRegexEmptyPattern.class.getDeclaredMethod("testMethod");
+      final var annotation = testMethod.getAnnotation(ExpectedDataSet.class).sources()[0];
+
+      // When & Then
+      final var exception =
+          assertThrows(
+              IllegalArgumentException.class,
+              () -> resolver.resolveColumnStrategies(annotation),
+              "should throw IllegalArgumentException");
+      final var message = exception.getMessage();
+      assertTrue(
+          message != null && message.contains("EMAIL"),
+          "exception message should contain column name 'EMAIL'");
+      assertTrue(
+          message != null && message.contains("REGEX"),
+          "exception message should mention REGEX strategy");
+    }
+
+    /**
      * Verifies that resolveColumnStrategies handles REGEX strategy with pattern.
      *
      * @throws NoSuchMethodException if method cannot be found
@@ -795,6 +825,19 @@ class AnnotationResolverTest {
                 columnStrategies = {
                   @ColumnStrategy(name = "lowercase_column", strategy = Strategy.STRICT)
                 }))
+    void testMethod() {}
+  }
+
+  /** Test class with REGEX strategy and empty pattern. */
+  static class TestClassWithRegexEmptyPattern {
+    /** Test constructor. */
+    TestClassWithRegexEmptyPattern() {}
+
+    /** Test method. */
+    @ExpectedDataSet(
+        sources =
+            @DataSetSource(
+                columnStrategies = {@ColumnStrategy(name = "EMAIL", strategy = Strategy.REGEX)}))
     void testMethod() {}
   }
 


### PR DESCRIPTION
## Summary

- **#102**: Wrap `AnnotationResolver.toColumnStrategyMapping()` in try-catch to provide column name context when REGEX strategy has empty pattern, improving the error message from generic to actionable (e.g., `@ColumnStrategy for column 'ID' uses REGEX strategy but pattern is empty`)
- **#105**: Change `Strategy.toComparisonStrategy()` no-arg overload from `public` to `private` to prevent direct use without pattern parameter, reducing API surface area

## Test plan

- [x] `./gradlew spotlessApply` passes
- [x] `./gradlew :db-tester-api:test` passes (Strategy visibility change)
- [x] `./gradlew :db-tester-core:test` passes (AnnotationResolver error message)
- [x] `./gradlew build` passes (full build including DocLint)
- [x] Verify REGEX empty pattern error message includes column name
- [x] Verify `toComparisonStrategy()` no-arg is no longer accessible from outside Strategy class

Closes #102
Closes #105