### PR TITLE
feat(api): add convenience factory methods for programmatic dataset construction

### DIFF
--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/dataset/Row.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/dataset/Row.java
@@ -2,7 +2,11 @@ package io.github.seijikohara.dbtester.api.dataset;
 
 import io.github.seijikohara.dbtester.api.domain.CellValue;
 import io.github.seijikohara.dbtester.api.domain.ColumnName;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a single logical row within a {@link Table}.
@@ -27,6 +31,36 @@ public interface Row {
    */
   static Row of(final Map<ColumnName, CellValue> values) {
     return new SimpleRow(Map.copyOf(values));
+  }
+
+  /**
+   * Creates a new row by pairing column names with raw values.
+   *
+   * <p>Each column name is paired with the value at the same index. Null values in the values list
+   * are mapped to {@link CellValue#NULL}.
+   *
+   * @param columns the column names as strings
+   * @param values the raw values corresponding to each column
+   * @return a new immutable row instance
+   * @throws IllegalArgumentException if columns and values have different sizes
+   */
+  static Row of(final List<String> columns, final List<? extends @Nullable Object> values) {
+    if (columns.size() != values.size()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Column count (%d) does not match value count (%d)", columns.size(), values.size()));
+    }
+    final var map =
+        IntStream.range(0, columns.size())
+            .boxed()
+            .collect(
+                Collectors.toUnmodifiableMap(
+                    i -> new ColumnName(columns.get(i)),
+                    i -> {
+                      final var val = values.get(i);
+                      return val == null ? CellValue.NULL : new CellValue(val);
+                    }));
+    return new SimpleRow(map);
   }
 
   /**

--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/dataset/Table.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/dataset/Table.java
@@ -3,6 +3,7 @@ package io.github.seijikohara.dbtester.api.dataset;
 import io.github.seijikohara.dbtester.api.domain.ColumnName;
 import io.github.seijikohara.dbtester.api.domain.TableName;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents the structure and data of a single database table.
@@ -44,6 +45,38 @@ public interface Table {
   static Table of(final String name, final List<String> columns, final List<Row> rows) {
     return new SimpleTable(
         new TableName(name), columns.stream().map(ColumnName::new).toList(), List.copyOf(rows));
+  }
+
+  /**
+   * Creates a new table from raw values without requiring explicit {@code ColumnName} or {@code
+   * CellValue} wrapping.
+   *
+   * <p>This convenience method reduces boilerplate when constructing tables programmatically. Each
+   * inner list represents a row, with values corresponding positionally to the column names. Null
+   * values are mapped to {@link io.github.seijikohara.dbtester.api.domain.CellValue#NULL}.
+   *
+   * <p>Example usage:
+   *
+   * <pre>{@code
+   * var table = Table.ofValues("USERS",
+   *     List.of("ID", "NAME", "AGE"),
+   *     List.of(
+   *         List.of(1, "Alice", 30),
+   *         List.of(2, "Bob", 25)));
+   * }</pre>
+   *
+   * @param name the table name
+   * @param columns the column names in declaration order
+   * @param rows list of rows, each row is a list of raw values corresponding to columns
+   * @return a new immutable table instance
+   * @throws IllegalArgumentException if any row has a different number of values than columns
+   */
+  static Table ofValues(
+      final String name,
+      final List<String> columns,
+      final List<List<? extends @Nullable Object>> rows) {
+    final var tableRows = rows.stream().map(values -> Row.of(columns, values)).toList();
+    return of(name, columns, tableRows);
   }
 
   /**

--- a/db-tester-api/src/test/java/io/github/seijikohara/dbtester/api/dataset/RowTest.java
+++ b/db-tester-api/src/test/java/io/github/seijikohara/dbtester/api/dataset/RowTest.java
@@ -1,11 +1,15 @@
 package io.github.seijikohara.dbtester.api.dataset;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.seijikohara.dbtester.api.domain.CellValue;
 import io.github.seijikohara.dbtester.api.domain.ColumnName;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -51,6 +55,108 @@ class RowTest {
 
       assertNotNull(row);
       assertTrue(row.getValues().isEmpty());
+    }
+  }
+
+  /** Tests for of(List, List) factory method. */
+  @Nested
+  @DisplayName("of(List<String>, List<?>)")
+  class OfColumnsAndValuesTest {
+
+    /** Tests for of(List, List) factory method. */
+    OfColumnsAndValuesTest() {}
+
+    /** Verifies that of creates Row when columns and values match. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should create row when columns and values match")
+    void shouldCreateRow_whenColumnsAndValuesMatch() {
+      // Given
+      final var columns = List.of("ID", "NAME", "AGE");
+      final List<? /* @Nullable */> values = List.of(1, "Alice", 30);
+
+      // When
+      final var row = Row.of(columns, values);
+
+      // Then
+      assertAll(
+          "row should contain all column-value pairs",
+          () -> assertEquals(3, row.getValues().size(), "should have 3 entries"),
+          () ->
+              assertEquals(
+                  new CellValue(1),
+                  row.getValue(new ColumnName("ID")),
+                  "should have correct ID value"),
+          () ->
+              assertEquals(
+                  new CellValue("Alice"),
+                  row.getValue(new ColumnName("NAME")),
+                  "should have correct NAME value"),
+          () ->
+              assertEquals(
+                  new CellValue(30),
+                  row.getValue(new ColumnName("AGE")),
+                  "should have correct AGE value"));
+    }
+
+    /** Verifies that of maps null values to CellValue.NULL. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should map null to CellValue.NULL when null provided")
+    void shouldMapNullToNullCellValue_whenNullProvided() {
+      // Given
+      final var columns = List.of("ID", "NAME");
+      final var values = new ArrayList<>();
+      values.add(1);
+      values.add(null);
+
+      // When
+      final var row = Row.of(columns, values);
+
+      // Then
+      assertAll(
+          "row should handle null value",
+          () ->
+              assertEquals(
+                  new CellValue(1), row.getValue(new ColumnName("ID")), "should have ID value"),
+          () ->
+              assertEquals(
+                  CellValue.NULL,
+                  row.getValue(new ColumnName("NAME")),
+                  "should have NULL for NAME"));
+    }
+
+    /** Verifies that of throws exception when sizes mismatch. */
+    @Test
+    @Tag("error")
+    @DisplayName("should throw exception when sizes mismatch")
+    void shouldThrowException_whenSizeMismatch() {
+      // Given
+      final var columns = List.of("ID", "NAME");
+      final List<? /* @Nullable */> values = List.of(1);
+
+      // When & Then
+      final var exception =
+          assertThrows(
+              IllegalArgumentException.class,
+              () -> Row.of(columns, values),
+              "should throw IllegalArgumentException");
+      final var message = exception.getMessage();
+      assertTrue(
+          message != null && message.contains("does not match"),
+          "exception should mention size mismatch");
+    }
+
+    /** Verifies that of creates empty row when both lists are empty. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should create empty row when both lists are empty")
+    void shouldCreateEmptyRow_whenBothListsAreEmpty() {
+      // When
+      final var row = Row.of(List.of(), List.of());
+
+      // Then
+      assertTrue(row.getValues().isEmpty(), "row should have no values");
     }
   }
 

--- a/db-tester-api/src/test/java/io/github/seijikohara/dbtester/api/dataset/TableTest.java
+++ b/db-tester-api/src/test/java/io/github/seijikohara/dbtester/api/dataset/TableTest.java
@@ -1,12 +1,15 @@
 package io.github.seijikohara.dbtester.api.dataset;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.seijikohara.dbtester.api.domain.CellValue;
 import io.github.seijikohara.dbtester.api.domain.ColumnName;
 import io.github.seijikohara.dbtester.api.domain.TableName;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
@@ -97,6 +100,109 @@ class TableTest {
 
       assertNotNull(table);
       assertTrue(table.getColumns().isEmpty());
+    }
+  }
+
+  /** Tests for ofValues(String, List, List) factory method. */
+  @Nested
+  @DisplayName("ofValues(String, List<String>, List<List<?>>)")
+  class OfValuesTest {
+
+    /** Tests for ofValues factory method. */
+    OfValuesTest() {}
+
+    /** Verifies that ofValues creates Table with valid input. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should create table when valid input provided")
+    void shouldCreateTable_whenValidInputProvided() {
+      // Given
+      final var columns = List.of("ID", "NAME", "AGE");
+      final List<List<? /* @Nullable */>> rows =
+          List.of(List.of(1, "Alice", 30), List.of(2, "Bob", 25));
+
+      // When
+      final var table = Table.ofValues("USERS", columns, rows);
+
+      // Then
+      assertAll(
+          "table should contain correct structure and data",
+          () -> assertEquals("USERS", table.getName().value(), "should have correct table name"),
+          () -> assertEquals(3, table.getColumns().size(), "should have 3 columns"),
+          () -> assertEquals("ID", table.getColumns().get(0).value(), "first column should be ID"),
+          () ->
+              assertEquals(
+                  "NAME", table.getColumns().get(1).value(), "second column should be NAME"),
+          () ->
+              assertEquals("AGE", table.getColumns().get(2).value(), "third column should be AGE"),
+          () -> assertEquals(2, table.getRowCount(), "should have 2 rows"));
+    }
+
+    /** Verifies that ofValues handles null values in rows. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should map null values to CellValue.NULL")
+    void shouldHandleNullValues_whenNullInRow() {
+      // Given
+      final var columns = List.of("ID", "NAME");
+      final var rowWithNull = new ArrayList<>();
+      rowWithNull.add(1);
+      rowWithNull.add(null);
+      final List<List<? /* @Nullable */>> rows = List.of(rowWithNull);
+
+      // When
+      final var table = Table.ofValues("USERS", columns, rows);
+
+      // Then
+      final var row = table.getRows().get(0);
+      assertAll(
+          "row should handle null value correctly",
+          () ->
+              assertEquals(
+                  new CellValue(1), row.getValue(new ColumnName("ID")), "should have ID value"),
+          () ->
+              assertEquals(
+                  CellValue.NULL,
+                  row.getValue(new ColumnName("NAME")),
+                  "should have NULL for NAME"));
+    }
+
+    /** Verifies that ofValues throws exception when row size mismatches column count. */
+    @Test
+    @Tag("error")
+    @DisplayName("should throw exception when row size mismatches column count")
+    void shouldThrowException_whenRowSizeMismatch() {
+      // Given
+      final var columns = List.of("ID", "NAME");
+      final List<List<? /* @Nullable */>> rows = List.of(List.of(1)); // Only 1 value for 2 columns
+
+      // When & Then
+      final var exception =
+          assertThrows(
+              IllegalArgumentException.class,
+              () -> Table.ofValues("USERS", columns, rows),
+              "should throw IllegalArgumentException");
+      final var message = exception.getMessage();
+      assertTrue(
+          message != null && message.contains("does not match"),
+          "exception should mention size mismatch");
+    }
+
+    /** Verifies that ofValues creates empty table when no rows provided. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should create empty table when no rows provided")
+    void shouldCreateEmptyTable_whenNoRowsProvided() {
+      // When
+      final var table = Table.ofValues("EMPTY", List.of("ID"), List.of());
+
+      // Then
+      assertAll(
+          "empty table should have correct structure",
+          () -> assertEquals("EMPTY", table.getName().value(), "should have correct table name"),
+          () -> assertEquals(1, table.getColumns().size(), "should have 1 column"),
+          () -> assertEquals(0, table.getRowCount(), "should have 0 rows"),
+          () -> assertTrue(table.getRows().isEmpty(), "rows should be empty"));
     }
   }
 

--- a/docs/specs/ja/public-api.md
+++ b/docs/specs/ja/public-api.md
@@ -254,6 +254,7 @@ void testWithColumnStrategies() { }
 |----------|---------|------|
 | `of(TableName, List<ColumnName>, List<Row>)` | `Table` | 型安全な名前でテーブルを作成します |
 | `of(String, List<String>, List<Row>)` | `Table` | 文字列名でテーブルを作成します（簡易版） |
+| `ofValues(String, List<String>, List<List<?>>)` | `Table` | 生の値からテーブルを作成します（ラッピング不要の簡易版） |
 
 **インスタンスメソッド**:
 
@@ -282,6 +283,7 @@ void testWithColumnStrategies() { }
 | メソッド | 戻り値型 | 説明 |
 |----------|---------|------|
 | `of(Map<ColumnName, CellValue>)` | `Row` | 指定されたカラム値ペアで行を作成します |
+| `of(List<String>, List<?>)` | `Row` | カラム名と生の値をペアにして行を作成します（簡易版） |
 
 **インスタンスメソッド**:
 

--- a/docs/specs/public-api.md
+++ b/docs/specs/public-api.md
@@ -247,6 +247,7 @@ Represents the structure and data of a database table.
 |--------|-------------|-------------|
 | `of(TableName, List<ColumnName>, List<Row>)` | `Table` | Creates a table with type-safe names |
 | `of(String, List<String>, List<Row>)` | `Table` | Creates a table with string names (convenience) |
+| `ofValues(String, List<String>, List<List<?>>)` | `Table` | Creates a table from raw values without wrapping (convenience) |
 
 **Instance Methods**:
 
@@ -274,6 +275,7 @@ Represents a single database record.
 | Method | Return Type | Description |
 |--------|-------------|-------------|
 | `of(Map<ColumnName, CellValue>)` | `Row` | Creates a row with the specified column-value pairs |
+| `of(List<String>, List<?>)` | `Row` | Creates a row by pairing column names with raw values (convenience) |
 
 **Instance Methods**:
 

--- a/examples/db-tester-example-junit/src/test/java/example/feature/ProgrammaticAssertionApiTest.java
+++ b/examples/db-tester-example-junit/src/test/java/example/feature/ProgrammaticAssertionApiTest.java
@@ -482,6 +482,41 @@ final class ProgrammaticAssertionApiTest {
   }
 
   /**
+   * Demonstrates concise table construction using {@link Table#ofValues}.
+   *
+   * <p>This test shows the convenience factory method that eliminates boilerplate from {@code
+   * ColumnName} and {@code CellValue} wrapping. Compare with {@link
+   * #shouldValidateQueryResultsUsingAssertEqualsByQuery()} which uses the verbose API.
+   *
+   * @throws Exception if test fails
+   */
+  @Test
+  @Tag("normal")
+  @DisplayName("should demonstrate concise table construction using Table.ofValues")
+  @DataSet
+  void shouldDemonstrateConciseTableConstructionUsingOfValues() throws Exception {
+    // Given
+    logger.info("Running Table.ofValues demonstration");
+
+    // When & Then
+    // Build expected table concisely using ofValues
+    final var expectedTable =
+        Table.ofValues(
+            "QUERY_RESULT",
+            List.of("ID", "COLUMN1", "COLUMN2"),
+            List.of(List.of(1, "Value1", 100), List.of(2, "Value2", 200)));
+
+    // Use DatabaseAssertion.assertEqualsByQuery to validate query results
+    DatabaseAssertion.assertEqualsByQuery(
+        expectedTable,
+        dataSource,
+        "QUERY_RESULT",
+        "SELECT ID, COLUMN1, COLUMN2 FROM TABLE1 WHERE ID IN (1, 2) ORDER BY ID");
+
+    logger.info("Table.ofValues demonstration completed");
+  }
+
+  /**
    * Demonstrates using {@link DatabaseAssertion#assertEqualsByQuery} with TableSet for multi-table
    * scenarios.
    *


### PR DESCRIPTION
## Summary

- **#103**: Add `Table.ofValues(String, List<String>, List<List<?>>)` for concise table construction without explicit `ColumnName`/`CellValue` wrapping
- Add `Row.of(List<String>, List<?>)` to zip column names with raw values into a Row
- Null values in row data are automatically mapped to `CellValue.NULL`
- Add `Table.ofValues` demonstration to `ProgrammaticAssertionApiTest` in examples
- Update `public-api.md` documentation (English and Japanese)

### Before (verbose)
```java
final var columnId = new ColumnName("ID");
final var columnValue = new ColumnName("COLUMN1");
final var row = Row.of(Map.of(
    columnId, new CellValue(1),
    columnValue, new CellValue("Value1")));
final var table = Table.of(new TableName("TABLE1"),
    List.of(columnId, columnValue), List.of(row));
```

### After (concise)
```java
final var table = Table.ofValues("TABLE1",
    List.of("ID", "COLUMN1"),
    List.of(List.of(1, "Value1")));
```

## Test plan

- [x] `./gradlew spotlessApply` passes
- [x] `./gradlew :db-tester-api:test` passes (Table and Row new factory methods)
- [x] `./gradlew build` passes (full build including examples and DocLint)
- [x] Verify `Table.ofValues` creates correct table structure
- [x] Verify `Row.of(List, List)` creates correct row with value mapping
- [x] Verify null values are mapped to `CellValue.NULL`
- [x] Verify size mismatch throws `IllegalArgumentException`
- [x] Verify `ProgrammaticAssertionApiTest` example passes

Closes #103