### PR TITLE
feat: add JSON/YAML data format support

### DIFF
--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/config/DataFormat.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/config/DataFormat.java
@@ -25,7 +25,23 @@ public enum DataFormat {
    *
    * <p>Files with the {@code .tsv} extension. Fields are separated by tabs.
    */
-  TSV(".tsv");
+  TSV(".tsv"),
+
+  /**
+   * JavaScript Object Notation format.
+   *
+   * <p>Files with the {@code .json} extension. Each file contains an array of objects representing
+   * table rows.
+   */
+  JSON(".json"),
+
+  /**
+   * YAML Ain't Markup Language format.
+   *
+   * <p>Files with the {@code .yaml} extension. Each file contains a list of mappings representing
+   * table rows.
+   */
+  YAML(".yaml");
 
   /** The file extension associated with this format (including the leading dot). */
   private final String extension;

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/format/json/JsonFormatProvider.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/format/json/JsonFormatProvider.java
@@ -1,0 +1,77 @@
+package io.github.seijikohara.dbtester.internal.format.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.seijikohara.dbtester.api.config.ConventionSettings;
+import io.github.seijikohara.dbtester.api.dataset.TableSet;
+import io.github.seijikohara.dbtester.internal.domain.FileExtension;
+import io.github.seijikohara.dbtester.internal.format.parser.StructuredFormatParser;
+import io.github.seijikohara.dbtester.internal.format.spi.FormatProvider;
+import java.nio.file.Path;
+
+/**
+ * Format provider for JSON (JavaScript Object Notation) files.
+ *
+ * <p>This provider parses JSON files from a directory and converts them into a {@link TableSet}.
+ * Each JSON file represents a single database table, where the filename (without extension) becomes
+ * the table name. The JSON format uses an array of objects, with each object representing a row and
+ * key-value pairs representing column-value mappings.
+ *
+ * <p>Example JSON file content:
+ *
+ * <pre>{@code
+ * [
+ *   {"ID": 1, "NAME": "Alice", "EMAIL": "alice@example.com"},
+ *   {"ID": 2, "NAME": "Bob", "EMAIL": "bob@example.com"}
+ * ]
+ * }</pre>
+ *
+ * <p>Column order is determined by the first object's key order. Null values in JSON are preserved
+ * as NULL database values. All non-null values are converted to strings.
+ *
+ * <p>Table ordering is determined by the load order file (default: {@value
+ * ConventionSettings#DEFAULT_LOAD_ORDER_FILE_NAME}) if present, otherwise tables are loaded in
+ * alphabetical order by filename.
+ *
+ * <p>This class is stateless and thread-safe.
+ *
+ * @see FormatProvider
+ * @see StructuredFormatParser
+ */
+public final class JsonFormatProvider implements FormatProvider {
+
+  /** The file extension for JSON files. */
+  private static final FileExtension FILE_EXTENSION = new FileExtension("json");
+
+  /** The parser for JSON files. */
+  private final StructuredFormatParser parser;
+
+  /**
+   * Creates a new JSON format provider.
+   *
+   * <p>This constructor is used by ServiceLoader for automatic discovery.
+   */
+  public JsonFormatProvider() {
+    this.parser = new StructuredFormatParser(".json", new ObjectMapper());
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @return the JSON file extension
+   */
+  @Override
+  public FileExtension supportedFileExtension() {
+    return FILE_EXTENSION;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @param directory the directory containing JSON files
+   * @return the parsed dataset containing all tables
+   */
+  @Override
+  public TableSet parse(final Path directory) {
+    return parser.parse(directory);
+  }
+}

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/format/json/package-info.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/format/json/package-info.java
@@ -1,0 +1,13 @@
+/**
+ * JSON format provider for parsing JSON dataset files.
+ *
+ * <p>This package provides the {@link
+ * io.github.seijikohara.dbtester.internal.format.json.JsonFormatProvider} implementation of the
+ * {@link io.github.seijikohara.dbtester.internal.format.spi.FormatProvider} SPI for JSON files.
+ *
+ * @see io.github.seijikohara.dbtester.internal.format.spi.FormatProvider
+ */
+@NullMarked
+package io.github.seijikohara.dbtester.internal.format.json;
+
+import org.jspecify.annotations.NullMarked;

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/format/parser/StructuredFormatParser.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/format/parser/StructuredFormatParser.java
@@ -1,0 +1,217 @@
+package io.github.seijikohara.dbtester.internal.format.parser;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.seijikohara.dbtester.api.dataset.Row;
+import io.github.seijikohara.dbtester.api.dataset.Table;
+import io.github.seijikohara.dbtester.api.dataset.TableSet;
+import io.github.seijikohara.dbtester.api.domain.CellValue;
+import io.github.seijikohara.dbtester.api.domain.ColumnName;
+import io.github.seijikohara.dbtester.api.domain.TableName;
+import io.github.seijikohara.dbtester.api.exception.DataSetLoadException;
+import io.github.seijikohara.dbtester.internal.dataset.SimpleRow;
+import io.github.seijikohara.dbtester.internal.dataset.SimpleTable;
+import io.github.seijikohara.dbtester.internal.dataset.SimpleTableSet;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Parser for structured format files (JSON, YAML) using Jackson ObjectMapper.
+ *
+ * <p>This parser reads structured files from a directory and converts them into a {@link TableSet}.
+ * Each file represents a single database table, where the filename (without extension) becomes the
+ * table name. The file contains an array of objects, where each object represents a row with
+ * key-value pairs for columns.
+ *
+ * <p>Column order is determined by the first row's key order. Null values in JSON/YAML are
+ * converted to {@link CellValue#NULL}. All non-null values are converted to strings.
+ *
+ * <p>This class is stateless and thread-safe. Instances can be safely shared between threads.
+ *
+ * @see TableSet
+ * @see ObjectMapper
+ */
+public final class StructuredFormatParser {
+
+  /** Logger for this class. */
+  private static final Logger logger = LoggerFactory.getLogger(StructuredFormatParser.class);
+
+  /** Type reference for parsing array of maps. */
+  private static final TypeReference<List<Map<String, Object>>> ROWS_TYPE = new RowsTypeReference();
+
+  /**
+   * Type reference for parsing array of maps.
+   *
+   * <p>Jackson requires a concrete subclass of TypeReference to preserve generic type information
+   * at runtime for proper deserialization of the nested generic structure.
+   */
+  private static final class RowsTypeReference extends TypeReference<List<Map<String, Object>>> {
+
+    /** Creates a new instance. */
+    RowsTypeReference() {
+      super();
+    }
+  }
+
+  /** The file extension (including dot). */
+  private final String extension;
+
+  /** Jackson ObjectMapper for parsing. */
+  private final ObjectMapper objectMapper;
+
+  /**
+   * Creates a new parser with the specified configuration.
+   *
+   * @param extension the file extension (e.g., ".json", ".yaml")
+   * @param objectMapper the Jackson ObjectMapper configured for the format
+   */
+  public StructuredFormatParser(final String extension, final ObjectMapper objectMapper) {
+    this.extension = extension;
+    this.objectMapper = objectMapper;
+  }
+
+  /**
+   * Parses all matching files in the specified directory into a TableSet.
+   *
+   * @param directory the directory containing data files
+   * @return the parsed dataset containing all tables
+   * @throws DataSetLoadException if parsing fails
+   */
+  public TableSet parse(final Path directory) {
+    if (!Files.isDirectory(directory)) {
+      throw new DataSetLoadException(
+          String.format("Not a directory: %s", directory.toAbsolutePath()));
+    }
+
+    logger.debug("Parsing {} files from directory: {}", extension, directory);
+
+    final var files = listDataFiles(directory);
+    final var tables = files.stream().sorted().map(this::parseFile).toList();
+
+    logger.debug("Parsed {} tables from directory: {}", tables.size(), directory);
+
+    return new SimpleTableSet(tables);
+  }
+
+  /**
+   * Lists all data files matching the configured extension in the directory.
+   *
+   * @param directory the directory to scan
+   * @return list of file paths
+   */
+  private List<Path> listDataFiles(final Path directory) {
+    try (final Stream<Path> paths = Files.list(directory)) {
+      return paths
+          .filter(Files::isRegularFile)
+          .filter(path -> path.toString().toLowerCase(Locale.ROOT).endsWith(extension))
+          .toList();
+    } catch (final IOException e) {
+      throw new DataSetLoadException(
+          String.format("Failed to list files in directory: %s", directory), e);
+    }
+  }
+
+  /**
+   * Parses a single file into a Table.
+   *
+   * @param file the file to parse
+   * @return the parsed table
+   */
+  private Table parseFile(final Path file) {
+    final var tableName = new TableName(extractTableName(file));
+
+    logger.debug("Parsing file: {} as table: {}", file.getFileName(), tableName.value());
+
+    try {
+      final List<Map<String, Object>> rawRows = objectMapper.readValue(file.toFile(), ROWS_TYPE);
+
+      if (rawRows.isEmpty()) {
+        throw new DataSetLoadException(
+            String.format(
+                "File contains no rows (column definition required): %s", file.toAbsolutePath()));
+      }
+
+      // Determine column order from the first row
+      final var columnNames = extractColumnNames(rawRows.getFirst());
+
+      // Convert all rows
+      final var rows = rawRows.stream().map(rawRow -> createRow(columnNames, rawRow)).toList();
+
+      logger.debug(
+          "Parsed table {} with {} columns and {} rows",
+          tableName.value(),
+          columnNames.size(),
+          rows.size());
+
+      return new SimpleTable(tableName, columnNames, rows);
+    } catch (final IOException e) {
+      throw new DataSetLoadException(
+          String.format("Failed to parse file: %s", file.toAbsolutePath()), e);
+    }
+  }
+
+  /**
+   * Extracts column names from the first row's keys.
+   *
+   * @param firstRow the first row map
+   * @return list of column names in key order
+   */
+  private List<ColumnName> extractColumnNames(final Map<String, Object> firstRow) {
+    return firstRow.keySet().stream().map(ColumnName::new).toList();
+  }
+
+  /**
+   * Extracts the table name from a file path.
+   *
+   * @param file the file path
+   * @return the table name (filename without extension)
+   */
+  private String extractTableName(final Path file) {
+    final var fileName = file.getFileName().toString();
+    final var dotIndex = fileName.lastIndexOf('.');
+    return dotIndex > 0 ? fileName.substring(0, dotIndex) : fileName;
+  }
+
+  /**
+   * Creates a Row from column names and a raw row map.
+   *
+   * @param columnNames the column names
+   * @param rawRow the raw row map from JSON/YAML
+   * @return the created row
+   */
+  private Row createRow(final List<ColumnName> columnNames, final Map<String, Object> rawRow) {
+    final var rowValues = new LinkedHashMap<ColumnName, CellValue>();
+
+    for (final var columnName : columnNames) {
+      final var rawValue = rawRow.get(columnName.value());
+      rowValues.put(columnName, toCellValue(rawValue));
+    }
+
+    return new SimpleRow(rowValues);
+  }
+
+  /**
+   * Converts a raw object value to a CellValue.
+   *
+   * <p>Null values are converted to {@link CellValue#NULL}. All non-null values are converted to
+   * their string representation.
+   *
+   * @param rawValue the raw object value
+   * @return the CellValue
+   */
+  private CellValue toCellValue(final @Nullable Object rawValue) {
+    if (rawValue == null) {
+      return CellValue.NULL;
+    }
+    return new CellValue(rawValue.toString());
+  }
+}

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/format/yaml/YamlFormatProvider.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/format/yaml/YamlFormatProvider.java
@@ -1,0 +1,83 @@
+package io.github.seijikohara.dbtester.internal.format.yaml;
+
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import io.github.seijikohara.dbtester.api.config.ConventionSettings;
+import io.github.seijikohara.dbtester.api.dataset.TableSet;
+import io.github.seijikohara.dbtester.internal.domain.FileExtension;
+import io.github.seijikohara.dbtester.internal.format.parser.StructuredFormatParser;
+import io.github.seijikohara.dbtester.internal.format.spi.FormatProvider;
+import java.nio.file.Path;
+
+/**
+ * Format provider for YAML (YAML Ain't Markup Language) files.
+ *
+ * <p>This provider parses YAML files from a directory and converts them into a {@link TableSet}.
+ * Each YAML file represents a single database table, where the filename (without extension) becomes
+ * the table name. The YAML format uses a list of mappings, with each mapping representing a row and
+ * key-value pairs representing column-value mappings.
+ *
+ * <p>Example YAML file content:
+ *
+ * <pre>{@code
+ * - ID: 1
+ *   NAME: Alice
+ *   EMAIL: alice@example.com
+ * - ID: 2
+ *   NAME: Bob
+ *   EMAIL: bob@example.com
+ * }</pre>
+ *
+ * <p>Column order is determined by the first mapping's key order. Null values in YAML (represented
+ * by {@code null} or {@code ~}) are preserved as NULL database values. All non-null values are
+ * converted to strings.
+ *
+ * <p>YAML comments are supported and ignored during parsing.
+ *
+ * <p>Table ordering is determined by the load order file (default: {@value
+ * ConventionSettings#DEFAULT_LOAD_ORDER_FILE_NAME}) if present, otherwise tables are loaded in
+ * alphabetical order by filename.
+ *
+ * <p>This class is stateless and thread-safe.
+ *
+ * @see FormatProvider
+ * @see StructuredFormatParser
+ */
+public final class YamlFormatProvider implements FormatProvider {
+
+  /** The file extension for YAML files. */
+  private static final FileExtension FILE_EXTENSION = new FileExtension("yaml");
+
+  /** The parser for YAML files. */
+  private final StructuredFormatParser parser;
+
+  /**
+   * Creates a new YAML format provider.
+   *
+   * <p>This constructor is used by ServiceLoader for automatic discovery.
+   */
+  public YamlFormatProvider() {
+    this.parser = new StructuredFormatParser(".yaml", new YAMLMapper(new YAMLFactory()));
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @return the YAML file extension
+   */
+  @Override
+  public FileExtension supportedFileExtension() {
+    return FILE_EXTENSION;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @param directory the directory containing YAML files
+   * @return the parsed dataset containing all tables
+   */
+  @Override
+  public TableSet parse(final Path directory) {
+    return parser.parse(directory);
+  }
+}

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/format/yaml/package-info.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/format/yaml/package-info.java
@@ -1,0 +1,13 @@
+/**
+ * YAML format provider for parsing YAML dataset files.
+ *
+ * <p>This package provides the {@link
+ * io.github.seijikohara.dbtester.internal.format.yaml.YamlFormatProvider} implementation of the
+ * {@link io.github.seijikohara.dbtester.internal.format.spi.FormatProvider} SPI for YAML files.
+ *
+ * @see io.github.seijikohara.dbtester.internal.format.spi.FormatProvider
+ */
+@NullMarked
+package io.github.seijikohara.dbtester.internal.format.yaml;
+
+import org.jspecify.annotations.NullMarked;

--- a/db-tester-core/src/main/java/module-info.java
+++ b/db-tester-core/src/main/java/module-info.java
@@ -34,5 +34,7 @@ module io.github.seijikohara.dbtester.core {
   // Internal format providers
   provides io.github.seijikohara.dbtester.internal.format.spi.FormatProvider with
       io.github.seijikohara.dbtester.internal.format.csv.CsvFormatProvider,
-      io.github.seijikohara.dbtester.internal.format.tsv.TsvFormatProvider;
+      io.github.seijikohara.dbtester.internal.format.tsv.TsvFormatProvider,
+      io.github.seijikohara.dbtester.internal.format.json.JsonFormatProvider,
+      io.github.seijikohara.dbtester.internal.format.yaml.YamlFormatProvider;
 }

--- a/db-tester-core/src/main/resources/META-INF/services/io.github.seijikohara.dbtester.internal.format.spi.FormatProvider
+++ b/db-tester-core/src/main/resources/META-INF/services/io.github.seijikohara.dbtester.internal.format.spi.FormatProvider
@@ -1,2 +1,4 @@
 io.github.seijikohara.dbtester.internal.format.csv.CsvFormatProvider
 io.github.seijikohara.dbtester.internal.format.tsv.TsvFormatProvider
+io.github.seijikohara.dbtester.internal.format.json.JsonFormatProvider
+io.github.seijikohara.dbtester.internal.format.yaml.YamlFormatProvider

--- a/db-tester-core/src/test/java/io/github/seijikohara/dbtester/api/config/DataFormatTest.java
+++ b/db-tester-core/src/test/java/io/github/seijikohara/dbtester/api/config/DataFormatTest.java
@@ -83,6 +83,72 @@ class DataFormatTest {
     }
   }
 
+  /** Tests for the JSON format. */
+  @Nested
+  @DisplayName("JSON format")
+  class JsonFormat {
+
+    /** Tests for the JSON format. */
+    JsonFormat() {}
+
+    /** Verifies that JSON format has correct extension. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should have .json extension")
+    void shouldHaveJsonExtension() {
+      // When
+      final var extension = DataFormat.JSON.getExtension();
+
+      // Then
+      assertEquals(".json", extension, "JSON extension should be .json");
+    }
+
+    /** Verifies that JSON format name is JSON. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should have name JSON")
+    void shouldHaveNameJson() {
+      // When
+      final var name = DataFormat.JSON.name();
+
+      // Then
+      assertEquals("JSON", name, "name should be JSON");
+    }
+  }
+
+  /** Tests for the YAML format. */
+  @Nested
+  @DisplayName("YAML format")
+  class YamlFormat {
+
+    /** Tests for the YAML format. */
+    YamlFormat() {}
+
+    /** Verifies that YAML format has correct extension. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should have .yaml extension")
+    void shouldHaveYamlExtension() {
+      // When
+      final var extension = DataFormat.YAML.getExtension();
+
+      // Then
+      assertEquals(".yaml", extension, "YAML extension should be .yaml");
+    }
+
+    /** Verifies that YAML format name is YAML. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should have name YAML")
+    void shouldHaveNameYaml() {
+      // When
+      final var name = DataFormat.YAML.name();
+
+      // Then
+      assertEquals("YAML", name, "name should be YAML");
+    }
+  }
+
   /** Tests for enum values. */
   @Nested
   @DisplayName("values() method")
@@ -103,9 +169,11 @@ class DataFormatTest {
       assertAll(
           "should have all formats",
           () -> assertNotNull(values, "values should not be null"),
-          () -> assertEquals(2, values.length, "should have two formats"),
+          () -> assertEquals(4, values.length, "should have four formats"),
           () -> assertEquals(DataFormat.CSV, values[0], "first should be CSV"),
-          () -> assertEquals(DataFormat.TSV, values[1], "second should be TSV"));
+          () -> assertEquals(DataFormat.TSV, values[1], "second should be TSV"),
+          () -> assertEquals(DataFormat.JSON, values[2], "third should be JSON"),
+          () -> assertEquals(DataFormat.YAML, values[3], "fourth should be YAML"));
     }
   }
 
@@ -139,6 +207,30 @@ class DataFormatTest {
 
       // Then
       assertEquals(DataFormat.TSV, format, "should return TSV");
+    }
+
+    /** Verifies that valueOf returns correct format for JSON. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return JSON for valueOf(\"JSON\")")
+    void shouldReturnJsonForValueOfJson() {
+      // When
+      final var format = DataFormat.valueOf("JSON");
+
+      // Then
+      assertEquals(DataFormat.JSON, format, "should return JSON");
+    }
+
+    /** Verifies that valueOf returns correct format for YAML. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return YAML for valueOf(\"YAML\")")
+    void shouldReturnYamlForValueOfYaml() {
+      // When
+      final var format = DataFormat.valueOf("YAML");
+
+      // Then
+      assertEquals(DataFormat.YAML, format, "should return YAML");
     }
   }
 

--- a/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/format/json/JsonFormatProviderTest.java
+++ b/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/format/json/JsonFormatProviderTest.java
@@ -1,0 +1,337 @@
+package io.github.seijikohara.dbtester.internal.format.json;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.seijikohara.dbtester.api.domain.CellValue;
+import io.github.seijikohara.dbtester.api.domain.ColumnName;
+import io.github.seijikohara.dbtester.api.exception.DataSetLoadException;
+import io.github.seijikohara.dbtester.internal.domain.FileExtension;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Unit tests for {@link JsonFormatProvider}. */
+@DisplayName("JsonFormatProvider")
+class JsonFormatProviderTest {
+
+  /** Tests for the JsonFormatProvider class. */
+  JsonFormatProviderTest() {}
+
+  /** The provider instance under test. */
+  private JsonFormatProvider provider;
+
+  /** Sets up test fixtures before each test. */
+  @BeforeEach
+  void setUp() {
+    provider = new JsonFormatProvider();
+  }
+
+  /** Tests for the constructor. */
+  @Nested
+  @DisplayName("constructor")
+  class ConstructorMethod {
+
+    /** Tests for the constructor. */
+    ConstructorMethod() {}
+
+    /** Verifies that constructor creates instance when called. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should create instance when called")
+    void shouldCreateInstance_whenCalled() {
+      // When
+      final var instance = new JsonFormatProvider();
+
+      // Then
+      assertNotNull(instance, "instance should not be null");
+    }
+  }
+
+  /** Tests for the supportedFileExtension() method. */
+  @Nested
+  @DisplayName("supportedFileExtension() method")
+  class SupportedFileExtensionMethod {
+
+    /** Tests for the supportedFileExtension method. */
+    SupportedFileExtensionMethod() {}
+
+    /** Verifies that supportedFileExtension returns json extension. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return json extension when called")
+    void shouldReturnJsonExtension_whenCalled() {
+      // When
+      final var result = provider.supportedFileExtension();
+
+      // Then
+      assertEquals(new FileExtension("json"), result, "should return json extension");
+    }
+  }
+
+  /** Tests for the parse() method. */
+  @Nested
+  @DisplayName("parse(Path) method")
+  class ParseMethod {
+
+    /** Tests for the parse method. */
+    ParseMethod() {}
+
+    /**
+     * Verifies that parse returns dataset when valid JSON file exists.
+     *
+     * @param tempDir temporary directory for test files
+     * @throws IOException if file operations fail
+     */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return dataset when valid JSON file exists")
+    void shouldReturnDataSet_whenValidJsonFileExists(final @TempDir Path tempDir)
+        throws IOException {
+      // Given
+      createJsonFile(
+          tempDir,
+          "users.json",
+          """
+          [
+            {"ID": 1, "NAME": "John", "EMAIL": "john@example.com"}
+          ]
+          """);
+
+      // When
+      final var result = provider.parse(tempDir);
+
+      // Then
+      assertAll(
+          "dataset should contain parsed table",
+          () -> assertNotNull(result, "result should not be null"),
+          () -> assertEquals(1, result.getTables().size(), "should have one table"));
+
+      final var table = result.getTables().getFirst();
+      assertAll(
+          "table should have correct structure",
+          () -> assertEquals("users", table.getName().value(), "should have correct table name"),
+          () -> assertEquals(3, table.getColumns().size(), "should have 3 columns"),
+          () -> assertEquals(1, table.getRowCount(), "should have 1 row"));
+    }
+
+    /**
+     * Verifies that parse handles multiple JSON files.
+     *
+     * @param tempDir temporary directory for test files
+     * @throws IOException if file operations fail
+     */
+    @Test
+    @Tag("normal")
+    @DisplayName("should handle multiple JSON files when multiple files exist")
+    void shouldHandleMultipleFiles_whenMultipleFilesExist(final @TempDir Path tempDir)
+        throws IOException {
+      // Given
+      createJsonFile(tempDir, "users.json", "[{\"ID\": 1, \"NAME\": \"John\"}]");
+      createJsonFile(tempDir, "orders.json", "[{\"ID\": 1, \"USER_ID\": 1, \"AMOUNT\": \"100\"}]");
+
+      // When
+      final var result = provider.parse(tempDir);
+
+      // Then
+      assertEquals(2, result.getTables().size(), "should have two tables");
+    }
+
+    /**
+     * Verifies that parse handles NULL values correctly.
+     *
+     * @param tempDir temporary directory for test files
+     * @throws IOException if file operations fail
+     */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should handle NULL values when null exists in JSON")
+    void shouldHandleNullValues_whenNullExistsInJson(final @TempDir Path tempDir)
+        throws IOException {
+      // Given
+      createJsonFile(
+          tempDir,
+          "users.json",
+          """
+          [
+            {"ID": 1, "NAME": null, "EMAIL": "john@example.com"}
+          ]
+          """);
+
+      // When
+      final var result = provider.parse(tempDir);
+
+      // Then
+      final var table = result.getTables().getFirst();
+      final var row = table.getRows().getFirst();
+      final var nameValue = row.getValue(new ColumnName("NAME"));
+
+      assertEquals(CellValue.NULL, nameValue, "null cell should be NULL");
+    }
+
+    /**
+     * Verifies that parse handles multiple rows.
+     *
+     * @param tempDir temporary directory for test files
+     * @throws IOException if file operations fail
+     */
+    @Test
+    @Tag("normal")
+    @DisplayName("should handle multiple rows when array contains multiple objects")
+    void shouldHandleMultipleRows_whenArrayContainsMultipleObjects(final @TempDir Path tempDir)
+        throws IOException {
+      // Given
+      createJsonFile(
+          tempDir,
+          "users.json",
+          """
+          [
+            {"ID": 1, "NAME": "Alice"},
+            {"ID": 2, "NAME": "Bob"},
+            {"ID": 3, "NAME": "Charlie"}
+          ]
+          """);
+
+      // When
+      final var result = provider.parse(tempDir);
+
+      // Then
+      final var table = result.getTables().getFirst();
+      assertEquals(3, table.getRowCount(), "should have 3 rows");
+    }
+
+    /**
+     * Verifies that parse converts numeric values to strings.
+     *
+     * @param tempDir temporary directory for test files
+     * @throws IOException if file operations fail
+     */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should convert numeric values to strings")
+    void shouldConvertNumericValues_toStrings(final @TempDir Path tempDir) throws IOException {
+      // Given
+      createJsonFile(
+          tempDir,
+          "products.json",
+          """
+          [
+            {"ID": 1, "PRICE": 99.99, "QUANTITY": 10}
+          ]
+          """);
+
+      // When
+      final var result = provider.parse(tempDir);
+
+      // Then
+      final var table = result.getTables().getFirst();
+      final var row = table.getRows().getFirst();
+      final var priceValue = row.getValue(new ColumnName("PRICE"));
+      final var quantityValue = row.getValue(new ColumnName("QUANTITY"));
+
+      assertAll(
+          "numeric values should be converted to strings",
+          () -> assertNotNull(priceValue.value(), "price value should not be null"),
+          () ->
+              assertTrue(
+                  priceValue.value() != null && priceValue.value().toString().contains("99.99"),
+                  "price should be converted to string"),
+          () -> assertNotNull(quantityValue.value(), "quantity value should not be null"),
+          () ->
+              assertEquals(
+                  "10",
+                  quantityValue.value() != null ? quantityValue.value().toString() : "",
+                  "quantity should be string"));
+    }
+
+    /**
+     * Verifies that parse throws exception when file is empty array.
+     *
+     * @param tempDir temporary directory for test files
+     * @throws IOException if file operations fail
+     */
+    @Test
+    @Tag("error")
+    @DisplayName("should throw exception when JSON array is empty")
+    void shouldThrowException_whenJsonArrayIsEmpty(final @TempDir Path tempDir) throws IOException {
+      // Given
+      createJsonFile(tempDir, "users.json", "[]");
+
+      // When & Then
+      final var exception =
+          assertThrows(
+              DataSetLoadException.class,
+              () -> provider.parse(tempDir),
+              "should throw DataSetLoadException");
+
+      final var message = exception.getMessage();
+      assertTrue(
+          message != null && message.contains("no rows"),
+          "exception message should mention no rows");
+    }
+
+    /**
+     * Verifies that parse throws exception when JSON is invalid.
+     *
+     * @param tempDir temporary directory for test files
+     * @throws IOException if file operations fail
+     */
+    @Test
+    @Tag("error")
+    @DisplayName("should throw exception when JSON is invalid")
+    void shouldThrowException_whenJsonIsInvalid(final @TempDir Path tempDir) throws IOException {
+      // Given
+      createJsonFile(tempDir, "users.json", "{invalid json}");
+
+      // When & Then
+      assertThrows(
+          DataSetLoadException.class,
+          () -> provider.parse(tempDir),
+          "should throw DataSetLoadException for invalid JSON");
+    }
+
+    /**
+     * Verifies that parse throws exception when path is not a directory.
+     *
+     * @param tempDir temporary directory for test files
+     * @throws IOException if file operations fail
+     */
+    @Test
+    @Tag("error")
+    @DisplayName("should throw exception when path is not a directory")
+    void shouldThrowException_whenPathIsNotDirectory(final @TempDir Path tempDir)
+        throws IOException {
+      // Given
+      final var file = tempDir.resolve("notadirectory.json");
+      Files.writeString(file, "[]");
+
+      // When & Then
+      assertThrows(
+          DataSetLoadException.class,
+          () -> provider.parse(file),
+          "should throw DataSetLoadException when path is a file");
+    }
+  }
+
+  /**
+   * Creates a JSON file with the specified content.
+   *
+   * @param dir the directory to create the file in
+   * @param fileName the file name
+   * @param content the JSON content
+   * @throws IOException if file creation fails
+   */
+  private static void createJsonFile(final Path dir, final String fileName, final String content)
+      throws IOException {
+    Files.writeString(dir.resolve(fileName), content);
+  }
+}

--- a/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/format/json/package-info.java
+++ b/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/format/json/package-info.java
@@ -1,0 +1,5 @@
+/** Unit tests for JSON format provider classes. */
+@NullMarked
+package io.github.seijikohara.dbtester.internal.format.json;
+
+import org.jspecify.annotations.NullMarked;

--- a/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/format/yaml/YamlFormatProviderTest.java
+++ b/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/format/yaml/YamlFormatProviderTest.java
@@ -1,0 +1,414 @@
+package io.github.seijikohara.dbtester.internal.format.yaml;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.seijikohara.dbtester.api.domain.CellValue;
+import io.github.seijikohara.dbtester.api.domain.ColumnName;
+import io.github.seijikohara.dbtester.api.exception.DataSetLoadException;
+import io.github.seijikohara.dbtester.internal.domain.FileExtension;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Unit tests for {@link YamlFormatProvider}. */
+@DisplayName("YamlFormatProvider")
+class YamlFormatProviderTest {
+
+  /** Tests for the YamlFormatProvider class. */
+  YamlFormatProviderTest() {}
+
+  /** The provider instance under test. */
+  private YamlFormatProvider provider;
+
+  /** Sets up test fixtures before each test. */
+  @BeforeEach
+  void setUp() {
+    provider = new YamlFormatProvider();
+  }
+
+  /** Tests for the constructor. */
+  @Nested
+  @DisplayName("constructor")
+  class ConstructorMethod {
+
+    /** Tests for the constructor. */
+    ConstructorMethod() {}
+
+    /** Verifies that constructor creates instance when called. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should create instance when called")
+    void shouldCreateInstance_whenCalled() {
+      // When
+      final var instance = new YamlFormatProvider();
+
+      // Then
+      assertNotNull(instance, "instance should not be null");
+    }
+  }
+
+  /** Tests for the supportedFileExtension() method. */
+  @Nested
+  @DisplayName("supportedFileExtension() method")
+  class SupportedFileExtensionMethod {
+
+    /** Tests for the supportedFileExtension method. */
+    SupportedFileExtensionMethod() {}
+
+    /** Verifies that supportedFileExtension returns yaml extension. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return yaml extension when called")
+    void shouldReturnYamlExtension_whenCalled() {
+      // When
+      final var result = provider.supportedFileExtension();
+
+      // Then
+      assertEquals(new FileExtension("yaml"), result, "should return yaml extension");
+    }
+  }
+
+  /** Tests for the parse() method. */
+  @Nested
+  @DisplayName("parse(Path) method")
+  class ParseMethod {
+
+    /** Tests for the parse method. */
+    ParseMethod() {}
+
+    /**
+     * Verifies that parse returns dataset when valid YAML file exists.
+     *
+     * @param tempDir temporary directory for test files
+     * @throws IOException if file operations fail
+     */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return dataset when valid YAML file exists")
+    void shouldReturnDataSet_whenValidYamlFileExists(final @TempDir Path tempDir)
+        throws IOException {
+      // Given
+      createYamlFile(
+          tempDir,
+          "users.yaml",
+          """
+          - ID: 1
+            NAME: John
+            EMAIL: john@example.com
+          """);
+
+      // When
+      final var result = provider.parse(tempDir);
+
+      // Then
+      assertAll(
+          "dataset should contain parsed table",
+          () -> assertNotNull(result, "result should not be null"),
+          () -> assertEquals(1, result.getTables().size(), "should have one table"));
+
+      final var table = result.getTables().getFirst();
+      assertAll(
+          "table should have correct structure",
+          () -> assertEquals("users", table.getName().value(), "should have correct table name"),
+          () -> assertEquals(3, table.getColumns().size(), "should have 3 columns"),
+          () -> assertEquals(1, table.getRowCount(), "should have 1 row"));
+    }
+
+    /**
+     * Verifies that parse handles multiple YAML files.
+     *
+     * @param tempDir temporary directory for test files
+     * @throws IOException if file operations fail
+     */
+    @Test
+    @Tag("normal")
+    @DisplayName("should handle multiple YAML files when multiple files exist")
+    void shouldHandleMultipleFiles_whenMultipleFilesExist(final @TempDir Path tempDir)
+        throws IOException {
+      // Given
+      createYamlFile(
+          tempDir,
+          "users.yaml",
+          """
+          - ID: 1
+            NAME: John
+          """);
+      createYamlFile(
+          tempDir,
+          "orders.yaml",
+          """
+          - ID: 1
+            USER_ID: 1
+            AMOUNT: 100
+          """);
+
+      // When
+      final var result = provider.parse(tempDir);
+
+      // Then
+      assertEquals(2, result.getTables().size(), "should have two tables");
+    }
+
+    /**
+     * Verifies that parse handles NULL values correctly.
+     *
+     * @param tempDir temporary directory for test files
+     * @throws IOException if file operations fail
+     */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should handle NULL values when null exists in YAML")
+    void shouldHandleNullValues_whenNullExistsInYaml(final @TempDir Path tempDir)
+        throws IOException {
+      // Given
+      createYamlFile(
+          tempDir,
+          "users.yaml",
+          """
+          - ID: 1
+            NAME: null
+            EMAIL: john@example.com
+          """);
+
+      // When
+      final var result = provider.parse(tempDir);
+
+      // Then
+      final var table = result.getTables().getFirst();
+      final var row = table.getRows().getFirst();
+      final var nameValue = row.getValue(new ColumnName("NAME"));
+
+      assertEquals(CellValue.NULL, nameValue, "null cell should be NULL");
+    }
+
+    /**
+     * Verifies that parse handles tilde null notation.
+     *
+     * @param tempDir temporary directory for test files
+     * @throws IOException if file operations fail
+     */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should handle tilde null notation when ~ is used")
+    void shouldHandleTildeNull_whenTildeIsUsed(final @TempDir Path tempDir) throws IOException {
+      // Given
+      createYamlFile(
+          tempDir,
+          "users.yaml",
+          """
+          - ID: 1
+            NAME: ~
+            EMAIL: john@example.com
+          """);
+
+      // When
+      final var result = provider.parse(tempDir);
+
+      // Then
+      final var table = result.getTables().getFirst();
+      final var row = table.getRows().getFirst();
+      final var nameValue = row.getValue(new ColumnName("NAME"));
+
+      assertEquals(CellValue.NULL, nameValue, "tilde should be treated as NULL");
+    }
+
+    /**
+     * Verifies that parse handles multiple rows.
+     *
+     * @param tempDir temporary directory for test files
+     * @throws IOException if file operations fail
+     */
+    @Test
+    @Tag("normal")
+    @DisplayName("should handle multiple rows when list contains multiple items")
+    void shouldHandleMultipleRows_whenListContainsMultipleItems(final @TempDir Path tempDir)
+        throws IOException {
+      // Given
+      createYamlFile(
+          tempDir,
+          "users.yaml",
+          """
+          - ID: 1
+            NAME: Alice
+          - ID: 2
+            NAME: Bob
+          - ID: 3
+            NAME: Charlie
+          """);
+
+      // When
+      final var result = provider.parse(tempDir);
+
+      // Then
+      final var table = result.getTables().getFirst();
+      assertEquals(3, table.getRowCount(), "should have 3 rows");
+    }
+
+    /**
+     * Verifies that parse handles YAML comments.
+     *
+     * @param tempDir temporary directory for test files
+     * @throws IOException if file operations fail
+     */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should ignore YAML comments")
+    void shouldIgnoreYamlComments_whenCommentsExist(final @TempDir Path tempDir)
+        throws IOException {
+      // Given
+      createYamlFile(
+          tempDir,
+          "users.yaml",
+          """
+          # This is a comment
+          - ID: 1  # inline comment
+            NAME: John
+            # Another comment
+            EMAIL: john@example.com
+          """);
+
+      // When
+      final var result = provider.parse(tempDir);
+
+      // Then
+      final var table = result.getTables().getFirst();
+      assertEquals(1, table.getRowCount(), "should have 1 row");
+      assertEquals(3, table.getColumns().size(), "should have 3 columns");
+    }
+
+    /**
+     * Verifies that parse converts numeric values to strings.
+     *
+     * @param tempDir temporary directory for test files
+     * @throws IOException if file operations fail
+     */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should convert numeric values to strings")
+    void shouldConvertNumericValues_toStrings(final @TempDir Path tempDir) throws IOException {
+      // Given
+      createYamlFile(
+          tempDir,
+          "products.yaml",
+          """
+          - ID: 1
+            PRICE: 99.99
+            QUANTITY: 10
+          """);
+
+      // When
+      final var result = provider.parse(tempDir);
+
+      // Then
+      final var table = result.getTables().getFirst();
+      final var row = table.getRows().getFirst();
+      final var priceValue = row.getValue(new ColumnName("PRICE"));
+      final var quantityValue = row.getValue(new ColumnName("QUANTITY"));
+
+      assertAll(
+          "numeric values should be converted to strings",
+          () -> assertNotNull(priceValue.value(), "price value should not be null"),
+          () ->
+              assertTrue(
+                  priceValue.value() != null && priceValue.value().toString().contains("99.99"),
+                  "price should be converted to string"),
+          () -> assertNotNull(quantityValue.value(), "quantity value should not be null"),
+          () ->
+              assertEquals(
+                  "10",
+                  quantityValue.value() != null ? quantityValue.value().toString() : "",
+                  "quantity should be string"));
+    }
+
+    /**
+     * Verifies that parse throws exception when file is empty array.
+     *
+     * @param tempDir temporary directory for test files
+     * @throws IOException if file operations fail
+     */
+    @Test
+    @Tag("error")
+    @DisplayName("should throw exception when YAML list is empty")
+    void shouldThrowException_whenYamlListIsEmpty(final @TempDir Path tempDir) throws IOException {
+      // Given
+      createYamlFile(tempDir, "users.yaml", "[]");
+
+      // When & Then
+      final var exception =
+          assertThrows(
+              DataSetLoadException.class,
+              () -> provider.parse(tempDir),
+              "should throw DataSetLoadException");
+
+      final var message = exception.getMessage();
+      assertTrue(
+          message != null && message.contains("no rows"),
+          "exception message should mention no rows");
+    }
+
+    /**
+     * Verifies that parse throws exception when YAML is invalid.
+     *
+     * @param tempDir temporary directory for test files
+     * @throws IOException if file operations fail
+     */
+    @Test
+    @Tag("error")
+    @DisplayName("should throw exception when YAML is invalid")
+    void shouldThrowException_whenYamlIsInvalid(final @TempDir Path tempDir) throws IOException {
+      // Given
+      createYamlFile(tempDir, "users.yaml", "invalid: yaml: structure: [");
+
+      // When & Then
+      assertThrows(
+          DataSetLoadException.class,
+          () -> provider.parse(tempDir),
+          "should throw DataSetLoadException for invalid YAML");
+    }
+
+    /**
+     * Verifies that parse throws exception when path is not a directory.
+     *
+     * @param tempDir temporary directory for test files
+     * @throws IOException if file operations fail
+     */
+    @Test
+    @Tag("error")
+    @DisplayName("should throw exception when path is not a directory")
+    void shouldThrowException_whenPathIsNotDirectory(final @TempDir Path tempDir)
+        throws IOException {
+      // Given
+      final var file = tempDir.resolve("notadirectory.yaml");
+      Files.writeString(file, "[]");
+
+      // When & Then
+      assertThrows(
+          DataSetLoadException.class,
+          () -> provider.parse(file),
+          "should throw DataSetLoadException when path is a file");
+    }
+  }
+
+  /**
+   * Creates a YAML file with the specified content.
+   *
+   * @param dir the directory to create the file in
+   * @param fileName the file name
+   * @param content the YAML content
+   * @throws IOException if file creation fails
+   */
+  private static void createYamlFile(final Path dir, final String fileName, final String content)
+      throws IOException {
+    Files.writeString(dir.resolve(fileName), content);
+  }
+}

--- a/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/format/yaml/package-info.java
+++ b/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/format/yaml/package-info.java
@@ -1,0 +1,5 @@
+/** Unit tests for YAML format provider classes. */
+@NullMarked
+package io.github.seijikohara.dbtester.internal.format.yaml;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
## Summary
- Add JSON and YAML data format support to complement existing CSV/TSV formats
- Implement JsonFormatProvider and YamlFormatProvider using Jackson ObjectMapper
- Create shared StructuredFormatParser for common parsing logic
- Add comprehensive tests for both formats

## Changes Made
- Add `JSON` and `YAML` enum values to `DataFormat`
- Add `JsonFormatProvider` for parsing `.json` files
- Add `YamlFormatProvider` for parsing `.yaml` files
- Add `StructuredFormatParser` as shared parser implementation
- Register providers via `ServiceLoader` and `module-info.java`
- Add tests for all new functionality

## Features
- One file per table pattern (consistent with CSV/TSV)
- Column order determined by first row's key order
- Null values converted to `CellValue.NULL`
- All non-null values converted to strings
- Supports multiple files (one per table)

## Test Plan
- [x] JsonFormatProvider tests pass (11 tests)
- [x] YamlFormatProvider tests pass (12 tests)
- [x] DataFormatTest updated for JSON/YAML
- [x] verifyNullMarkedPackages passes
- [x] db-tester-api build passes
- [x] db-tester-core build passes

Closes #121