### PR TITLE
refactor: extract common lifecycle logic using SPI pattern

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -230,7 +230,7 @@ subprojects.filter { it.name in javaModules }.forEach { subproject ->
 
         extensions.configure<SpotlessExtension> {
             java {
-                googleJavaFormat()
+                googleJavaFormat("1.34.0")
             }
         }
 

--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/spi/ExpectationSupport.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/spi/ExpectationSupport.java
@@ -1,0 +1,39 @@
+package io.github.seijikohara.dbtester.api.spi;
+
+import io.github.seijikohara.dbtester.api.annotation.ExpectedDataSet;
+import io.github.seijikohara.dbtester.api.context.TestContext;
+import io.github.seijikohara.dbtester.api.exception.ValidationException;
+
+/**
+ * Service Provider Interface for executing database expectation verification.
+ *
+ * <p>This SPI abstracts expectation verification, allowing test framework modules (JUnit, Spock,
+ * Kotest) to depend only on the API module. The actual implementation is provided by the core
+ * module and loaded via {@link java.util.ServiceLoader}.
+ *
+ * <p>The verification phase loads expected datasets specified in annotations (e.g.,
+ * {@code @ExpectedDataSet}) or resolved via conventions, and compares them with the actual database
+ * state. The comparison supports retry with configurable count and delay for eventual consistency
+ * scenarios.
+ *
+ * <p>The framework discovers implementations automatically via {@link java.util.ServiceLoader}.
+ * Users typically do not interact with this interface directly; instead, they use the framework's
+ * test extensions (JUnit Jupiter, Spock, Kotest) which internally delegate to this provider.
+ *
+ * @see java.util.ServiceLoader
+ * @see ExpectationProvider
+ */
+public interface ExpectationSupport {
+
+  /**
+   * Verifies that the database state matches the expected datasets.
+   *
+   * <p>Loads expected datasets based on the test context and compares them with the actual database
+   * state. Supports retry with configurable count and delay for eventual consistency scenarios.
+   *
+   * @param context the test context containing configuration, registry, and test metadata
+   * @param expectedDataSet the ExpectedDataSet annotation containing verification settings
+   * @throws ValidationException if verification fails after all retries
+   */
+  void verify(TestContext context, ExpectedDataSet expectedDataSet);
+}

--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/spi/PreparationSupport.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/spi/PreparationSupport.java
@@ -1,0 +1,35 @@
+package io.github.seijikohara.dbtester.api.spi;
+
+import io.github.seijikohara.dbtester.api.annotation.DataSet;
+import io.github.seijikohara.dbtester.api.context.TestContext;
+
+/**
+ * Service Provider Interface for executing database preparation operations.
+ *
+ * <p>This SPI abstracts preparation execution, allowing test framework modules (JUnit, Spock,
+ * Kotest) to depend only on the API module. The actual implementation is provided by the core
+ * module and loaded via {@link java.util.ServiceLoader}.
+ *
+ * <p>The preparation phase loads datasets specified in annotations (e.g., {@code @DataSet}) or
+ * resolved via conventions, and applies them to the database using the configured operation.
+ *
+ * <p>The framework discovers implementations automatically via {@link java.util.ServiceLoader}.
+ * Users typically do not interact with this interface directly; instead, they use the framework's
+ * test extensions (JUnit Jupiter, Spock, Kotest) which internally delegate to this provider.
+ *
+ * @see java.util.ServiceLoader
+ * @see OperationProvider
+ */
+public interface PreparationSupport {
+
+  /**
+   * Executes database preparation for a test.
+   *
+   * <p>Loads datasets based on the test context and applies them to the database. The operation
+   * type, transaction mode, and other settings are determined by the test context configuration.
+   *
+   * @param context the test context containing configuration, registry, and test metadata
+   * @param dataSet the DataSet annotation containing preparation settings
+   */
+  void execute(TestContext context, DataSet dataSet);
+}

--- a/db-tester-api/src/main/java/module-info.java
+++ b/db-tester-api/src/main/java/module-info.java
@@ -27,7 +27,9 @@ module io.github.seijikohara.dbtester.api {
   // SPI for implementations
   uses io.github.seijikohara.dbtester.api.spi.AssertionProvider;
   uses io.github.seijikohara.dbtester.api.spi.DataSetLoaderProvider;
-  uses io.github.seijikohara.dbtester.api.spi.OperationProvider;
   uses io.github.seijikohara.dbtester.api.spi.ExpectationProvider;
+  uses io.github.seijikohara.dbtester.api.spi.ExpectationSupport;
+  uses io.github.seijikohara.dbtester.api.spi.OperationProvider;
+  uses io.github.seijikohara.dbtester.api.spi.PreparationSupport;
   uses io.github.seijikohara.dbtester.api.scenario.ScenarioNameResolver;
 }

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/lifecycle/DefaultExpectationSupport.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/lifecycle/DefaultExpectationSupport.java
@@ -1,0 +1,207 @@
+package io.github.seijikohara.dbtester.internal.lifecycle;
+
+import io.github.seijikohara.dbtester.api.annotation.ExpectedDataSet;
+import io.github.seijikohara.dbtester.api.config.RowOrdering;
+import io.github.seijikohara.dbtester.api.context.TestContext;
+import io.github.seijikohara.dbtester.api.exception.ValidationException;
+import io.github.seijikohara.dbtester.api.loader.ExpectedTableSet;
+import io.github.seijikohara.dbtester.api.spi.ExpectationProvider;
+import io.github.seijikohara.dbtester.api.spi.ExpectationSupport;
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.ServiceLoader;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Default implementation of {@link ExpectationSupport}.
+ *
+ * <p>This class provides the common expectation verification logic used by all test framework
+ * integrations (JUnit, Spock, Kotest). It delegates to {@link ExpectationProvider} for database
+ * comparison operations.
+ */
+public final class DefaultExpectationSupport implements ExpectationSupport {
+
+  /** Logger for tracking expectation verification. */
+  private static final Logger logger = LoggerFactory.getLogger(DefaultExpectationSupport.class);
+
+  /** The expectation provider for database verification. */
+  private final ExpectationProvider expectationProvider;
+
+  /** Creates a new instance with an expectation provider loaded via ServiceLoader. */
+  public DefaultExpectationSupport() {
+    this.expectationProvider =
+        ServiceLoader.load(ExpectationProvider.class)
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "No ExpectationProvider implementation found. "
+                            + "Ensure db-tester-core is on the classpath."));
+  }
+
+  /**
+   * Creates a new instance with the specified expectation provider.
+   *
+   * @param expectationProvider the expectation provider
+   */
+  DefaultExpectationSupport(final ExpectationProvider expectationProvider) {
+    this.expectationProvider =
+        Objects.requireNonNull(expectationProvider, "expectationProvider must not be null");
+  }
+
+  @Override
+  public void verify(final TestContext context, final ExpectedDataSet expectedDataSet) {
+    Objects.requireNonNull(context, "context must not be null");
+    Objects.requireNonNull(expectedDataSet, "expectedDataSet must not be null");
+
+    logger.debug(
+        "Verifying expectation for test: {}.{}",
+        context.testClass().getSimpleName(),
+        context.testMethod().getName());
+
+    final var expectedTableSets =
+        context.configuration().loader().loadExpectationDataSetsWithExclusions(context);
+
+    if (expectedTableSets.isEmpty()) {
+      logger.debug("No expectation datasets found");
+      return;
+    }
+
+    final var rowOrdering = expectedDataSet.rowOrdering();
+    final var retryCount = resolveRetryCount(expectedDataSet, context);
+    final var retryDelay = resolveRetryDelay(expectedDataSet, context);
+
+    verifyWithRetry(context, expectedTableSets, rowOrdering, retryCount, retryDelay);
+  }
+
+  /**
+   * Resolves the retry count from annotation or global settings.
+   *
+   * @param expectedDataSet the annotation
+   * @param context the test context
+   * @return the resolved retry count
+   */
+  private int resolveRetryCount(final ExpectedDataSet expectedDataSet, final TestContext context) {
+    final var annotationValue = expectedDataSet.retryCount();
+    return annotationValue >= 0
+        ? annotationValue
+        : context.configuration().conventions().retryCount();
+  }
+
+  /**
+   * Resolves the retry delay from annotation or global settings.
+   *
+   * @param expectedDataSet the annotation
+   * @param context the test context
+   * @return the resolved retry delay
+   */
+  private Duration resolveRetryDelay(
+      final ExpectedDataSet expectedDataSet, final TestContext context) {
+    final var annotationValue = expectedDataSet.retryDelayMillis();
+    return annotationValue >= 0
+        ? Duration.ofMillis(annotationValue)
+        : context.configuration().conventions().retryDelay();
+  }
+
+  /**
+   * Verifies expectation datasets with retry support.
+   *
+   * @param context the test context
+   * @param expectedTableSets the expected datasets
+   * @param rowOrdering the row ordering strategy
+   * @param retryCount the number of retries (0 = no retry)
+   * @param retryDelay the delay between retries
+   */
+  private void verifyWithRetry(
+      final TestContext context,
+      final List<ExpectedTableSet> expectedTableSets,
+      final RowOrdering rowOrdering,
+      final int retryCount,
+      final Duration retryDelay) {
+    ValidationException lastException = null;
+
+    for (int attempt = 0; attempt <= retryCount; attempt++) {
+      try {
+        if (attempt > 0) {
+          logger.debug(
+              "Retry attempt {} of {} after {} ms delay",
+              attempt,
+              retryCount,
+              retryDelay.toMillis());
+          Thread.sleep(retryDelay.toMillis());
+        }
+
+        for (final var expectedTableSet : expectedTableSets) {
+          verifyExpectedTableSet(context, expectedTableSet, rowOrdering);
+        }
+
+        // Success - exit the retry loop
+        return;
+      } catch (final ValidationException e) {
+        lastException = e;
+        if (attempt < retryCount) {
+          logger.debug("Verification failed, will retry: {}", e.getMessage());
+        }
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new ValidationException("Verification interrupted during retry delay", e);
+      }
+    }
+
+    // All retries exhausted, throw the last exception
+    throw lastException;
+  }
+
+  /**
+   * Verifies a single ExpectedTableSet against the database.
+   *
+   * @param context the test context
+   * @param expectedTableSet the expected table set
+   * @param rowOrdering the row ordering strategy
+   */
+  private void verifyExpectedTableSet(
+      final TestContext context,
+      final ExpectedTableSet expectedTableSet,
+      final RowOrdering rowOrdering) {
+    final var tableSet = expectedTableSet.tableSet();
+    final var excludeColumns = expectedTableSet.excludeColumns();
+    final var columnStrategies = expectedTableSet.columnStrategies();
+    final DataSource dataSource =
+        tableSet.getDataSource().orElseGet(() -> context.registry().get(""));
+
+    final var tableCount = tableSet.getTables().size();
+    logger.info(
+        "Validating expectation TableSet for {}: {} tables ({})",
+        context.testMethod().getName(),
+        tableCount,
+        rowOrdering);
+
+    if (expectedTableSet.hasExclusions()) {
+      logger.debug("Excluding columns from verification: {}", excludeColumns);
+    }
+
+    if (expectedTableSet.hasColumnStrategies()) {
+      logger.debug("Using column strategies for: {}", columnStrategies.keySet());
+    }
+
+    final var operationDefaults = context.configuration().operations();
+
+    try {
+      expectationProvider.verifyExpectation(
+          tableSet, dataSource, excludeColumns, columnStrategies, rowOrdering, operationDefaults);
+
+      logger.info(
+          "Expectation validation completed successfully for {}: {} tables",
+          context.testMethod().getName(),
+          tableCount);
+    } catch (final ValidationException e) {
+      throw new ValidationException(
+          String.format(
+              "Failed to verify expectation TableSet for %s", context.testMethod().getName()),
+          e);
+    }
+  }
+}

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/lifecycle/DefaultPreparationSupport.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/lifecycle/DefaultPreparationSupport.java
@@ -1,0 +1,117 @@
+package io.github.seijikohara.dbtester.internal.lifecycle;
+
+import io.github.seijikohara.dbtester.api.annotation.DataSet;
+import io.github.seijikohara.dbtester.api.context.TestContext;
+import io.github.seijikohara.dbtester.api.dataset.TableSet;
+import io.github.seijikohara.dbtester.api.spi.OperationProvider;
+import io.github.seijikohara.dbtester.api.spi.PreparationSupport;
+import java.util.Objects;
+import java.util.ServiceLoader;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Default implementation of {@link PreparationSupport}.
+ *
+ * <p>This class provides the common preparation logic used by all test framework integrations
+ * (JUnit, Spock, Kotest). It delegates to {@link OperationProvider} for database operations.
+ */
+public final class DefaultPreparationSupport implements PreparationSupport {
+
+  /** Logger for tracking preparation execution. */
+  private static final Logger logger = LoggerFactory.getLogger(DefaultPreparationSupport.class);
+
+  /** The operation provider for database operations. */
+  private final OperationProvider operationProvider;
+
+  /** Creates a new instance with an operation provider loaded via ServiceLoader. */
+  public DefaultPreparationSupport() {
+    this.operationProvider =
+        ServiceLoader.load(OperationProvider.class)
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "No OperationProvider implementation found. "
+                            + "Ensure db-tester-core is on the classpath."));
+  }
+
+  /**
+   * Creates a new instance with the specified operation provider.
+   *
+   * @param operationProvider the operation provider
+   */
+  DefaultPreparationSupport(final OperationProvider operationProvider) {
+    this.operationProvider =
+        Objects.requireNonNull(operationProvider, "operationProvider must not be null");
+  }
+
+  @Override
+  public void execute(final TestContext context, final DataSet dataSet) {
+    Objects.requireNonNull(context, "context must not be null");
+    Objects.requireNonNull(dataSet, "dataSet must not be null");
+
+    logger.debug(
+        "Executing preparation for test: {}.{}",
+        context.testClass().getSimpleName(),
+        context.testMethod().getName());
+
+    final var tableSets = context.configuration().loader().loadPreparationDataSets(context);
+
+    if (tableSets.isEmpty()) {
+      logger.debug("No preparation datasets found");
+      return;
+    }
+
+    tableSets.forEach(tableSet -> executeTableSet(context, tableSet, dataSet));
+  }
+
+  /**
+   * Executes a single TableSet against the database.
+   *
+   * @param context the test context
+   * @param tableSet the table set to execute
+   * @param dataSet the DataSet annotation containing operation settings
+   */
+  private void executeTableSet(
+      final TestContext context, final TableSet tableSet, final DataSet dataSet) {
+    final var dataSource = tableSet.getDataSource().orElseGet(() -> context.registry().get(""));
+    final var tableCount = tableSet.getTables().size();
+
+    logger.info(
+        "Executing preparation TableSet for {}: {} tables",
+        context.testMethod().getName(),
+        tableCount);
+
+    executeOperationOnDataSource(context, tableSet, dataSet, dataSource);
+
+    logger.info(
+        "Preparation completed successfully for {}: {} tables",
+        context.testMethod().getName(),
+        tableCount);
+  }
+
+  /**
+   * Executes the operation on the data source.
+   *
+   * @param context the test context
+   * @param tableSet the table set
+   * @param dataSet the data set annotation
+   * @param dataSource the data source
+   */
+  private void executeOperationOnDataSource(
+      final TestContext context,
+      final TableSet tableSet,
+      final DataSet dataSet,
+      final DataSource dataSource) {
+    final var operation = dataSet.operation();
+    final var tableOrderingStrategy = dataSet.tableOrdering();
+    final var conventions = context.configuration().conventions();
+    final var transactionMode = conventions.transactionMode();
+    final var queryTimeout = conventions.queryTimeout();
+
+    operationProvider.execute(
+        operation, tableSet, dataSource, tableOrderingStrategy, transactionMode, queryTimeout);
+  }
+}

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/lifecycle/package-info.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/lifecycle/package-info.java
@@ -1,0 +1,12 @@
+/**
+ * Test lifecycle support implementations.
+ *
+ * <p>This package contains implementations of the lifecycle SPIs ({@link
+ * io.github.seijikohara.dbtester.api.spi.PreparationSupport} and {@link
+ * io.github.seijikohara.dbtester.api.spi.ExpectationSupport}) that provide common logic for test
+ * framework integrations.
+ */
+@NullMarked
+package io.github.seijikohara.dbtester.internal.lifecycle;
+
+import org.jspecify.annotations.NullMarked;

--- a/db-tester-core/src/main/java/module-info.java
+++ b/db-tester-core/src/main/java/module-info.java
@@ -26,10 +26,14 @@ module io.github.seijikohara.dbtester.core {
       io.github.seijikohara.dbtester.internal.spi.DefaultAssertionProvider;
   provides io.github.seijikohara.dbtester.api.spi.DataSetLoaderProvider with
       io.github.seijikohara.dbtester.internal.loader.DefaultDataSetLoaderProvider;
-  provides io.github.seijikohara.dbtester.api.spi.OperationProvider with
-      io.github.seijikohara.dbtester.internal.spi.DefaultOperationProvider;
   provides io.github.seijikohara.dbtester.api.spi.ExpectationProvider with
       io.github.seijikohara.dbtester.internal.spi.DefaultExpectationProvider;
+  provides io.github.seijikohara.dbtester.api.spi.ExpectationSupport with
+      io.github.seijikohara.dbtester.internal.lifecycle.DefaultExpectationSupport;
+  provides io.github.seijikohara.dbtester.api.spi.OperationProvider with
+      io.github.seijikohara.dbtester.internal.spi.DefaultOperationProvider;
+  provides io.github.seijikohara.dbtester.api.spi.PreparationSupport with
+      io.github.seijikohara.dbtester.internal.lifecycle.DefaultPreparationSupport;
 
   // Internal format providers
   provides io.github.seijikohara.dbtester.internal.format.spi.FormatProvider with

--- a/db-tester-core/src/main/resources/META-INF/services/io.github.seijikohara.dbtester.api.spi.ExpectationSupport
+++ b/db-tester-core/src/main/resources/META-INF/services/io.github.seijikohara.dbtester.api.spi.ExpectationSupport
@@ -1,0 +1,1 @@
+io.github.seijikohara.dbtester.internal.lifecycle.DefaultExpectationSupport

--- a/db-tester-core/src/main/resources/META-INF/services/io.github.seijikohara.dbtester.api.spi.PreparationSupport
+++ b/db-tester-core/src/main/resources/META-INF/services/io.github.seijikohara.dbtester.api.spi.PreparationSupport
@@ -1,0 +1,1 @@
+io.github.seijikohara.dbtester.internal.lifecycle.DefaultPreparationSupport

--- a/db-tester-junit/src/main/java/io/github/seijikohara/dbtester/junit/jupiter/lifecycle/ExpectationVerifier.java
+++ b/db-tester-junit/src/main/java/io/github/seijikohara/dbtester/junit/jupiter/lifecycle/ExpectationVerifier.java
@@ -1,45 +1,43 @@
 package io.github.seijikohara.dbtester.junit.jupiter.lifecycle;
 
 import io.github.seijikohara.dbtester.api.annotation.ExpectedDataSet;
-import io.github.seijikohara.dbtester.api.config.RowOrdering;
 import io.github.seijikohara.dbtester.api.context.TestContext;
-import io.github.seijikohara.dbtester.api.exception.ValidationException;
-import io.github.seijikohara.dbtester.api.loader.ExpectedTableSet;
-import io.github.seijikohara.dbtester.api.spi.ExpectationProvider;
-import java.time.Duration;
-import java.util.List;
+import io.github.seijikohara.dbtester.api.spi.ExpectationSupport;
 import java.util.ServiceLoader;
-import javax.sql.DataSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Validates expectation datasets against the live database after test execution.
  *
- * <p>The verifier delegates to {@link ExpectationProvider} for database operations. The verifier
- * opens a connection through the dataset's {@link DataSource}, applies column filtering so that
- * only declared columns participate in comparisons, and raises {@link ValidationException} when the
- * observed database state deviates from the expected dataset.
+ * <p>This class delegates to {@link ExpectationSupport} for the actual verification logic. It
+ * provides a JUnit-specific facade for backward compatibility and framework-specific customization.
  *
- * <p>Like {@link PreparationExecutor}, this class is stateless and thread-safe. It performs
- * structured logging to aid debugging and rewraps any {@link ValidationException} thrown by the
- * verifier with additional test context so failures remain actionable in the calling layer.
- *
+ * @see ExpectationSupport
  * @see PreparationExecutor
- * @see ExpectationProvider
  */
 public final class ExpectationVerifier {
 
-  /** Logger for tracking expectation verification. */
-  private static final Logger logger = LoggerFactory.getLogger(ExpectationVerifier.class);
-
-  /** The expectation provider. */
-  private final ExpectationProvider expectationProvider;
+  /** The expectation support for database verification. */
+  private final ExpectationSupport support;
 
   /** Creates a new expectation verifier. */
   public ExpectationVerifier() {
-    this.expectationProvider =
-        ServiceLoader.load(ExpectationProvider.class).findFirst().orElseThrow();
+    this.support =
+        ServiceLoader.load(ExpectationSupport.class)
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "No ExpectationSupport implementation found. "
+                            + "Ensure db-tester-core is on the classpath."));
+  }
+
+  /**
+   * Creates a new expectation verifier with the specified support.
+   *
+   * @param support the expectation support
+   */
+  ExpectationVerifier(final ExpectationSupport support) {
+    this.support = support;
   }
 
   /**
@@ -55,154 +53,6 @@ public final class ExpectationVerifier {
    * @throws AssertionError if the database state does not match the expected state after retries
    */
   public void verify(final TestContext context, final ExpectedDataSet expectedDataSet) {
-    logger.debug(
-        "Verifying expectation for test: {}.{}",
-        context.testClass().getSimpleName(),
-        context.testMethod().getName());
-
-    final var expectedTableSets =
-        context.configuration().loader().loadExpectationDataSetsWithExclusions(context);
-
-    if (expectedTableSets.isEmpty()) {
-      logger.debug("No expectation datasets found");
-      return;
-    }
-
-    final var rowOrdering = expectedDataSet.rowOrdering();
-    final var retryCount = resolveRetryCount(expectedDataSet, context);
-    final var retryDelay = resolveRetryDelay(expectedDataSet, context);
-
-    verifyWithRetry(context, expectedTableSets, rowOrdering, retryCount, retryDelay);
-  }
-
-  /**
-   * Resolves the retry count from annotation or global settings.
-   *
-   * @param expectedDataSet the annotation
-   * @param context the test context
-   * @return the resolved retry count
-   */
-  private int resolveRetryCount(final ExpectedDataSet expectedDataSet, final TestContext context) {
-    final var annotationValue = expectedDataSet.retryCount();
-    return annotationValue >= 0
-        ? annotationValue
-        : context.configuration().conventions().retryCount();
-  }
-
-  /**
-   * Resolves the retry delay from annotation or global settings.
-   *
-   * @param expectedDataSet the annotation
-   * @param context the test context
-   * @return the resolved retry delay
-   */
-  private Duration resolveRetryDelay(
-      final ExpectedDataSet expectedDataSet, final TestContext context) {
-    final var annotationValue = expectedDataSet.retryDelayMillis();
-    return annotationValue >= 0
-        ? Duration.ofMillis(annotationValue)
-        : context.configuration().conventions().retryDelay();
-  }
-
-  /**
-   * Verifies expectation datasets with retry support.
-   *
-   * @param context the test context
-   * @param expectedTableSets the expected datasets
-   * @param rowOrdering the row ordering strategy
-   * @param retryCount the number of retries (0 = no retry)
-   * @param retryDelay the delay between retries
-   */
-  private void verifyWithRetry(
-      final TestContext context,
-      final List<ExpectedTableSet> expectedTableSets,
-      final RowOrdering rowOrdering,
-      final int retryCount,
-      final Duration retryDelay) {
-    ValidationException lastException = null;
-
-    for (int attempt = 0; attempt <= retryCount; attempt++) {
-      try {
-        if (attempt > 0) {
-          logger.debug(
-              "Retry attempt {} of {} after {} ms delay",
-              attempt,
-              retryCount,
-              retryDelay.toMillis());
-          Thread.sleep(retryDelay.toMillis());
-        }
-
-        expectedTableSets.forEach(
-            expectedTableSet -> verifyExpectedTableSet(context, expectedTableSet, rowOrdering));
-
-        // Success - exit the retry loop
-        return;
-      } catch (final ValidationException e) {
-        lastException = e;
-        if (attempt < retryCount) {
-          logger.debug("Verification failed, will retry: {}", e.getMessage());
-        }
-      } catch (final InterruptedException e) {
-        Thread.currentThread().interrupt();
-        throw new ValidationException("Verification interrupted during retry delay", e);
-      }
-    }
-
-    // All retries exhausted, throw the last exception
-    throw lastException;
-  }
-
-  /**
-   * Verifies a single ExpectedTableSet against the database.
-   *
-   * <p>Delegates to {@link ExpectationProvider#verifyExpectation} for full data comparison
-   * including column filtering, column comparison strategies, row ordering, and detailed assertion
-   * messages. If verification fails, wraps the exception with additional test context.
-   *
-   * @param context the test context providing access to the data source registry
-   * @param expectedTableSet the expected TableSet with exclusion and strategy metadata
-   * @param rowOrdering the row comparison strategy (ORDERED or UNORDERED)
-   * @throws ValidationException if verification fails with wrapped context information
-   */
-  private void verifyExpectedTableSet(
-      final TestContext context,
-      final ExpectedTableSet expectedTableSet,
-      final RowOrdering rowOrdering) {
-    final var tableSet = expectedTableSet.tableSet();
-    final var excludeColumns = expectedTableSet.excludeColumns();
-    final var columnStrategies = expectedTableSet.columnStrategies();
-    final var dataSource = tableSet.getDataSource().orElseGet(() -> context.registry().get(""));
-
-    final var tableCount = tableSet.getTables().size();
-    logger.info(
-        "Validating expectation TableSet for {}: {} tables ({})",
-        context.testMethod().getName(),
-        tableCount,
-        rowOrdering);
-
-    if (expectedTableSet.hasExclusions()) {
-      logger.debug("Excluding columns from verification: {}", excludeColumns);
-    }
-
-    if (expectedTableSet.hasColumnStrategies()) {
-      logger.debug("Using column strategies for: {}", columnStrategies.keySet());
-    }
-
-    final var operationDefaults = context.configuration().operations();
-
-    try {
-      expectationProvider.verifyExpectation(
-          tableSet, dataSource, excludeColumns, columnStrategies, rowOrdering, operationDefaults);
-
-      logger.info(
-          "Expectation validation completed successfully for {}: {} tables",
-          context.testMethod().getName(),
-          tableCount);
-    } catch (final ValidationException e) {
-      throw new ValidationException(
-          String.format(
-              "Failed to verify expectation TableSet for %s", context.testMethod().getName()),
-          e);
-    }
+    support.verify(context, expectedDataSet);
   }
 }

--- a/db-tester-junit/src/main/java/io/github/seijikohara/dbtester/junit/jupiter/lifecycle/PreparationExecutor.java
+++ b/db-tester-junit/src/main/java/io/github/seijikohara/dbtester/junit/jupiter/lifecycle/PreparationExecutor.java
@@ -2,33 +2,41 @@ package io.github.seijikohara.dbtester.junit.jupiter.lifecycle;
 
 import io.github.seijikohara.dbtester.api.annotation.DataSet;
 import io.github.seijikohara.dbtester.api.context.TestContext;
-import io.github.seijikohara.dbtester.api.dataset.TableSet;
-import io.github.seijikohara.dbtester.api.operation.Operation;
-import io.github.seijikohara.dbtester.api.operation.TableOrderingStrategy;
-import io.github.seijikohara.dbtester.api.spi.OperationProvider;
-import java.time.Duration;
+import io.github.seijikohara.dbtester.api.spi.PreparationSupport;
 import java.util.ServiceLoader;
-import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Executes the preparation phase of database testing.
  *
- * <p>This class loads datasets according to the {@link DataSet} annotation and applies them to the
- * database using the configured operation.
+ * <p>This class delegates to {@link PreparationSupport} for the actual preparation logic. It
+ * provides a JUnit-specific facade for backward compatibility and framework-specific customization.
+ *
+ * @see PreparationSupport
  */
 public final class PreparationExecutor {
 
-  /** Logger for tracking preparation execution. */
-  private static final Logger logger = LoggerFactory.getLogger(PreparationExecutor.class);
-
-  /** The operation provider for database operations. */
-  private final OperationProvider operationProvider;
+  /** The preparation support for database operations. */
+  private final PreparationSupport support;
 
   /** Creates a new preparation executor. */
   public PreparationExecutor() {
-    this.operationProvider = ServiceLoader.load(OperationProvider.class).findFirst().orElseThrow();
+    this.support =
+        ServiceLoader.load(PreparationSupport.class)
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "No PreparationSupport implementation found. "
+                            + "Ensure db-tester-core is on the classpath."));
+  }
+
+  /**
+   * Creates a new preparation executor with the specified support.
+   *
+   * @param support the preparation support
+   */
+  PreparationExecutor(final PreparationSupport support) {
+    this.support = support;
   }
 
   /**
@@ -41,54 +49,6 @@ public final class PreparationExecutor {
    * @param dataSet the DataSet annotation specifying the operation to perform
    */
   public void execute(final TestContext context, final DataSet dataSet) {
-    logger.debug(
-        "Executing preparation for test: {}.{}",
-        context.testClass().getSimpleName(),
-        context.testMethod().getName());
-
-    final var tableSets = context.configuration().loader().loadPreparationDataSets(context);
-
-    if (tableSets.isEmpty()) {
-      logger.debug("No preparation datasets found");
-      return;
-    }
-
-    final var operation = dataSet.operation();
-    final var tableOrderingStrategy = dataSet.tableOrdering();
-    tableSets.forEach(
-        tableSet -> executeTableSet(context, tableSet, operation, tableOrderingStrategy));
-  }
-
-  /**
-   * Executes a single TableSet against the database.
-   *
-   * <p>This method resolves the DataSource from either the TableSet itself or falls back to the
-   * default registry. It then delegates to the operation executor to apply the TableSet using the
-   * specified operation.
-   *
-   * @param context the test context providing access to the data source registry
-   * @param tableSet the TableSet to execute containing tables and optional data source
-   * @param operation the database operation to perform (CLEAN_INSERT, INSERT, etc.)
-   * @param tableOrderingStrategy the strategy for determining table processing order
-   */
-  private void executeTableSet(
-      final TestContext context,
-      final TableSet tableSet,
-      final Operation operation,
-      final TableOrderingStrategy tableOrderingStrategy) {
-    final var dataSource = tableSet.getDataSource().orElseGet(() -> context.registry().get(""));
-    final var conventions = context.configuration().conventions();
-    final var transactionMode = conventions.transactionMode();
-    final @Nullable Duration queryTimeout = conventions.queryTimeout();
-
-    logger.debug(
-        "Applying {} operation with TableSet using {} table ordering (transactionMode={}, timeout={})",
-        operation,
-        tableOrderingStrategy,
-        transactionMode,
-        queryTimeout);
-
-    operationProvider.execute(
-        operation, tableSet, dataSource, tableOrderingStrategy, transactionMode, queryTimeout);
+    support.execute(context, dataSet);
   }
 }

--- a/db-tester-junit/src/main/java/module-info.java
+++ b/db-tester-junit/src/main/java/module-info.java
@@ -18,6 +18,10 @@ module io.github.seijikohara.dbtester.junit {
   requires org.jspecify;
   requires static org.slf4j;
 
+  // SPI service consumers
+  uses io.github.seijikohara.dbtester.api.spi.ExpectationSupport;
+  uses io.github.seijikohara.dbtester.api.spi.PreparationSupport;
+
   // SPI service providers
   provides io.github.seijikohara.dbtester.api.scenario.ScenarioNameResolver with
       io.github.seijikohara.dbtester.junit.jupiter.spi.JUnitScenarioNameResolver;

--- a/db-tester-junit/src/test/java/io/github/seijikohara/dbtester/junit/jupiter/lifecycle/ExpectationVerifierTest.java
+++ b/db-tester-junit/src/test/java/io/github/seijikohara/dbtester/junit/jupiter/lifecycle/ExpectationVerifierTest.java
@@ -6,35 +6,17 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.github.seijikohara.dbtester.api.annotation.ExpectedDataSet;
-import io.github.seijikohara.dbtester.api.config.ColumnStrategyMapping;
 import io.github.seijikohara.dbtester.api.config.Configuration;
-import io.github.seijikohara.dbtester.api.config.ConventionSettings;
 import io.github.seijikohara.dbtester.api.config.DataSourceRegistry;
-import io.github.seijikohara.dbtester.api.config.OperationDefaults;
-import io.github.seijikohara.dbtester.api.config.RowOrdering;
 import io.github.seijikohara.dbtester.api.context.TestContext;
-import io.github.seijikohara.dbtester.api.dataset.Row;
-import io.github.seijikohara.dbtester.api.dataset.Table;
-import io.github.seijikohara.dbtester.api.dataset.TableSet;
-import io.github.seijikohara.dbtester.api.domain.CellValue;
-import io.github.seijikohara.dbtester.api.domain.ColumnName;
-import io.github.seijikohara.dbtester.api.domain.TableName;
 import io.github.seijikohara.dbtester.api.exception.ValidationException;
 import io.github.seijikohara.dbtester.api.loader.DataSetLoader;
-import io.github.seijikohara.dbtester.api.loader.ExpectedTableSet;
-import io.github.seijikohara.dbtester.api.spi.ExpectationProvider;
-import java.lang.reflect.Field;
-import java.time.Duration;
-import java.util.Collection;
+import io.github.seijikohara.dbtester.api.spi.ExpectationSupport;
 import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import javax.sql.DataSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -43,11 +25,13 @@ import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link ExpectationVerifier}. */
 @DisplayName("ExpectationVerifier")
-@SuppressWarnings("unchecked")
 class ExpectationVerifierTest {
 
   /** Tests for the ExpectationVerifier class. */
   ExpectationVerifierTest() {}
+
+  /** Mock expectation support for tests. */
+  private ExpectationSupport mockSupport;
 
   /** The verifier instance under test. */
   private ExpectationVerifier verifier;
@@ -55,7 +39,8 @@ class ExpectationVerifierTest {
   /** Sets up test fixtures before each test. */
   @BeforeEach
   void setUp() {
-    verifier = new ExpectationVerifier();
+    mockSupport = mock(ExpectationSupport.class);
+    verifier = new ExpectationVerifier(mockSupport);
   }
 
   /** Tests for the constructor. */
@@ -72,20 +57,51 @@ class ExpectationVerifierTest {
     @DisplayName("should create instance when called")
     void shouldCreateInstance_whenCalled() {
       // When
-      final var instance = new ExpectationVerifier();
+      final var instance = new ExpectationVerifier(mockSupport);
 
       // Then
       assertNotNull(instance, "instance should not be null");
     }
   }
 
-  /** Tests for the verify(TestContext, Expectation) method. */
+  /** Tests for the verify(TestContext, ExpectedDataSet) method. */
   @Nested
-  @DisplayName("verify(TestContext, Expectation) method")
+  @DisplayName("verify(TestContext, ExpectedDataSet) method")
   class VerifyMethod {
 
     /** Tests for the verify method. */
     VerifyMethod() {}
+
+    /**
+     * Verifies that verify delegates to expectation support.
+     *
+     * @throws NoSuchMethodException if the test method is not found
+     */
+    @Test
+    @Tag("normal")
+    @DisplayName("should delegate to expectation support")
+    void shouldDelegateToSupport_whenCalled() throws NoSuchMethodException {
+      // Given
+      final var mockConfiguration = mock(Configuration.class);
+      final var mockLoader = mock(DataSetLoader.class);
+      final var mockRegistry = mock(DataSourceRegistry.class);
+
+      when(mockConfiguration.loader()).thenReturn(mockLoader);
+      when(mockLoader.loadExpectationDataSetsWithExclusions(any(TestContext.class)))
+          .thenReturn(Collections.emptyList());
+
+      final var testClass = TestClass.class;
+      final var testMethod = testClass.getDeclaredMethod("testMethod");
+      final var context = new TestContext(testClass, testMethod, mockConfiguration, mockRegistry);
+
+      final var expectedDataSet = testMethod.getAnnotation(ExpectedDataSet.class);
+
+      // When
+      verifier.verify(context, expectedDataSet);
+
+      // Then
+      verify(mockSupport).verify(context, expectedDataSet);
+    }
 
     /**
      * Verifies that verify completes without error when no datasets found.
@@ -118,345 +134,38 @@ class ExpectationVerifierTest {
     }
 
     /**
-     * Verifies that verify processes datasets when found.
+     * Verifies that verify propagates validation exception from support.
      *
-     * @throws Exception if reflection or test setup fails
-     */
-    @Test
-    @Tag("normal")
-    @DisplayName("should verify expectation when datasets found")
-    void shouldVerifyExpectation_whenDatasetsFound() throws Exception {
-      // Given
-      final var mockConfiguration = mock(Configuration.class);
-      final var mockLoader = mock(DataSetLoader.class);
-      final var mockConventions = mock(ConventionSettings.class);
-      final var mockDataSource = mock(DataSource.class);
-      final var mockExpectationProvider = mock(ExpectationProvider.class);
-
-      final var registry = new DataSourceRegistry();
-      registry.registerDefault(mockDataSource);
-
-      // Create a simple TableSet
-      final var table =
-          Table.of(
-              new TableName("users"),
-              List.of(new ColumnName("id"), new ColumnName("name")),
-              List.of(
-                  Row.of(
-                      Map.of(
-                          new ColumnName("id"),
-                          new CellValue("1"),
-                          new ColumnName("name"),
-                          new CellValue("John")))));
-      final var tableSet = TableSet.of(table);
-      final var expectedTableSet =
-          new ExpectedTableSet(tableSet, Collections.emptySet(), Collections.emptyMap());
-
-      when(mockConfiguration.loader()).thenReturn(mockLoader);
-      when(mockConfiguration.conventions()).thenReturn(mockConventions);
-      when(mockConfiguration.operations()).thenReturn(OperationDefaults.standard());
-      when(mockLoader.loadExpectationDataSetsWithExclusions(any(TestContext.class)))
-          .thenReturn(List.of(expectedTableSet));
-      when(mockConventions.retryCount()).thenReturn(0);
-      when(mockConventions.retryDelay()).thenReturn(Duration.ofMillis(100));
-
-      // Inject mock ExpectationProvider using reflection
-      final Field providerField = ExpectationVerifier.class.getDeclaredField("expectationProvider");
-      providerField.setAccessible(true);
-      providerField.set(verifier, mockExpectationProvider);
-
-      final var testClass = TestClass.class;
-      final var testMethod = testClass.getDeclaredMethod("testMethod");
-      final var context = new TestContext(testClass, testMethod, mockConfiguration, registry);
-
-      final var expectedDataSet = testMethod.getAnnotation(ExpectedDataSet.class);
-
-      // When
-      verifier.verify(context, expectedDataSet);
-
-      // Then
-      verify(mockExpectationProvider)
-          .verifyExpectation(
-              any(TableSet.class),
-              any(DataSource.class),
-              any(Collection.class),
-              any(Map.class),
-              any(RowOrdering.class),
-              any(OperationDefaults.class));
-    }
-
-    /**
-     * Verifies that verify uses annotation retry count when specified.
-     *
-     * @throws Exception if reflection or test setup fails
-     */
-    @Test
-    @Tag("normal")
-    @DisplayName("should use annotation retry count when specified")
-    void shouldUseAnnotationRetryCount_whenSpecified() throws Exception {
-      // Given
-      final var mockConfiguration = mock(Configuration.class);
-      final var mockLoader = mock(DataSetLoader.class);
-      final var mockConventions = mock(ConventionSettings.class);
-      final var mockDataSource = mock(DataSource.class);
-      final var mockExpectationProvider = mock(ExpectationProvider.class);
-
-      final var registry = new DataSourceRegistry();
-      registry.registerDefault(mockDataSource);
-
-      final var table =
-          Table.of(
-              new TableName("users"),
-              List.of(new ColumnName("id")),
-              List.of(Row.of(Map.of(new ColumnName("id"), new CellValue("1")))));
-      final var tableSet = TableSet.of(table);
-      final var expectedTableSet =
-          new ExpectedTableSet(tableSet, Collections.emptySet(), Collections.emptyMap());
-
-      when(mockConfiguration.loader()).thenReturn(mockLoader);
-      when(mockConfiguration.conventions()).thenReturn(mockConventions);
-      when(mockConfiguration.operations()).thenReturn(OperationDefaults.standard());
-      when(mockLoader.loadExpectationDataSetsWithExclusions(any(TestContext.class)))
-          .thenReturn(List.of(expectedTableSet));
-      when(mockConventions.retryCount()).thenReturn(5);
-      when(mockConventions.retryDelay()).thenReturn(Duration.ofMillis(100));
-
-      final Field providerField = ExpectationVerifier.class.getDeclaredField("expectationProvider");
-      providerField.setAccessible(true);
-      providerField.set(verifier, mockExpectationProvider);
-
-      final var testClass = TestClassWithRetrySettings.class;
-      final var testMethod = testClass.getDeclaredMethod("testMethod");
-      final var context = new TestContext(testClass, testMethod, mockConfiguration, registry);
-
-      final var expectedDataSet = testMethod.getAnnotation(ExpectedDataSet.class);
-
-      // When
-      verifier.verify(context, expectedDataSet);
-
-      // Then - verify was called (using annotation's retryCount=2)
-      verify(mockExpectationProvider)
-          .verifyExpectation(
-              any(TableSet.class),
-              any(DataSource.class),
-              any(Collection.class),
-              any(Map.class),
-              any(RowOrdering.class),
-              any(OperationDefaults.class));
-    }
-
-    /**
-     * Verifies that verify retries on validation exception.
-     *
-     * @throws Exception if reflection or test setup fails
+     * @throws NoSuchMethodException if the test method is not found
      */
     @Test
     @Tag("exceptional")
-    @DisplayName("should retry and succeed on validation exception")
-    void shouldRetryAndSucceed_onValidationException() throws Exception {
+    @DisplayName("should propagate validation exception from support")
+    void shouldPropagateValidationException_fromSupport() throws NoSuchMethodException {
       // Given
       final var mockConfiguration = mock(Configuration.class);
       final var mockLoader = mock(DataSetLoader.class);
-      final var mockConventions = mock(ConventionSettings.class);
-      final var mockDataSource = mock(DataSource.class);
-      final var mockExpectationProvider = mock(ExpectationProvider.class);
-
-      final var registry = new DataSourceRegistry();
-      registry.registerDefault(mockDataSource);
-
-      final var table =
-          Table.of(
-              new TableName("users"),
-              List.of(new ColumnName("id")),
-              List.of(Row.of(Map.of(new ColumnName("id"), new CellValue("1")))));
-      final var tableSet = TableSet.of(table);
-      final var expectedTableSet =
-          new ExpectedTableSet(tableSet, Collections.emptySet(), Collections.emptyMap());
+      final var mockRegistry = mock(DataSourceRegistry.class);
 
       when(mockConfiguration.loader()).thenReturn(mockLoader);
-      when(mockConfiguration.conventions()).thenReturn(mockConventions);
-      when(mockConfiguration.operations()).thenReturn(OperationDefaults.standard());
       when(mockLoader.loadExpectationDataSetsWithExclusions(any(TestContext.class)))
-          .thenReturn(List.of(expectedTableSet));
-      when(mockConventions.retryCount()).thenReturn(2);
-      when(mockConventions.retryDelay()).thenReturn(Duration.ofMillis(10));
-
-      // Fail first time, succeed second time
-      doThrow(new ValidationException("First attempt failed"))
-          .doNothing()
-          .when(mockExpectationProvider)
-          .verifyExpectation(
-              any(TableSet.class),
-              any(DataSource.class),
-              any(Collection.class),
-              any(Map.class),
-              any(RowOrdering.class),
-              any(OperationDefaults.class));
-
-      final Field providerField = ExpectationVerifier.class.getDeclaredField("expectationProvider");
-      providerField.setAccessible(true);
-      providerField.set(verifier, mockExpectationProvider);
+          .thenReturn(Collections.emptyList());
 
       final var testClass = TestClass.class;
       final var testMethod = testClass.getDeclaredMethod("testMethod");
-      final var context = new TestContext(testClass, testMethod, mockConfiguration, registry);
+      final var context = new TestContext(testClass, testMethod, mockConfiguration, mockRegistry);
 
       final var expectedDataSet = testMethod.getAnnotation(ExpectedDataSet.class);
 
-      // When & Then
-      assertDoesNotThrow(
-          () -> verifier.verify(context, expectedDataSet), "should succeed after retry");
-
-      verify(mockExpectationProvider, times(2))
-          .verifyExpectation(
-              any(TableSet.class),
-              any(DataSource.class),
-              any(Collection.class),
-              any(Map.class),
-              any(RowOrdering.class),
-              any(OperationDefaults.class));
-    }
-
-    /**
-     * Verifies that verify throws exception after all retries exhausted.
-     *
-     * @throws Exception if reflection or test setup fails
-     */
-    @Test
-    @Tag("exceptional")
-    @DisplayName("should throw exception after all retries exhausted")
-    void shouldThrowException_afterAllRetriesExhausted() throws Exception {
-      // Given
-      final var mockConfiguration = mock(Configuration.class);
-      final var mockLoader = mock(DataSetLoader.class);
-      final var mockConventions = mock(ConventionSettings.class);
-      final var mockDataSource = mock(DataSource.class);
-      final var mockExpectationProvider = mock(ExpectationProvider.class);
-
-      final var registry = new DataSourceRegistry();
-      registry.registerDefault(mockDataSource);
-
-      final var table =
-          Table.of(
-              new TableName("users"),
-              List.of(new ColumnName("id")),
-              List.of(Row.of(Map.of(new ColumnName("id"), new CellValue("1")))));
-      final var tableSet = TableSet.of(table);
-      final var expectedTableSet =
-          new ExpectedTableSet(tableSet, Collections.emptySet(), Collections.emptyMap());
-
-      when(mockConfiguration.loader()).thenReturn(mockLoader);
-      when(mockConfiguration.conventions()).thenReturn(mockConventions);
-      when(mockConfiguration.operations()).thenReturn(OperationDefaults.standard());
-      when(mockLoader.loadExpectationDataSetsWithExclusions(any(TestContext.class)))
-          .thenReturn(List.of(expectedTableSet));
-      when(mockConventions.retryCount()).thenReturn(1);
-      when(mockConventions.retryDelay()).thenReturn(Duration.ofMillis(10));
-
-      // Always fail
-      doThrow(new ValidationException("Persistent failure"))
-          .when(mockExpectationProvider)
-          .verifyExpectation(
-              any(TableSet.class),
-              any(DataSource.class),
-              any(Collection.class),
-              any(Map.class),
-              any(RowOrdering.class),
-              any(OperationDefaults.class));
-
-      final Field providerField = ExpectationVerifier.class.getDeclaredField("expectationProvider");
-      providerField.setAccessible(true);
-      providerField.set(verifier, mockExpectationProvider);
-
-      final var testClass = TestClass.class;
-      final var testMethod = testClass.getDeclaredMethod("testMethod");
-      final var context = new TestContext(testClass, testMethod, mockConfiguration, registry);
-
-      final var expectedDataSet = testMethod.getAnnotation(ExpectedDataSet.class);
+      doThrow(new ValidationException("Verification failed"))
+          .when(mockSupport)
+          .verify(any(TestContext.class), any(ExpectedDataSet.class));
 
       // When & Then
       assertThrows(
           ValidationException.class,
           () -> verifier.verify(context, expectedDataSet),
-          "should throw exception after retries exhausted");
-
-      // Should have tried 2 times (initial + 1 retry)
-      verify(mockExpectationProvider, times(2))
-          .verifyExpectation(
-              any(TableSet.class),
-              any(DataSource.class),
-              any(Collection.class),
-              any(Map.class),
-              any(RowOrdering.class),
-              any(OperationDefaults.class));
-    }
-
-    /**
-     * Verifies that verify handles exclusions and column strategies.
-     *
-     * @throws Exception if reflection or test setup fails
-     */
-    @Test
-    @Tag("normal")
-    @DisplayName("should handle exclusions and column strategies")
-    void shouldHandleExclusionsAndColumnStrategies() throws Exception {
-      // Given
-      final var mockConfiguration = mock(Configuration.class);
-      final var mockLoader = mock(DataSetLoader.class);
-      final var mockConventions = mock(ConventionSettings.class);
-      final var mockDataSource = mock(DataSource.class);
-      final var mockExpectationProvider = mock(ExpectationProvider.class);
-
-      final var registry = new DataSourceRegistry();
-      registry.registerDefault(mockDataSource);
-
-      final var table =
-          Table.of(
-              new TableName("users"),
-              List.of(new ColumnName("id"), new ColumnName("created_at")),
-              List.of(
-                  Row.of(
-                      Map.of(
-                          new ColumnName("id"),
-                          new CellValue("1"),
-                          new ColumnName("created_at"),
-                          new CellValue("2024-01-01")))));
-      final var tableSet = TableSet.of(table);
-      final var columnStrategy = ColumnStrategyMapping.ignore("CREATED_AT");
-      final var expectedTableSet =
-          new ExpectedTableSet(
-              tableSet, java.util.Set.of("CREATED_AT"), Map.of("CREATED_AT", columnStrategy));
-
-      when(mockConfiguration.loader()).thenReturn(mockLoader);
-      when(mockConfiguration.conventions()).thenReturn(mockConventions);
-      when(mockConfiguration.operations()).thenReturn(OperationDefaults.standard());
-      when(mockLoader.loadExpectationDataSetsWithExclusions(any(TestContext.class)))
-          .thenReturn(List.of(expectedTableSet));
-      when(mockConventions.retryCount()).thenReturn(0);
-      when(mockConventions.retryDelay()).thenReturn(Duration.ofMillis(100));
-
-      final Field providerField = ExpectationVerifier.class.getDeclaredField("expectationProvider");
-      providerField.setAccessible(true);
-      providerField.set(verifier, mockExpectationProvider);
-
-      final var testClass = TestClass.class;
-      final var testMethod = testClass.getDeclaredMethod("testMethod");
-      final var context = new TestContext(testClass, testMethod, mockConfiguration, registry);
-
-      final var expectedDataSet = testMethod.getAnnotation(ExpectedDataSet.class);
-
-      // When
-      verifier.verify(context, expectedDataSet);
-
-      // Then
-      verify(mockExpectationProvider)
-          .verifyExpectation(
-              any(TableSet.class),
-              any(DataSource.class),
-              any(Collection.class),
-              any(Map.class),
-              any(RowOrdering.class),
-              any(OperationDefaults.class));
+          "should propagate validation exception from support");
     }
   }
 

--- a/db-tester-junit/src/test/java/io/github/seijikohara/dbtester/junit/jupiter/lifecycle/PreparationExecutorTest.java
+++ b/db-tester-junit/src/test/java/io/github/seijikohara/dbtester/junit/jupiter/lifecycle/PreparationExecutorTest.java
@@ -9,26 +9,11 @@ import static org.mockito.Mockito.when;
 
 import io.github.seijikohara.dbtester.api.annotation.DataSet;
 import io.github.seijikohara.dbtester.api.config.Configuration;
-import io.github.seijikohara.dbtester.api.config.ConventionSettings;
 import io.github.seijikohara.dbtester.api.config.DataSourceRegistry;
-import io.github.seijikohara.dbtester.api.config.TransactionMode;
 import io.github.seijikohara.dbtester.api.context.TestContext;
-import io.github.seijikohara.dbtester.api.dataset.Row;
-import io.github.seijikohara.dbtester.api.dataset.Table;
-import io.github.seijikohara.dbtester.api.dataset.TableSet;
-import io.github.seijikohara.dbtester.api.domain.CellValue;
-import io.github.seijikohara.dbtester.api.domain.ColumnName;
-import io.github.seijikohara.dbtester.api.domain.TableName;
 import io.github.seijikohara.dbtester.api.loader.DataSetLoader;
-import io.github.seijikohara.dbtester.api.operation.Operation;
-import io.github.seijikohara.dbtester.api.operation.TableOrderingStrategy;
-import io.github.seijikohara.dbtester.api.spi.OperationProvider;
-import java.lang.reflect.Field;
-import java.time.Duration;
+import io.github.seijikohara.dbtester.api.spi.PreparationSupport;
 import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import javax.sql.DataSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -42,13 +27,17 @@ class PreparationExecutorTest {
   /** Tests for the PreparationExecutor class. */
   PreparationExecutorTest() {}
 
+  /** Mock preparation support for tests. */
+  private PreparationSupport mockSupport;
+
   /** The executor instance under test. */
   private PreparationExecutor executor;
 
   /** Sets up test fixtures before each test. */
   @BeforeEach
   void setUp() {
-    executor = new PreparationExecutor();
+    mockSupport = mock(PreparationSupport.class);
+    executor = new PreparationExecutor(mockSupport);
   }
 
   /** Tests for the constructor. */
@@ -65,30 +54,61 @@ class PreparationExecutorTest {
     @DisplayName("should create instance when called")
     void shouldCreateInstance_whenCalled() {
       // When
-      final var instance = new PreparationExecutor();
+      final var instance = new PreparationExecutor(mockSupport);
 
       // Then
       assertNotNull(instance, "instance should not be null");
     }
   }
 
-  /** Tests for the execute(TestContext, Preparation) method. */
+  /** Tests for the execute(TestContext, DataSet) method. */
   @Nested
-  @DisplayName("execute(TestContext, Preparation) method")
+  @DisplayName("execute(TestContext, DataSet) method")
   class ExecuteMethod {
 
     /** Tests for the execute method. */
     ExecuteMethod() {}
 
     /**
-     * Verifies that execute completes without error when no datasets found.
+     * Verifies that execute delegates to support.
      *
      * @throws NoSuchMethodException if the test method is not found
      */
     @Test
     @Tag("normal")
-    @DisplayName("should complete without error when no datasets found")
-    void shouldCompleteWithoutError_whenNoDatasetsFound() throws NoSuchMethodException {
+    @DisplayName("should delegate to preparation support")
+    void shouldDelegateToSupport_whenCalled() throws NoSuchMethodException {
+      // Given
+      final var mockConfiguration = mock(Configuration.class);
+      final var mockLoader = mock(DataSetLoader.class);
+      final var mockRegistry = mock(DataSourceRegistry.class);
+
+      when(mockConfiguration.loader()).thenReturn(mockLoader);
+      when(mockLoader.loadPreparationDataSets(any(TestContext.class)))
+          .thenReturn(Collections.emptyList());
+
+      final var testClass = TestClass.class;
+      final var testMethod = testClass.getDeclaredMethod("testMethod");
+      final var context = new TestContext(testClass, testMethod, mockConfiguration, mockRegistry);
+
+      final var dataSet = testMethod.getAnnotation(DataSet.class);
+
+      // When
+      executor.execute(context, dataSet);
+
+      // Then
+      verify(mockSupport).execute(context, dataSet);
+    }
+
+    /**
+     * Verifies that execute completes without error.
+     *
+     * @throws NoSuchMethodException if the test method is not found
+     */
+    @Test
+    @Tag("normal")
+    @DisplayName("should complete without error when called")
+    void shouldCompleteWithoutError_whenCalled() throws NoSuchMethodException {
       // Given
       final var mockConfiguration = mock(Configuration.class);
       final var mockLoader = mock(DataSetLoader.class);
@@ -106,121 +126,7 @@ class PreparationExecutorTest {
 
       // When & Then
       assertDoesNotThrow(
-          () -> executor.execute(context, dataSet),
-          "should complete without error when no datasets found");
-    }
-
-    /**
-     * Verifies that execute processes datasets when found.
-     *
-     * @throws Exception if reflection or test setup fails
-     */
-    @Test
-    @Tag("normal")
-    @DisplayName("should execute operation when datasets found")
-    void shouldExecuteOperation_whenDatasetsFound() throws Exception {
-      // Given
-      final var mockConfiguration = mock(Configuration.class);
-      final var mockLoader = mock(DataSetLoader.class);
-      final var mockConventions = mock(ConventionSettings.class);
-      final var mockDataSource = mock(DataSource.class);
-      final var mockOperationProvider = mock(OperationProvider.class);
-
-      final var registry = new DataSourceRegistry();
-      registry.registerDefault(mockDataSource);
-
-      // Create a simple TableSet
-      final var table =
-          Table.of(
-              new TableName("users"),
-              List.of(new ColumnName("id"), new ColumnName("name")),
-              List.of(
-                  Row.of(
-                      Map.of(
-                          new ColumnName("id"),
-                          new CellValue("1"),
-                          new ColumnName("name"),
-                          new CellValue("John")))));
-      final var tableSet = TableSet.of(table);
-
-      when(mockConfiguration.loader()).thenReturn(mockLoader);
-      when(mockConfiguration.conventions()).thenReturn(mockConventions);
-      when(mockLoader.loadPreparationDataSets(any(TestContext.class)))
-          .thenReturn(List.of(tableSet));
-      when(mockConventions.transactionMode()).thenReturn(TransactionMode.SINGLE_TRANSACTION);
-      when(mockConventions.queryTimeout()).thenReturn(Duration.ofSeconds(30));
-
-      // Inject mock OperationProvider using reflection
-      final Field providerField = PreparationExecutor.class.getDeclaredField("operationProvider");
-      providerField.setAccessible(true);
-      providerField.set(executor, mockOperationProvider);
-
-      final var testClass = TestClass.class;
-      final var testMethod = testClass.getDeclaredMethod("testMethod");
-      final var context = new TestContext(testClass, testMethod, mockConfiguration, registry);
-
-      final var dataSet = testMethod.getAnnotation(DataSet.class);
-
-      // When
-      executor.execute(context, dataSet);
-
-      // Then
-      verify(mockOperationProvider)
-          .execute(
-              any(Operation.class),
-              any(TableSet.class),
-              any(DataSource.class),
-              any(TableOrderingStrategy.class),
-              any(TransactionMode.class),
-              any(Duration.class));
-    }
-
-    /**
-     * Verifies that execute handles null query timeout.
-     *
-     * @throws Exception if reflection or test setup fails
-     */
-    @Test
-    @Tag("edge-case")
-    @DisplayName("should handle null query timeout")
-    void shouldHandleNullQueryTimeout() throws Exception {
-      // Given
-      final var mockConfiguration = mock(Configuration.class);
-      final var mockLoader = mock(DataSetLoader.class);
-      final var mockConventions = mock(ConventionSettings.class);
-      final var mockDataSource = mock(DataSource.class);
-      final var mockOperationProvider = mock(OperationProvider.class);
-
-      final var registry = new DataSourceRegistry();
-      registry.registerDefault(mockDataSource);
-
-      final var table =
-          Table.of(
-              new TableName("users"),
-              List.of(new ColumnName("id")),
-              List.of(Row.of(Map.of(new ColumnName("id"), new CellValue("1")))));
-      final var tableSet = TableSet.of(table);
-
-      when(mockConfiguration.loader()).thenReturn(mockLoader);
-      when(mockConfiguration.conventions()).thenReturn(mockConventions);
-      when(mockLoader.loadPreparationDataSets(any(TestContext.class)))
-          .thenReturn(List.of(tableSet));
-      when(mockConventions.transactionMode()).thenReturn(TransactionMode.AUTO_COMMIT);
-      when(mockConventions.queryTimeout()).thenReturn(null);
-
-      final Field providerField = PreparationExecutor.class.getDeclaredField("operationProvider");
-      providerField.setAccessible(true);
-      providerField.set(executor, mockOperationProvider);
-
-      final var testClass = TestClass.class;
-      final var testMethod = testClass.getDeclaredMethod("testMethod");
-      final var context = new TestContext(testClass, testMethod, mockConfiguration, registry);
-
-      final var dataSet = testMethod.getAnnotation(DataSet.class);
-
-      // When & Then
-      assertDoesNotThrow(
-          () -> executor.execute(context, dataSet), "should handle null query timeout");
+          () -> executor.execute(context, dataSet), "should complete without error when called");
     }
   }
 

--- a/db-tester-kotest/src/main/kotlin/io/github/seijikohara/dbtester/kotest/lifecycle/KotestExpectationVerifier.kt
+++ b/db-tester-kotest/src/main/kotlin/io/github/seijikohara/dbtester/kotest/lifecycle/KotestExpectationVerifier.kt
@@ -1,38 +1,25 @@
 package io.github.seijikohara.dbtester.kotest.lifecycle
 
 import io.github.seijikohara.dbtester.api.annotation.ExpectedDataSet
-import io.github.seijikohara.dbtester.api.config.RowOrdering
 import io.github.seijikohara.dbtester.api.context.TestContext
-import io.github.seijikohara.dbtester.api.exception.ValidationException
-import io.github.seijikohara.dbtester.api.loader.ExpectedTableSet
-import io.github.seijikohara.dbtester.api.spi.ExpectationProvider
-import org.slf4j.LoggerFactory
-import java.time.Duration
+import io.github.seijikohara.dbtester.api.spi.ExpectationSupport
 import java.util.ServiceLoader
 
 /**
  * Validates expectation datasets against the live database after test execution.
  *
- * The verifier delegates to [ExpectationProvider] for database operations. The verifier
- * opens a connection through the dataset's DataSource, applies column filtering so that
- * only declared columns participate in comparisons, and raises [ValidationException] when the
- * observed database state deviates from the expected dataset.
+ * This class delegates to [ExpectationSupport] for the actual verification logic. It
+ * provides a Kotest-specific facade for backward compatibility and framework-specific customization.
  *
- * Like [KotestPreparationExecutor], this class is stateless and thread-safe. It performs
- * structured logging to aid debugging and rewraps any [ValidationException] thrown by the
- * verifier with additional test context so failures remain actionable in the calling layer.
- *
+ * @property support the expectation support
+ * @see ExpectationSupport
  * @see KotestPreparationExecutor
- * @see ExpectationProvider
  */
-class KotestExpectationVerifier {
-    /** Companion object containing class-level logger. */
-    companion object {
-        private val logger = LoggerFactory.getLogger(KotestExpectationVerifier::class.java)
-    }
-
-    private val expectationProvider: ExpectationProvider =
-        ServiceLoader.load(ExpectationProvider::class.java).findFirst().orElseThrow()
+class KotestExpectationVerifier internal constructor(
+    private val support: ExpectationSupport,
+) {
+    /** Creates a new expectation verifier with a support loaded via ServiceLoader. */
+    constructor() : this(loadExpectationSupport())
 
     /**
      * Verifies the database state against expected datasets.
@@ -48,185 +35,18 @@ class KotestExpectationVerifier {
     fun verify(
         context: TestContext,
         expectedDataSet: ExpectedDataSet,
-    ): Unit =
-        context.testMethod().name.let { methodName ->
-            logger.debug(
-                "Verifying expectation for test: {}.{}",
-                context.testClass().simpleName,
-                methodName,
-            )
-            context
-                .configuration()
-                .loader()
-                .loadExpectationDataSetsWithExclusions(context)
-                .takeIf { expectedTableSets -> expectedTableSets.isNotEmpty() }
-                ?.also { expectedTableSets ->
-                    verifyWithRetry(
-                        context,
-                        expectedTableSets,
-                        methodName,
-                        expectedDataSet.rowOrdering,
-                        resolveRetryCount(expectedDataSet, context),
-                        resolveRetryDelay(expectedDataSet, context),
+    ): Unit = support.verify(context, expectedDataSet)
+
+    /** Companion object containing factory methods. */
+    companion object {
+        private fun loadExpectationSupport(): ExpectationSupport =
+            ServiceLoader
+                .load(ExpectationSupport::class.java)
+                .findFirst()
+                .orElseThrow {
+                    IllegalStateException(
+                        "No ExpectationSupport implementation found. Ensure db-tester-core is on the classpath.",
                     )
                 }
-                ?: logger.debug("No expectation datasets found")
-        }
-
-    /**
-     * Resolves the retry count from annotation or global settings.
-     *
-     * @param expectedDataSet the annotation
-     * @param context the test context
-     * @return the resolved retry count
-     */
-    private fun resolveRetryCount(
-        expectedDataSet: ExpectedDataSet,
-        context: TestContext,
-    ): Int =
-        expectedDataSet.retryCount
-            .takeIf { it >= 0 }
-            ?: context.configuration().conventions().retryCount()
-
-    /**
-     * Resolves the retry delay from annotation or global settings.
-     *
-     * @param expectedDataSet the annotation
-     * @param context the test context
-     * @return the resolved retry delay
-     */
-    private fun resolveRetryDelay(
-        expectedDataSet: ExpectedDataSet,
-        context: TestContext,
-    ): Duration =
-        expectedDataSet.retryDelayMillis
-            .takeIf { it >= 0 }
-            ?.let { Duration.ofMillis(it) }
-            ?: context.configuration().conventions().retryDelay()
-
-    /**
-     * Verifies expectation datasets with retry support.
-     *
-     * @param context the test context
-     * @param expectedTableSets the expected datasets
-     * @param methodName the test method name for logging
-     * @param rowOrdering the row ordering strategy
-     * @param retryCount the number of retries (0 = no retry)
-     * @param retryDelay the delay between retries
-     */
-    private fun verifyWithRetry(
-        context: TestContext,
-        expectedTableSets: List<ExpectedTableSet>,
-        methodName: String,
-        rowOrdering: RowOrdering,
-        retryCount: Int,
-        retryDelay: Duration,
-    ) {
-        var lastException: ValidationException? = null
-
-        for (attempt in 0..retryCount) {
-            try {
-                if (attempt > 0) {
-                    logger.debug(
-                        "Retry attempt {} of {} after {} ms delay",
-                        attempt,
-                        retryCount,
-                        retryDelay.toMillis(),
-                    )
-                    Thread.sleep(retryDelay.toMillis())
-                }
-
-                expectedTableSets.forEach { expectedTableSet ->
-                    verifyExpectedTableSet(context, expectedTableSet, methodName, rowOrdering)
-                }
-
-                // Success - exit the retry loop
-                return
-            } catch (e: ValidationException) {
-                lastException = e
-                if (attempt < retryCount) {
-                    logger.debug("Verification failed, will retry: {}", e.message)
-                }
-            } catch (e: InterruptedException) {
-                Thread.currentThread().interrupt()
-                throw ValidationException("Verification interrupted during retry delay", e)
-            }
-        }
-
-        // All retries exhausted, throw the last exception
-        throw lastException!!
     }
-
-    /**
-     * Verifies a single ExpectedTableSet against the database.
-     *
-     * Delegates to [ExpectationProvider.verifyExpectation] for full data comparison
-     * including column filtering, column comparison strategies, row ordering, and detailed
-     * assertion messages. If verification fails, wraps the exception with additional test context.
-     *
-     * @param context the test context providing access to the data source registry
-     * @param expectedTableSet the expected TableSet with exclusion and strategy metadata
-     * @param methodName the test method name for logging
-     * @param rowOrdering the row comparison strategy (ORDERED or UNORDERED)
-     * @throws ValidationException if verification fails with wrapped context information
-     */
-    private fun verifyExpectedTableSet(
-        context: TestContext,
-        expectedTableSet: ExpectedTableSet,
-        methodName: String,
-        rowOrdering: RowOrdering,
-    ): Unit =
-        expectedTableSet.tableSet().let { tableSet ->
-            val excludeColumns = expectedTableSet.excludeColumns()
-            val columnStrategies = expectedTableSet.columnStrategies()
-            val dataSource = tableSet.dataSource.orElseGet { context.registry().get("") }
-            val tableCount = tableSet.tables.size
-
-            logger.info(
-                "Validating expectation dataset for {}: {} tables ({})",
-                methodName,
-                tableCount,
-                rowOrdering,
-            )
-
-            if (expectedTableSet.hasExclusions()) {
-                logger.debug("Excluding columns from verification: {}", excludeColumns)
-            }
-
-            if (expectedTableSet.hasColumnStrategies()) {
-                logger.debug("Using column strategies for: {}", columnStrategies.keys)
-            }
-
-            val operationDefaults = context.configuration().operations()
-
-            runCatching {
-                expectationProvider.verifyExpectation(
-                    tableSet,
-                    dataSource,
-                    excludeColumns,
-                    columnStrategies,
-                    rowOrdering,
-                    operationDefaults,
-                )
-            }.onSuccess {
-                logger.info(
-                    "Expectation validation completed successfully for {}: {} tables",
-                    methodName,
-                    tableCount,
-                )
-            }.onFailure { e ->
-                when (e) {
-                    is ValidationException -> {
-                        throw ValidationException(
-                            "Failed to verify expectation dataset for $methodName",
-                            e,
-                        )
-                    }
-
-                    else -> {
-                        throw e
-                    }
-                }
-            }
-        }
 }

--- a/db-tester-kotest/src/main/kotlin/io/github/seijikohara/dbtester/kotest/lifecycle/KotestPreparationExecutor.kt
+++ b/db-tester-kotest/src/main/kotlin/io/github/seijikohara/dbtester/kotest/lifecycle/KotestPreparationExecutor.kt
@@ -1,30 +1,24 @@
 package io.github.seijikohara.dbtester.kotest.lifecycle
 
 import io.github.seijikohara.dbtester.api.annotation.DataSet
-import io.github.seijikohara.dbtester.api.config.TransactionMode
 import io.github.seijikohara.dbtester.api.context.TestContext
-import io.github.seijikohara.dbtester.api.dataset.TableSet
-import io.github.seijikohara.dbtester.api.operation.Operation
-import io.github.seijikohara.dbtester.api.operation.TableOrderingStrategy
-import io.github.seijikohara.dbtester.api.spi.OperationProvider
-import org.slf4j.LoggerFactory
-import java.time.Duration
+import io.github.seijikohara.dbtester.api.spi.PreparationSupport
 import java.util.ServiceLoader
 
 /**
  * Executes the preparation phase of database testing.
  *
- * This class loads datasets according to the [DataSet] annotation and applies them to
- * the database using the configured operation.
+ * This class delegates to [PreparationSupport] for the actual preparation logic. It
+ * provides a Kotest-specific facade for backward compatibility and framework-specific customization.
+ *
+ * @property support the preparation support
+ * @see PreparationSupport
  */
-class KotestPreparationExecutor {
-    /** Companion object containing class-level logger. */
-    companion object {
-        private val logger = LoggerFactory.getLogger(KotestPreparationExecutor::class.java)
-    }
-
-    private val operationProvider: OperationProvider =
-        ServiceLoader.load(OperationProvider::class.java).findFirst().orElseThrow()
+class KotestPreparationExecutor internal constructor(
+    private val support: PreparationSupport,
+) {
+    /** Creates a new preparation executor with a support loaded via ServiceLoader. */
+    constructor() : this(loadPreparationSupport())
 
     /**
      * Executes the preparation phase.
@@ -38,64 +32,18 @@ class KotestPreparationExecutor {
     fun execute(
         context: TestContext,
         dataSet: DataSet,
-    ): Unit =
-        logger
-            .debug(
-                "Executing preparation for test: {}.{}",
-                context.testClass().simpleName,
-                context.testMethod().name,
-            ).let {
-                context
-                    .configuration()
-                    .loader()
-                    .loadPreparationDataSets(context)
-                    .takeIf { tableSets -> tableSets.isNotEmpty() }
-                    ?.also { tableSets ->
-                        tableSets.forEach { tableSet ->
-                            executeTableSet(context, tableSet, dataSet.operation, dataSet.tableOrdering)
-                        }
-                    }
-                    ?: logger.debug("No preparation datasets found")
-            }
+    ): Unit = support.execute(context, dataSet)
 
-    /**
-     * Executes a single TableSet against the database.
-     *
-     * This method resolves the DataSource from either the TableSet itself or falls back to the
-     * default registry. It then delegates to the operation executor to apply the TableSet using the
-     * specified operation.
-     *
-     * @param context the test context providing access to the data source registry
-     * @param tableSet the TableSet to execute containing tables and optional data source
-     * @param operation the database operation to perform (CLEAN_INSERT, INSERT, etc.)
-     * @param tableOrderingStrategy the strategy for determining table processing order
-     */
-    private fun executeTableSet(
-        context: TestContext,
-        tableSet: TableSet,
-        operation: Operation,
-        tableOrderingStrategy: TableOrderingStrategy,
-    ) {
-        val dataSource = tableSet.dataSource.orElseGet { context.registry().get("") }
-        val conventions = context.configuration().conventions()
-        val transactionMode: TransactionMode = conventions.transactionMode()
-        val queryTimeout: Duration? = conventions.queryTimeout()
-
-        logger.debug(
-            "Applying {} operation with dataset using {} table ordering (transactionMode={}, timeout={})",
-            operation,
-            tableOrderingStrategy,
-            transactionMode,
-            queryTimeout,
-        )
-
-        operationProvider.execute(
-            operation,
-            tableSet,
-            dataSource,
-            tableOrderingStrategy,
-            transactionMode,
-            queryTimeout,
-        )
+    /** Companion object containing factory methods. */
+    companion object {
+        private fun loadPreparationSupport(): PreparationSupport =
+            ServiceLoader
+                .load(PreparationSupport::class.java)
+                .findFirst()
+                .orElseThrow {
+                    IllegalStateException(
+                        "No PreparationSupport implementation found. Ensure db-tester-core is on the classpath.",
+                    )
+                }
     }
 }

--- a/db-tester-kotest/src/test/kotlin/io/github/seijikohara/dbtester/kotest/lifecycle/KotestExpectationVerifierSpec.kt
+++ b/db-tester-kotest/src/test/kotlin/io/github/seijikohara/dbtester/kotest/lifecycle/KotestExpectationVerifierSpec.kt
@@ -1,33 +1,26 @@
 package io.github.seijikohara.dbtester.kotest.lifecycle
 
 import io.github.seijikohara.dbtester.api.annotation.ExpectedDataSet
-import io.github.seijikohara.dbtester.api.config.ColumnStrategyMapping
 import io.github.seijikohara.dbtester.api.config.Configuration
 import io.github.seijikohara.dbtester.api.config.ConventionSettings
 import io.github.seijikohara.dbtester.api.config.DataSourceRegistry
 import io.github.seijikohara.dbtester.api.config.OperationDefaults
 import io.github.seijikohara.dbtester.api.config.RowOrdering
 import io.github.seijikohara.dbtester.api.context.TestContext
-import io.github.seijikohara.dbtester.api.dataset.Row
-import io.github.seijikohara.dbtester.api.dataset.Table
-import io.github.seijikohara.dbtester.api.dataset.TableSet
-import io.github.seijikohara.dbtester.api.domain.CellValue
-import io.github.seijikohara.dbtester.api.domain.ColumnName
-import io.github.seijikohara.dbtester.api.domain.TableName
 import io.github.seijikohara.dbtester.api.exception.ValidationException
 import io.github.seijikohara.dbtester.api.loader.DataSetLoader
-import io.github.seijikohara.dbtester.api.loader.ExpectedTableSet
 import io.github.seijikohara.dbtester.api.operation.TableOrderingStrategy
-import io.github.seijikohara.dbtester.api.spi.ExpectationProvider
+import io.github.seijikohara.dbtester.api.spi.ExpectationSupport
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.verify
-import javax.sql.DataSource
 
 /**
  * Unit tests for [KotestExpectationVerifier].
@@ -36,15 +29,22 @@ import javax.sql.DataSource
  * database state after test execution.
  */
 class KotestExpectationVerifierSpec : AnnotationSpec() {
+    /** Mock expectation support. */
+    private lateinit var mockSupport: ExpectationSupport
+
     /** The verifier under test. */
     private lateinit var verifier: KotestExpectationVerifier
 
     @BeforeEach
-    fun setup(): Unit = run { verifier = KotestExpectationVerifier() }
+    fun setup(): Unit =
+        run {
+            mockSupport = mockk(relaxed = true)
+            verifier = KotestExpectationVerifier(mockSupport)
+        }
 
     @Test
     fun `should create instance`(): Unit =
-        KotestExpectationVerifier().let { instance ->
+        KotestExpectationVerifier(mockSupport).let { instance ->
             instance shouldNotBe null
         }
 
@@ -60,144 +60,34 @@ class KotestExpectationVerifierSpec : AnnotationSpec() {
 
     @Test
     fun `should create multiple independent verifiers`(): Unit =
-        KotestExpectationVerifier().let { verifier1 ->
-            KotestExpectationVerifier().let { verifier2 ->
+        KotestExpectationVerifier(mockSupport).let { verifier1 ->
+            KotestExpectationVerifier(mockSupport).let { verifier2 ->
                 (verifier1 === verifier2) shouldBe false
             }
         }
 
     @Test
-    fun `should verify expectation when datasets are found`() {
-        // Given: a mock expectation provider
-        val mockExpectationProvider = mockk<ExpectationProvider>(relaxed = true)
-        val mockDataSource = mockk<DataSource>()
-
-        // Inject mock provider using reflection
-        injectExpectationProvider(verifier, mockExpectationProvider)
-
-        // Given: a context with expected datasets
-        val registry = DataSourceRegistry()
-        registry.registerDefault(mockDataSource)
-        val context = createTestContextWithExpectedDatasets(registry)
-
-        // Given: a mock ExpectedDataSet annotation
+    fun `should delegate to expectation support`() {
+        // Given: a context and expected data set
+        val context = createTestContextWithEmptyDatasets()
         val expectedDataSet = createMockExpectedDataSet()
 
         // When: verifying expectation
         verifier.verify(context, expectedDataSet)
 
-        // Then: verification is executed
+        // Then: support is called
         verify(exactly = 1) {
-            mockExpectationProvider.verifyExpectation(
-                any(),
-                mockDataSource,
-                any(),
-                any(),
-                any(),
-                any(),
-            )
+            mockSupport.verify(context, expectedDataSet)
         }
     }
 
     @Test
-    fun `should use annotation retry count when specified`() {
-        // Given: a mock expectation provider
-        val mockExpectationProvider = mockk<ExpectationProvider>(relaxed = true)
-        val mockDataSource = mockk<DataSource>()
+    fun `should propagate validation exception from support`() {
+        // Given: a support that throws validation exception
+        val context = createTestContextWithEmptyDatasets()
+        val expectedDataSet = createMockExpectedDataSet()
 
-        // Inject mock provider using reflection
-        injectExpectationProvider(verifier, mockExpectationProvider)
-
-        // Given: a context with expected datasets
-        val registry = DataSourceRegistry()
-        registry.registerDefault(mockDataSource)
-        val context = createTestContextWithExpectedDatasets(registry)
-
-        // Given: a mock ExpectedDataSet annotation with retry settings
-        val expectedDataSet =
-            mockk<ExpectedDataSet>().also { eds ->
-                every { eds.retryCount } returns 2
-                every { eds.retryDelayMillis } returns 10
-                every { eds.rowOrdering } returns RowOrdering.ORDERED
-            }
-
-        // When: verifying expectation
-        verifier.verify(context, expectedDataSet)
-
-        // Then: verification is executed
-        verify(exactly = 1) {
-            mockExpectationProvider.verifyExpectation(
-                any(),
-                mockDataSource,
-                any(),
-                any(),
-                RowOrdering.ORDERED,
-                any(),
-            )
-        }
-    }
-
-    @Test
-    fun `should retry and succeed on validation exception`() {
-        // Given: a mock expectation provider that fails first then succeeds
-        val mockExpectationProvider = mockk<ExpectationProvider>()
-        val mockDataSource = mockk<DataSource>()
-        var callCount = 0
-
-        every { mockExpectationProvider.verifyExpectation(any(), any(), any(), any(), any(), any()) } answers {
-            callCount++
-            if (callCount == 1) {
-                throw ValidationException("First attempt failed")
-            }
-        }
-
-        // Inject mock provider using reflection
-        injectExpectationProvider(verifier, mockExpectationProvider)
-
-        // Given: a context with expected datasets
-        val registry = DataSourceRegistry()
-        registry.registerDefault(mockDataSource)
-        val context = createTestContextWithExpectedDatasets(registry)
-
-        // Given: a mock ExpectedDataSet annotation with retry settings
-        val expectedDataSet =
-            mockk<ExpectedDataSet>().also { eds ->
-                every { eds.retryCount } returns 2
-                every { eds.retryDelayMillis } returns 10
-                every { eds.rowOrdering } returns RowOrdering.ORDERED
-            }
-
-        // When: verifying expectation
-        verifier.verify(context, expectedDataSet)
-
-        // Then: verification succeeds after retry
-        callCount shouldBe 2
-    }
-
-    @Test
-    fun `should throw exception after all retries exhausted`() {
-        // Given: a mock expectation provider that always fails
-        val mockExpectationProvider = mockk<ExpectationProvider>()
-        val mockDataSource = mockk<DataSource>()
-
-        every { mockExpectationProvider.verifyExpectation(any(), any(), any(), any(), any(), any()) } throws
-            ValidationException("Always fails")
-
-        // Inject mock provider using reflection
-        injectExpectationProvider(verifier, mockExpectationProvider)
-
-        // Given: a context with expected datasets
-        val registry = DataSourceRegistry()
-        registry.registerDefault(mockDataSource)
-        val context = createTestContextWithExpectedDatasets(registry)
-
-        // Given: a mock ExpectedDataSet annotation with retry settings
-        val expectedDataSet =
-            mockk<ExpectedDataSet>().also { eds ->
-                every { eds.retryCount } returns 1
-                every { eds.retryDelayMillis } returns 10
-                every { eds.rowOrdering } returns RowOrdering.ORDERED
-            }
+        every { mockSupport.verify(any(), any()) } throws ValidationException("Verification failed")
 
         // When/Then: verifying expectation throws ValidationException
         shouldThrow<ValidationException> {
@@ -206,132 +96,69 @@ class KotestExpectationVerifierSpec : AnnotationSpec() {
     }
 
     @Test
-    fun `should handle exclusions and column strategies`() {
-        // Given: a mock expectation provider
-        val mockExpectationProvider = mockk<ExpectationProvider>(relaxed = true)
-        val mockDataSource = mockk<DataSource>()
-
-        // Inject mock provider using reflection
-        injectExpectationProvider(verifier, mockExpectationProvider)
-
-        // Given: a context with expected datasets having exclusions
-        val registry = DataSourceRegistry()
-        registry.registerDefault(mockDataSource)
-        val context = createTestContextWithExclusions(registry)
-
-        // Given: a mock ExpectedDataSet annotation
+    fun `should handle ordered row verification`() {
+        // Given: a context and expected data set with ordered rows
+        val context = createTestContextWithEmptyDatasets()
         val expectedDataSet =
             mockk<ExpectedDataSet>().also { eds ->
                 every { eds.retryCount } returns 0
                 every { eds.retryDelayMillis } returns -1
                 every { eds.rowOrdering } returns RowOrdering.ORDERED
+                every { eds.sources } returns emptyArray()
+                every { eds.tableOrdering } returns TableOrderingStrategy.AUTO
             }
 
         // When: verifying expectation
         verifier.verify(context, expectedDataSet)
 
-        // Then: verification is executed with exclusions
+        // Then: support is called with the expected data set
         verify(exactly = 1) {
-            mockExpectationProvider.verifyExpectation(
-                any(),
-                mockDataSource,
-                match { it.contains("CREATED_AT") },
-                any(),
-                any(),
-                any(),
-            )
+            mockSupport.verify(context, expectedDataSet)
         }
     }
 
     @Test
-    fun `should handle column strategies in verification`() {
-        // Given: a mock expectation provider
-        val mockExpectationProvider = mockk<ExpectationProvider>(relaxed = true)
-        val mockDataSource = mockk<DataSource>()
-
-        // Inject mock provider using reflection
-        injectExpectationProvider(verifier, mockExpectationProvider)
-
-        // Given: a context with expected datasets having column strategies
-        val registry = DataSourceRegistry()
-        registry.registerDefault(mockDataSource)
-        val context = createTestContextWithColumnStrategies(registry)
-
-        // Given: a mock ExpectedDataSet annotation
+    fun `should handle unordered row verification`() {
+        // Given: a context and expected data set with unordered rows
+        val context = createTestContextWithEmptyDatasets()
         val expectedDataSet =
             mockk<ExpectedDataSet>().also { eds ->
                 every { eds.retryCount } returns 0
-                every { eds.retryDelayMillis } returns -1
-                every { eds.rowOrdering } returns RowOrdering.ORDERED
-            }
-
-        // When: verifying expectation
-        verifier.verify(context, expectedDataSet)
-
-        // Then: verification is executed with column strategies
-        verify(exactly = 1) {
-            mockExpectationProvider.verifyExpectation(
-                any(),
-                mockDataSource,
-                any(),
-                match { it.containsKey("AMOUNT") },
-                any(),
-                any(),
-            )
-        }
-    }
-
-    @Test
-    fun `should use convention retry count when annotation has negative value`() {
-        // Given: a mock expectation provider
-        val mockExpectationProvider = mockk<ExpectationProvider>(relaxed = true)
-        val mockDataSource = mockk<DataSource>()
-
-        // Inject mock provider using reflection
-        injectExpectationProvider(verifier, mockExpectationProvider)
-
-        // Given: a context with expected datasets and custom conventions
-        val registry = DataSourceRegistry()
-        registry.registerDefault(mockDataSource)
-        val context = createTestContextWithRetryConventions(registry)
-
-        // Given: a mock ExpectedDataSet annotation with negative retry values (use convention)
-        val expectedDataSet =
-            mockk<ExpectedDataSet>().also { eds ->
-                every { eds.retryCount } returns -1
                 every { eds.retryDelayMillis } returns -1
                 every { eds.rowOrdering } returns RowOrdering.UNORDERED
+                every { eds.sources } returns emptyArray()
+                every { eds.tableOrdering } returns TableOrderingStrategy.AUTO
             }
 
         // When: verifying expectation
         verifier.verify(context, expectedDataSet)
 
-        // Then: verification is executed
+        // Then: support is called with the expected data set
         verify(exactly = 1) {
-            mockExpectationProvider.verifyExpectation(
-                any(),
-                mockDataSource,
-                any(),
-                any(),
-                RowOrdering.UNORDERED,
-                any(),
-            )
+            mockSupport.verify(context, expectedDataSet)
         }
     }
 
-    /**
-     * Injects a mock ExpectationProvider into the verifier using reflection.
-     *
-     * @param verifier the verifier to inject into
-     * @param mockProvider the mock provider to inject
-     */
-    private fun injectExpectationProvider(
-        verifier: KotestExpectationVerifier,
-        mockProvider: ExpectationProvider,
-    ) {
-        val providerField = KotestExpectationVerifier::class.java.getDeclaredField("expectationProvider")
-        providerField.isAccessible = true
-        providerField.set(verifier, mockProvider)
+    @Test
+    fun `should handle retry count settings`() {
+        // Given: a context and expected data set with retry settings
+        val context = createTestContextWithEmptyDatasets()
+        val expectedDataSet =
+            mockk<ExpectedDataSet>().also { eds ->
+                every { eds.retryCount } returns 3
+                every { eds.retryDelayMillis } returns 100
+                every { eds.rowOrdering } returns RowOrdering.ORDERED
+                every { eds.sources } returns emptyArray()
+                every { eds.tableOrdering } returns TableOrderingStrategy.AUTO
+            }
+
+        // When: verifying expectation
+        verifier.verify(context, expectedDataSet)
+
+        // Then: support is called with the expected data set (retry logic is handled by support)
+        verify(exactly = 1) {
+            mockSupport.verify(context, expectedDataSet)
+        }
     }
 
     /**
@@ -360,204 +187,6 @@ class KotestExpectationVerifierSpec : AnnotationSpec() {
                                 }
                             }
                     }
-            }
-        }
-
-    /**
-     * Creates a TestContext with expected datasets.
-     *
-     * @param registry the registry to use
-     * @return the test context
-     */
-    private fun createTestContextWithExpectedDatasets(registry: DataSourceRegistry): TestContext =
-        SampleTestClass::class.java.let { testClass ->
-            testClass.getMethod("sampleMethod").let { testMethod ->
-                // Create a simple table set
-                val table =
-                    Table.of(
-                        TableName("users"),
-                        listOf(ColumnName("id"), ColumnName("name")),
-                        listOf(
-                            Row.of(
-                                mapOf(
-                                    ColumnName("id") to CellValue("1"),
-                                    ColumnName("name") to CellValue("John"),
-                                ),
-                            ),
-                        ),
-                    )
-                val tableSet = TableSet.of(table)
-                val expectedTableSet = ExpectedTableSet(tableSet, emptySet(), emptyMap())
-
-                val loader =
-                    object : DataSetLoader {
-                        override fun loadPreparationDataSets(context: TestContext): List<TableSet> = emptyList()
-
-                        override fun loadExpectationDataSets(context: TestContext): List<TableSet> = listOf(tableSet)
-
-                        override fun loadExpectationDataSetsWithExclusions(context: TestContext): List<ExpectedTableSet> =
-                            listOf(expectedTableSet)
-                    }
-
-                val configuration =
-                    Configuration
-                        .builder()
-                        .conventions(ConventionSettings.standard())
-                        .operations(OperationDefaults.standard())
-                        .loader(loader)
-                        .build()
-
-                TestContext(testClass, testMethod, configuration, registry)
-            }
-        }
-
-    /**
-     * Creates a TestContext with exclusions.
-     *
-     * @param registry the registry to use
-     * @return the test context
-     */
-    private fun createTestContextWithExclusions(registry: DataSourceRegistry): TestContext =
-        SampleTestClass::class.java.let { testClass ->
-            testClass.getMethod("sampleMethod").let { testMethod ->
-                val table =
-                    Table.of(
-                        TableName("users"),
-                        listOf(ColumnName("id"), ColumnName("name"), ColumnName("created_at")),
-                        listOf(
-                            Row.of(
-                                mapOf(
-                                    ColumnName("id") to CellValue("1"),
-                                    ColumnName("name") to CellValue("John"),
-                                ),
-                            ),
-                        ),
-                    )
-                val tableSet = TableSet.of(table)
-                val expectedTableSet = ExpectedTableSet(tableSet, setOf("CREATED_AT"), emptyMap())
-
-                val loader =
-                    object : DataSetLoader {
-                        override fun loadPreparationDataSets(context: TestContext): List<TableSet> = emptyList()
-
-                        override fun loadExpectationDataSets(context: TestContext): List<TableSet> = listOf(tableSet)
-
-                        override fun loadExpectationDataSetsWithExclusions(context: TestContext): List<ExpectedTableSet> =
-                            listOf(expectedTableSet)
-                    }
-
-                val configuration =
-                    Configuration
-                        .builder()
-                        .conventions(ConventionSettings.standard())
-                        .operations(OperationDefaults.standard())
-                        .loader(loader)
-                        .build()
-
-                TestContext(testClass, testMethod, configuration, registry)
-            }
-        }
-
-    /**
-     * Creates a TestContext with column strategies.
-     *
-     * @param registry the registry to use
-     * @return the test context
-     */
-    private fun createTestContextWithColumnStrategies(registry: DataSourceRegistry): TestContext =
-        SampleTestClass::class.java.let { testClass ->
-            testClass.getMethod("sampleMethod").let { testMethod ->
-                val table =
-                    Table.of(
-                        TableName("orders"),
-                        listOf(ColumnName("id"), ColumnName("amount")),
-                        listOf(
-                            Row.of(
-                                mapOf(
-                                    ColumnName("id") to CellValue("1"),
-                                    ColumnName("amount") to CellValue("100.50"),
-                                ),
-                            ),
-                        ),
-                    )
-                val tableSet = TableSet.of(table)
-                val columnStrategies: Map<String, ColumnStrategyMapping> =
-                    mapOf("AMOUNT" to ColumnStrategyMapping.numeric("AMOUNT"))
-                val expectedTableSet = ExpectedTableSet(tableSet, emptySet(), columnStrategies)
-
-                val loader =
-                    object : DataSetLoader {
-                        override fun loadPreparationDataSets(context: TestContext): List<TableSet> = emptyList()
-
-                        override fun loadExpectationDataSets(context: TestContext): List<TableSet> = listOf(tableSet)
-
-                        override fun loadExpectationDataSetsWithExclusions(context: TestContext): List<ExpectedTableSet> =
-                            listOf(expectedTableSet)
-                    }
-
-                val configuration =
-                    Configuration
-                        .builder()
-                        .conventions(ConventionSettings.standard())
-                        .operations(OperationDefaults.standard())
-                        .loader(loader)
-                        .build()
-
-                TestContext(testClass, testMethod, configuration, registry)
-            }
-        }
-
-    /**
-     * Creates a TestContext with custom retry conventions.
-     *
-     * @param registry the registry to use
-     * @return the test context
-     */
-    private fun createTestContextWithRetryConventions(registry: DataSourceRegistry): TestContext =
-        SampleTestClass::class.java.let { testClass ->
-            testClass.getMethod("sampleMethod").let { testMethod ->
-                val table =
-                    Table.of(
-                        TableName("users"),
-                        listOf(ColumnName("id"), ColumnName("name")),
-                        listOf(
-                            Row.of(
-                                mapOf(
-                                    ColumnName("id") to CellValue("1"),
-                                    ColumnName("name") to CellValue("John"),
-                                ),
-                            ),
-                        ),
-                    )
-                val tableSet = TableSet.of(table)
-                val expectedTableSet = ExpectedTableSet(tableSet, emptySet(), emptyMap())
-
-                val loader =
-                    object : DataSetLoader {
-                        override fun loadPreparationDataSets(context: TestContext): List<TableSet> = emptyList()
-
-                        override fun loadExpectationDataSets(context: TestContext): List<TableSet> = listOf(tableSet)
-
-                        override fun loadExpectationDataSetsWithExclusions(context: TestContext): List<ExpectedTableSet> =
-                            listOf(expectedTableSet)
-                    }
-
-                val conventions =
-                    ConventionSettings
-                        .builder()
-                        .retryCount(3)
-                        .retryDelay(java.time.Duration.ofMillis(50))
-                        .build()
-
-                val configuration =
-                    Configuration
-                        .builder()
-                        .conventions(conventions)
-                        .operations(OperationDefaults.standard())
-                        .loader(loader)
-                        .build()
-
-                TestContext(testClass, testMethod, configuration, registry)
             }
         }
 

--- a/db-tester-kotest/src/test/kotlin/io/github/seijikohara/dbtester/kotest/lifecycle/KotestPreparationExecutorSpec.kt
+++ b/db-tester-kotest/src/test/kotlin/io/github/seijikohara/dbtester/kotest/lifecycle/KotestPreparationExecutorSpec.kt
@@ -6,24 +6,19 @@ import io.github.seijikohara.dbtester.api.config.ConventionSettings
 import io.github.seijikohara.dbtester.api.config.DataSourceRegistry
 import io.github.seijikohara.dbtester.api.config.OperationDefaults
 import io.github.seijikohara.dbtester.api.context.TestContext
-import io.github.seijikohara.dbtester.api.dataset.Row
-import io.github.seijikohara.dbtester.api.dataset.Table
-import io.github.seijikohara.dbtester.api.dataset.TableSet
-import io.github.seijikohara.dbtester.api.domain.CellValue
-import io.github.seijikohara.dbtester.api.domain.ColumnName
-import io.github.seijikohara.dbtester.api.domain.TableName
 import io.github.seijikohara.dbtester.api.loader.DataSetLoader
 import io.github.seijikohara.dbtester.api.operation.Operation
 import io.github.seijikohara.dbtester.api.operation.TableOrderingStrategy
-import io.github.seijikohara.dbtester.api.spi.OperationProvider
+import io.github.seijikohara.dbtester.api.spi.PreparationSupport
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.verify
-import javax.sql.DataSource
 
 /**
  * Unit tests for [KotestPreparationExecutor].
@@ -32,15 +27,22 @@ import javax.sql.DataSource
  * and applies datasets before test execution.
  */
 class KotestPreparationExecutorSpec : AnnotationSpec() {
+    /** Mock preparation support. */
+    private lateinit var mockSupport: PreparationSupport
+
     /** The executor under test. */
     private lateinit var executor: KotestPreparationExecutor
 
     @BeforeEach
-    fun setup(): Unit = run { executor = KotestPreparationExecutor() }
+    fun setup(): Unit =
+        run {
+            mockSupport = mockk(relaxed = true)
+            executor = KotestPreparationExecutor(mockSupport)
+        }
 
     @Test
     fun `should create instance`(): Unit =
-        KotestPreparationExecutor().let { instance ->
+        KotestPreparationExecutor(mockSupport).let { instance ->
             instance shouldNotBe null
         }
 
@@ -56,42 +58,24 @@ class KotestPreparationExecutorSpec : AnnotationSpec() {
 
     @Test
     fun `should create multiple independent executors`(): Unit =
-        KotestPreparationExecutor().let { executor1 ->
-            KotestPreparationExecutor().let { executor2 ->
+        KotestPreparationExecutor(mockSupport).let { executor1 ->
+            KotestPreparationExecutor(mockSupport).let { executor2 ->
                 (executor1 === executor2) shouldBe false
             }
         }
 
     @Test
-    fun `should execute operation when datasets are found`() {
-        // Given: a mock operation provider
-        val mockOperationProvider = mockk<OperationProvider>(relaxed = true)
-        val mockDataSource = mockk<DataSource>()
-
-        // Inject mock provider using reflection
-        injectOperationProvider(executor, mockOperationProvider)
-
-        // Given: a context with datasets
-        val registry = DataSourceRegistry()
-        registry.registerDefault(mockDataSource)
-        val context = createTestContextWithDatasets(registry)
-
-        // Given: a mock DataSet annotation
+    fun `should delegate to preparation support`() {
+        // Given: a context and data set
+        val context = createTestContextWithEmptyDatasets()
         val dataSet = createMockDataSet(Operation.CLEAN_INSERT)
 
         // When: executing preparation
         executor.execute(context, dataSet)
 
-        // Then: operation is executed
+        // Then: support is called
         verify(exactly = 1) {
-            mockOperationProvider.execute(
-                Operation.CLEAN_INSERT,
-                any(),
-                mockDataSource,
-                TableOrderingStrategy.AUTO,
-                any(),
-                any(),
-            )
+            mockSupport.execute(context, dataSet)
         }
     }
 
@@ -112,34 +96,16 @@ class KotestPreparationExecutorSpec : AnnotationSpec() {
 
     @Test
     fun `should handle null query timeout from conventions`() {
-        // Given: a mock operation provider
-        val mockOperationProvider = mockk<OperationProvider>(relaxed = true)
-        val mockDataSource = mockk<DataSource>()
-
-        // Inject mock provider using reflection
-        injectOperationProvider(executor, mockOperationProvider)
-
-        // Given: a context with datasets and null query timeout
-        val registry = DataSourceRegistry()
-        registry.registerDefault(mockDataSource)
-        val context = createTestContextWithDatasets(registry, queryTimeout = null)
-
-        // Given: a mock DataSet annotation
+        // Given: a context with null query timeout
+        val context = createTestContextWithDatasets(queryTimeout = null)
         val dataSet = createMockDataSet(Operation.CLEAN_INSERT)
 
         // When: executing preparation
         executor.execute(context, dataSet)
 
-        // Then: operation is executed with null timeout
+        // Then: support is called
         verify(exactly = 1) {
-            mockOperationProvider.execute(
-                Operation.CLEAN_INSERT,
-                any(),
-                mockDataSource,
-                TableOrderingStrategy.AUTO,
-                any(),
-                null,
-            )
+            mockSupport.execute(context, dataSet)
         }
     }
 
@@ -149,51 +115,17 @@ class KotestPreparationExecutorSpec : AnnotationSpec() {
      * @param operation the operation to test
      */
     private fun testOperationType(operation: Operation) {
-        // Given: a mock operation provider
-        val mockOperationProvider = mockk<OperationProvider>(relaxed = true)
-        val mockDataSource = mockk<DataSource>()
-
-        // Create a fresh executor and inject mock provider
-        val testExecutor = KotestPreparationExecutor()
-        injectOperationProvider(testExecutor, mockOperationProvider)
-
-        // Given: a context with datasets
-        val registry = DataSourceRegistry()
-        registry.registerDefault(mockDataSource)
-        val context = createTestContextWithDatasets(registry)
-
-        // Given: a mock DataSet annotation with specified operation
+        // Given: a context and data set with specified operation
+        val context = createTestContextWithEmptyDatasets()
         val dataSet = createMockDataSet(operation)
 
         // When: executing preparation
-        testExecutor.execute(context, dataSet)
+        executor.execute(context, dataSet)
 
-        // Then: operation is executed with correct operation type
+        // Then: support is called with correct data set
         verify(exactly = 1) {
-            mockOperationProvider.execute(
-                operation,
-                any(),
-                mockDataSource,
-                any(),
-                any(),
-                any(),
-            )
+            mockSupport.execute(context, dataSet)
         }
-    }
-
-    /**
-     * Injects a mock OperationProvider into the executor using reflection.
-     *
-     * @param executor the executor to inject into
-     * @param mockProvider the mock provider to inject
-     */
-    private fun injectOperationProvider(
-        executor: KotestPreparationExecutor,
-        mockProvider: OperationProvider,
-    ) {
-        val providerField = KotestPreparationExecutor::class.java.getDeclaredField("operationProvider")
-        providerField.isAccessible = true
-        providerField.set(executor, mockProvider)
     }
 
     /**
@@ -226,43 +158,19 @@ class KotestPreparationExecutorSpec : AnnotationSpec() {
         }
 
     /**
-     * Creates a TestContext with actual datasets.
+     * Creates a TestContext with configuration.
      *
-     * @param registry the registry to use
      * @param queryTimeout whether to include query timeout (null for no timeout)
      * @return the test context
      */
-    private fun createTestContextWithDatasets(
-        registry: DataSourceRegistry,
-        queryTimeout: java.time.Duration? = java.time.Duration.ofSeconds(30),
-    ): TestContext =
+    private fun createTestContextWithDatasets(queryTimeout: java.time.Duration? = java.time.Duration.ofSeconds(30)): TestContext =
         SampleTestClass::class.java.let { testClass ->
             testClass.getMethod("sampleMethod").let { testMethod ->
-                // Create a simple table set
-                val table =
-                    Table.of(
-                        TableName("users"),
-                        listOf(ColumnName("id"), ColumnName("name")),
-                        listOf(
-                            Row.of(
-                                mapOf(
-                                    ColumnName("id") to CellValue("1"),
-                                    ColumnName("name") to CellValue("John"),
-                                ),
-                            ),
-                        ),
-                    )
-                val tableSet = TableSet.of(table)
-
                 val loader =
-                    object : DataSetLoader {
-                        override fun loadPreparationDataSets(context: TestContext): List<TableSet> = listOf(tableSet)
-
-                        override fun loadExpectationDataSets(context: TestContext): List<TableSet> = emptyList()
-
-                        override fun loadExpectationDataSetsWithExclusions(
-                            context: TestContext,
-                        ): List<io.github.seijikohara.dbtester.api.loader.ExpectedTableSet> = emptyList()
+                    mockk<DataSetLoader>().also { loader ->
+                        every { loader.loadPreparationDataSets(any()) } returns emptyList()
+                        every { loader.loadExpectationDataSets(any()) } returns emptyList()
+                        every { loader.loadExpectationDataSetsWithExclusions(any()) } returns emptyList()
                     }
 
                 val conventionsBuilder = ConventionSettings.builder()
@@ -279,7 +187,7 @@ class KotestPreparationExecutorSpec : AnnotationSpec() {
                         .loader(loader)
                         .build()
 
-                TestContext(testClass, testMethod, configuration, registry)
+                TestContext(testClass, testMethod, configuration, DataSourceRegistry())
             }
         }
 

--- a/db-tester-spock/src/main/groovy/io/github/seijikohara/dbtester/spock/lifecycle/SpockExpectationVerifier.groovy
+++ b/db-tester-spock/src/main/groovy/io/github/seijikohara/dbtester/spock/lifecycle/SpockExpectationVerifier.groovy
@@ -1,34 +1,40 @@
 package io.github.seijikohara.dbtester.spock.lifecycle
 
-import groovy.util.logging.Slf4j
 import io.github.seijikohara.dbtester.api.annotation.ExpectedDataSet
-import io.github.seijikohara.dbtester.api.config.RowOrdering
 import io.github.seijikohara.dbtester.api.context.TestContext
-import io.github.seijikohara.dbtester.api.exception.ValidationException
-import io.github.seijikohara.dbtester.api.loader.ExpectedTableSet
-import io.github.seijikohara.dbtester.api.spi.ExpectationProvider
-import java.time.Duration
+import io.github.seijikohara.dbtester.api.spi.ExpectationSupport
 
 /**
  * Validates expectation datasets against the live database after test execution.
  *
- * <p>The verifier delegates to {@link ExpectationProvider} for database operations. The verifier opens
- * a connection through the dataset's {@code DataSource}, applies column filtering so that only
- * declared columns participate in comparisons, and raises {@link ValidationException} when the
- * observed database state deviates from the expected dataset.
+ * <p>This class delegates to {@link ExpectationSupport} for the actual verification logic. It
+ * provides a Spock-specific facade for backward compatibility and framework-specific customization.
  *
- * <p>This class is stateless and thread-safe. It performs structured logging to aid debugging and
- * rewraps any {@link ValidationException} thrown by the verifier with additional test context so
- * failures remain actionable in the calling layer.
- *
+ * @see ExpectationSupport
  * @see SpockPreparationExecutor
- * @see ExpectationProvider
  */
-@Slf4j
 class SpockExpectationVerifier {
 
-	/** Provider for expectation verification operations. */
-	private final ExpectationProvider expectationProvider = ServiceLoader.load(ExpectationProvider).findFirst().orElseThrow()
+	/** The expectation support. */
+	private final ExpectationSupport support
+
+	/** Creates a new expectation verifier. */
+	SpockExpectationVerifier() {
+		this.support = ServiceLoader.load(ExpectationSupport).findFirst()
+				.orElseThrow {
+					-> new IllegalStateException(
+					'No ExpectationSupport implementation found. Ensure db-tester-core is on the classpath.')
+				}
+	}
+
+	/**
+	 * Creates a new expectation verifier with the specified support.
+	 *
+	 * @param support the expectation support
+	 */
+	SpockExpectationVerifier(ExpectationSupport support) {
+		this.support = Objects.requireNonNull(support, 'support must not be null')
+	}
 
 	/**
 	 * Verifies the database state against expected datasets.
@@ -45,138 +51,6 @@ class SpockExpectationVerifier {
 		Objects.requireNonNull(context, 'context must not be null')
 		Objects.requireNonNull(expectedDataSet, 'expectedDataSet must not be null')
 
-		log.debug('Verifying expectation for test: {}.{}',
-				context.testClass().simpleName,
-				context.testMethod().name)
-
-		def expectedTableSets = context.configuration().loader().loadExpectationDataSetsWithExclusions(context)
-
-		if (expectedTableSets.empty) {
-			log.debug('No expectation datasets found')
-			return
-		}
-
-		def rowOrdering = expectedDataSet.rowOrdering()
-		def retryCount = resolveRetryCount(expectedDataSet, context)
-		def retryDelay = resolveRetryDelay(expectedDataSet, context)
-
-		verifyWithRetry(context, expectedTableSets, rowOrdering, retryCount, retryDelay)
-	}
-
-	/**
-	 * Resolves the retry count from annotation or global settings.
-	 *
-	 * @param expectedDataSet the annotation
-	 * @param context the test context
-	 * @return the resolved retry count
-	 */
-	private int resolveRetryCount(ExpectedDataSet expectedDataSet, TestContext context) {
-		def annotationValue = expectedDataSet.retryCount()
-		annotationValue >= 0 ? annotationValue : context.configuration().conventions().retryCount()
-	}
-
-	/**
-	 * Resolves the retry delay from annotation or global settings.
-	 *
-	 * @param expectedDataSet the annotation
-	 * @param context the test context
-	 * @return the resolved retry delay
-	 */
-	private Duration resolveRetryDelay(ExpectedDataSet expectedDataSet, TestContext context) {
-		def annotationValue = expectedDataSet.retryDelayMillis()
-		annotationValue >= 0 ? Duration.ofMillis(annotationValue) : context.configuration().conventions().retryDelay()
-	}
-
-	/**
-	 * Verifies expectation datasets with retry support.
-	 *
-	 * @param context the test context
-	 * @param expectedTableSets the expected datasets
-	 * @param rowOrdering the row ordering strategy
-	 * @param retryCount the number of retries (0 = no retry)
-	 * @param retryDelay the delay between retries
-	 */
-	private void verifyWithRetry(
-			TestContext context,
-			List<ExpectedTableSet> expectedTableSets,
-			RowOrdering rowOrdering,
-			int retryCount,
-			Duration retryDelay) {
-		ValidationException lastException = null
-
-		for (int attempt = 0; attempt <= retryCount; attempt++) {
-			try {
-				if (attempt > 0) {
-					log.debug('Retry attempt {} of {} after {} ms delay', attempt, retryCount, retryDelay.toMillis())
-					Thread.sleep(retryDelay.toMillis())
-				}
-
-				expectedTableSets.each { expectedTableSet ->
-					verifyExpectedTableSet(context, expectedTableSet, rowOrdering)
-				}
-
-				// Success - exit the retry loop
-				return
-			} catch (ValidationException e) {
-				lastException = e
-				if (attempt < retryCount) {
-					log.debug('Verification failed, will retry: {}', e.message)
-				}
-			} catch (InterruptedException e) {
-				Thread.currentThread().interrupt()
-				throw new ValidationException('Verification interrupted during retry delay', e)
-			}
-		}
-
-		// All retries exhausted, throw the last exception
-		throw lastException
-	}
-
-	/**
-	 * Verifies a single expected table set against the database.
-	 *
-	 * <p>Delegates to {@link ExpectationProvider#verifyExpectation} for full data comparison including
-	 * column filtering, column comparison strategies, row ordering, and detailed assertion messages.
-	 * If verification fails, wraps the exception with additional test context.
-	 *
-	 * @param context the test context providing access to the data source registry
-	 * @param expectedTableSet the expected table set with exclusion and strategy metadata
-	 * @param rowOrdering the row comparison strategy (ORDERED or UNORDERED)
-	 * @throws ValidationException if verification fails with wrapped context information
-	 */
-	private void verifyExpectedTableSet(TestContext context, ExpectedTableSet expectedTableSet, RowOrdering rowOrdering) {
-		def tableSet = expectedTableSet.tableSet()
-		def excludeColumns = expectedTableSet.excludeColumns()
-		def columnStrategies = expectedTableSet.columnStrategies()
-		def dataSource = tableSet.dataSource
-				.orElseGet { -> context.registry().get('') }
-
-		def tableCount = tableSet.tables.size()
-		log.info('Validating expectation dataset for {}: {} tables ({})',
-				context.testMethod().name,
-				tableCount,
-				rowOrdering)
-
-		if (expectedTableSet.hasExclusions()) {
-			log.debug('Excluding columns from verification: {}', excludeColumns)
-		}
-
-		if (expectedTableSet.hasColumnStrategies()) {
-			log.debug('Using column strategies for: {}', columnStrategies.keySet())
-		}
-
-		def operationDefaults = context.configuration().operations()
-
-		try {
-			expectationProvider.verifyExpectation(tableSet, dataSource, excludeColumns, columnStrategies, rowOrdering, operationDefaults)
-
-			log.info('Expectation validation completed successfully for {}: {} tables',
-					context.testMethod().name,
-					tableCount)
-		} catch (ValidationException e) {
-			throw new ValidationException(
-			"Failed to verify expectation dataset for ${context.testMethod().name}",
-			e)
-		}
+		support.verify(context, expectedDataSet)
 	}
 }

--- a/db-tester-spock/src/main/groovy/io/github/seijikohara/dbtester/spock/lifecycle/SpockPreparationExecutor.groovy
+++ b/db-tester-spock/src/main/groovy/io/github/seijikohara/dbtester/spock/lifecycle/SpockPreparationExecutor.groovy
@@ -1,78 +1,53 @@
 package io.github.seijikohara.dbtester.spock.lifecycle
 
-import groovy.util.logging.Slf4j
 import io.github.seijikohara.dbtester.api.annotation.DataSet
-import io.github.seijikohara.dbtester.api.config.TransactionMode
 import io.github.seijikohara.dbtester.api.context.TestContext
-import io.github.seijikohara.dbtester.api.dataset.TableSet
-import io.github.seijikohara.dbtester.api.operation.Operation
-import io.github.seijikohara.dbtester.api.operation.TableOrderingStrategy
-import io.github.seijikohara.dbtester.api.spi.OperationProvider
-import java.time.Duration
+import io.github.seijikohara.dbtester.api.spi.PreparationSupport
 
 /**
  * Executes the preparation phase of database testing for Spock specifications.
  *
- * <p>This class loads datasets according to the {@link DataSet} annotation and applies them
- * to the database using the configured operation.
+ * <p>This class delegates to {@link PreparationSupport} for the actual preparation logic. It
+ * provides a Spock-specific facade for backward compatibility and framework-specific customization.
+ *
+ * @see PreparationSupport
  */
-@Slf4j
 class SpockPreparationExecutor {
 
-	/** Provider for database operations. */
-	private final OperationProvider operationProvider = ServiceLoader.load(OperationProvider).findFirst().orElseThrow()
+	/** The preparation support. */
+	private final PreparationSupport support
+
+	/** Creates a new preparation executor. */
+	SpockPreparationExecutor() {
+		this.support = ServiceLoader.load(PreparationSupport).findFirst()
+				.orElseThrow {
+					-> new IllegalStateException(
+					'No PreparationSupport implementation found. Ensure db-tester-core is on the classpath.')
+				}
+	}
+
+	/**
+	 * Creates a new preparation executor with the specified support.
+	 *
+	 * @param support the preparation support
+	 */
+	SpockPreparationExecutor(PreparationSupport support) {
+		this.support = Objects.requireNonNull(support, 'support must not be null')
+	}
 
 	/**
 	 * Executes the preparation phase.
 	 *
-	 * @param context the test context
-	 * @param dataSet the data set annotation
+	 * <p>Loads the datasets specified in the {@link DataSet} annotation (or resolved via conventions)
+	 * and applies them to the database using the configured operation.
+	 *
+	 * @param context the test context containing configuration and registry
+	 * @param dataSet the DataSet annotation specifying the operation to perform
 	 */
 	void execute(TestContext context, DataSet dataSet) {
 		Objects.requireNonNull(context, 'context must not be null')
 		Objects.requireNonNull(dataSet, 'dataSet must not be null')
 
-		log.debug('Executing preparation for test: {}.{}',
-				context.testClass().simpleName,
-				context.testMethod().name)
-
-		List<TableSet> tableSets = context.configuration().loader().loadPreparationDataSets(context)
-
-		if (tableSets.empty) {
-			log.debug('No preparation datasets found')
-			return
-		}
-
-		def operation = dataSet.operation()
-		def tableOrderingStrategy = dataSet.tableOrdering()
-
-		tableSets.each { tableSet ->
-			executeTableSet(context, tableSet, operation, tableOrderingStrategy)
-		}
-	}
-
-	/**
-	 * Executes a single table set against the database.
-	 *
-	 * <p>This method resolves the DataSource from either the table set itself or falls back
-	 * to the default registry. It then delegates to the operation executor to apply the table set
-	 * using the specified operation.
-	 *
-	 * @param context the test context providing access to the data source registry
-	 * @param tableSet the table set to execute containing tables and optional data source
-	 * @param operation the database operation to perform
-	 * @param tableOrderingStrategy the strategy for determining table processing order
-	 */
-	private void executeTableSet(TestContext context, TableSet tableSet, Operation operation, TableOrderingStrategy tableOrderingStrategy) {
-		def dataSource = tableSet.dataSource
-				.orElseGet { -> context.registry().get('') }
-		def conventions = context.configuration().conventions()
-		TransactionMode transactionMode = conventions.transactionMode()
-		Duration queryTimeout = conventions.queryTimeout()
-
-		log.debug('Applying {} operation with dataset using {} table ordering (transactionMode={}, timeout={})',
-				operation, tableOrderingStrategy, transactionMode, queryTimeout)
-
-		operationProvider.execute(operation, tableSet, dataSource, tableOrderingStrategy, transactionMode, queryTimeout)
+		support.execute(context, dataSet)
 	}
 }

--- a/db-tester-spock/src/test/groovy/io/github/seijikohara/dbtester/spock/lifecycle/SpockExpectationVerifierSpec.groovy
+++ b/db-tester-spock/src/test/groovy/io/github/seijikohara/dbtester/spock/lifecycle/SpockExpectationVerifierSpec.groovy
@@ -7,17 +7,10 @@ import io.github.seijikohara.dbtester.api.config.DataSourceRegistry
 import io.github.seijikohara.dbtester.api.config.OperationDefaults
 import io.github.seijikohara.dbtester.api.config.RowOrdering
 import io.github.seijikohara.dbtester.api.context.TestContext
-import io.github.seijikohara.dbtester.api.dataset.Row
-import io.github.seijikohara.dbtester.api.dataset.Table
-import io.github.seijikohara.dbtester.api.dataset.TableSet
-import io.github.seijikohara.dbtester.api.domain.CellValue
-import io.github.seijikohara.dbtester.api.domain.ColumnName
-import io.github.seijikohara.dbtester.api.domain.TableName
 import io.github.seijikohara.dbtester.api.exception.ValidationException
 import io.github.seijikohara.dbtester.api.loader.DataSetLoader
-import io.github.seijikohara.dbtester.api.loader.ExpectedTableSet
-import io.github.seijikohara.dbtester.api.spi.ExpectationProvider
-import javax.sql.DataSource
+import io.github.seijikohara.dbtester.api.operation.TableOrderingStrategy
+import io.github.seijikohara.dbtester.api.spi.ExpectationSupport
 import spock.lang.Specification
 
 /**
@@ -28,16 +21,20 @@ import spock.lang.Specification
  */
 class SpockExpectationVerifierSpec extends Specification {
 
+	/** Mock expectation support for tests. */
+	ExpectationSupport mockSupport
+
 	/** The verifier under test. */
 	SpockExpectationVerifier verifier
 
 	def setup() {
-		verifier = new SpockExpectationVerifier()
+		mockSupport = Mock(ExpectationSupport)
+		verifier = new SpockExpectationVerifier(mockSupport)
 	}
 
 	def 'should create instance'() {
 		when: 'creating a new instance'
-		def instance = new SpockExpectationVerifier()
+		def instance = new SpockExpectationVerifier(mockSupport)
 
 		then: 'instance is created successfully'
 		instance != null
@@ -83,11 +80,90 @@ class SpockExpectationVerifierSpec extends Specification {
 
 	def 'should create multiple independent verifiers'() {
 		when: 'creating multiple verifiers'
-		def verifier1 = new SpockExpectationVerifier()
-		def verifier2 = new SpockExpectationVerifier()
+		def verifier1 = new SpockExpectationVerifier(mockSupport)
+		def verifier2 = new SpockExpectationVerifier(mockSupport)
 
 		then: 'verifiers are independent'
 		!verifier1.is(verifier2)
+	}
+
+	def 'should delegate to expectation support'() {
+		given: 'a context and expected data set'
+		def context = createTestContextWithEmptyDatasets()
+		def expectedDataSet = createMockExpectedDataSet()
+
+		when: 'verifying expectation'
+		verifier.verify(context, expectedDataSet)
+
+		then: 'support is called'
+		1 * mockSupport.verify(context, expectedDataSet)
+	}
+
+	def 'should propagate validation exception from support'() {
+		given: 'a context and expected data set'
+		def context = createTestContextWithEmptyDatasets()
+		def expectedDataSet = createMockExpectedDataSet()
+
+		mockSupport.verify(_, _) >> {
+			throw new ValidationException('Verification failed')
+		}
+
+		when: 'verifying expectation'
+		verifier.verify(context, expectedDataSet)
+
+		then: 'ValidationException is thrown'
+		thrown(ValidationException)
+	}
+
+	def 'should handle ordered row verification'() {
+		given: 'a context and expected data set with ordered rows'
+		def context = createTestContextWithEmptyDatasets()
+		def expectedDataSet = Mock(ExpectedDataSet)
+		expectedDataSet.retryCount() >> 0
+		expectedDataSet.retryDelayMillis() >> -1
+		expectedDataSet.rowOrdering() >> RowOrdering.ORDERED
+		expectedDataSet.sources() >> ([] as String[])
+		expectedDataSet.tableOrdering() >> TableOrderingStrategy.AUTO
+
+		when: 'verifying expectation'
+		verifier.verify(context, expectedDataSet)
+
+		then: 'support is called with the expected data set'
+		1 * mockSupport.verify(context, expectedDataSet)
+	}
+
+	def 'should handle unordered row verification'() {
+		given: 'a context and expected data set with unordered rows'
+		def context = createTestContextWithEmptyDatasets()
+		def expectedDataSet = Mock(ExpectedDataSet)
+		expectedDataSet.retryCount() >> 0
+		expectedDataSet.retryDelayMillis() >> -1
+		expectedDataSet.rowOrdering() >> RowOrdering.UNORDERED
+		expectedDataSet.sources() >> ([] as String[])
+		expectedDataSet.tableOrdering() >> TableOrderingStrategy.AUTO
+
+		when: 'verifying expectation'
+		verifier.verify(context, expectedDataSet)
+
+		then: 'support is called with the expected data set'
+		1 * mockSupport.verify(context, expectedDataSet)
+	}
+
+	def 'should handle retry count settings'() {
+		given: 'a context and expected data set with retry settings'
+		def context = createTestContextWithEmptyDatasets()
+		def expectedDataSet = Mock(ExpectedDataSet)
+		expectedDataSet.retryCount() >> 3
+		expectedDataSet.retryDelayMillis() >> 100
+		expectedDataSet.rowOrdering() >> RowOrdering.ORDERED
+		expectedDataSet.sources() >> ([] as String[])
+		expectedDataSet.tableOrdering() >> TableOrderingStrategy.AUTO
+
+		when: 'verifying expectation'
+		verifier.verify(context, expectedDataSet)
+
+		then: 'support is called with the expected data set (retry logic is handled by support)'
+		1 * mockSupport.verify(context, expectedDataSet)
 	}
 
 	/**
@@ -139,255 +215,12 @@ class SpockExpectationVerifierSpec extends Specification {
 	 */
 	private ExpectedDataSet createMockExpectedDataSet() {
 		def expectedDataSet = Mock(ExpectedDataSet)
-		expectedDataSet.paths() >> ([] as String[])
-		expectedDataSet.columns() >> ([] as String[])
-		return expectedDataSet
-	}
-
-	def 'should verify expectation when datasets are found'() {
-		given: 'a mock expectation provider'
-		def mockExpectationProvider = Mock(ExpectationProvider)
-		def mockDataSource = Mock(DataSource)
-
-		and: 'inject mock provider using reflection'
-		def providerField = SpockExpectationVerifier.getDeclaredField('expectationProvider')
-		providerField.accessible = true
-		providerField.set(verifier, mockExpectationProvider)
-
-		and: 'a context with expected datasets'
-		def registry = new DataSourceRegistry()
-		registry.registerDefault(mockDataSource)
-		def context = createTestContextWithExpectedDatasets(registry)
-
-		and: 'a mock ExpectedDataSet annotation'
-		def expectedDataSet = createMockExpectedDataSet()
-
-		when: 'verifying expectation'
-		verifier.verify(context, expectedDataSet)
-
-		then: 'verification is executed'
-		1 * mockExpectationProvider.verifyExpectation(_, mockDataSource, _, _, _, _)
-	}
-
-	def 'should use annotation retry count when specified'() {
-		given: 'a mock expectation provider'
-		def mockExpectationProvider = Mock(ExpectationProvider)
-		def mockDataSource = Mock(DataSource)
-
-		and: 'inject mock provider using reflection'
-		def providerField = SpockExpectationVerifier.getDeclaredField('expectationProvider')
-		providerField.accessible = true
-		providerField.set(verifier, mockExpectationProvider)
-
-		and: 'a context with expected datasets'
-		def registry = new DataSourceRegistry()
-		registry.registerDefault(mockDataSource)
-		def context = createTestContextWithExpectedDatasets(registry)
-
-		and: 'a mock ExpectedDataSet annotation with retry settings'
-		def expectedDataSet = Mock(ExpectedDataSet)
-		expectedDataSet.retryCount() >> 2
-		expectedDataSet.retryDelayMillis() >> 10
-		expectedDataSet.rowOrdering() >> RowOrdering.ORDERED
-
-		when: 'verifying expectation'
-		verifier.verify(context, expectedDataSet)
-
-		then: 'verification is executed'
-		1 * mockExpectationProvider.verifyExpectation(_, mockDataSource, _, _, RowOrdering.ORDERED, _)
-	}
-
-	def 'should retry and succeed on validation exception'() {
-		given: 'a mock expectation provider that fails first then succeeds'
-		def mockExpectationProvider = Mock(ExpectationProvider)
-		def mockDataSource = Mock(DataSource)
-		def callCount = 0
-
-		and: 'inject mock provider using reflection'
-		def providerField = SpockExpectationVerifier.getDeclaredField('expectationProvider')
-		providerField.accessible = true
-		providerField.set(verifier, mockExpectationProvider)
-
-		and: 'a context with expected datasets'
-		def registry = new DataSourceRegistry()
-		registry.registerDefault(mockDataSource)
-		def context = createTestContextWithExpectedDatasets(registry)
-
-		and: 'a mock ExpectedDataSet annotation with retry settings'
-		def expectedDataSet = Mock(ExpectedDataSet)
-		expectedDataSet.retryCount() >> 2
-		expectedDataSet.retryDelayMillis() >> 10
-		expectedDataSet.rowOrdering() >> RowOrdering.ORDERED
-
-		mockExpectationProvider.verifyExpectation(_, _, _, _, _, _) >> {
-			callCount++
-			if (callCount == 1) {
-				throw new ValidationException('First attempt failed')
-			}
-		}
-
-		when: 'verifying expectation'
-		verifier.verify(context, expectedDataSet)
-
-		then: 'verification succeeds after retry'
-		noExceptionThrown()
-		callCount == 2
-	}
-
-	def 'should throw exception after all retries exhausted'() {
-		given: 'a mock expectation provider that always fails'
-		def mockExpectationProvider = Mock(ExpectationProvider)
-		def mockDataSource = Mock(DataSource)
-
-		and: 'inject mock provider using reflection'
-		def providerField = SpockExpectationVerifier.getDeclaredField('expectationProvider')
-		providerField.accessible = true
-		providerField.set(verifier, mockExpectationProvider)
-
-		and: 'a context with expected datasets'
-		def registry = new DataSourceRegistry()
-		registry.registerDefault(mockDataSource)
-		def context = createTestContextWithExpectedDatasets(registry)
-
-		and: 'a mock ExpectedDataSet annotation with retry settings'
-		def expectedDataSet = Mock(ExpectedDataSet)
-		expectedDataSet.retryCount() >> 1
-		expectedDataSet.retryDelayMillis() >> 10
-		expectedDataSet.rowOrdering() >> RowOrdering.ORDERED
-
-		mockExpectationProvider.verifyExpectation(_, _, _, _, _, _) >> {
-			throw new ValidationException('Always fails')
-		}
-
-		when: 'verifying expectation'
-		verifier.verify(context, expectedDataSet)
-
-		then: 'ValidationException is thrown'
-		thrown(ValidationException)
-	}
-
-	def 'should handle exclusions and column strategies'() {
-		given: 'a mock expectation provider'
-		def mockExpectationProvider = Mock(ExpectationProvider)
-		def mockDataSource = Mock(DataSource)
-
-		and: 'inject mock provider using reflection'
-		def providerField = SpockExpectationVerifier.getDeclaredField('expectationProvider')
-		providerField.accessible = true
-		providerField.set(verifier, mockExpectationProvider)
-
-		and: 'a context with expected datasets having exclusions'
-		def registry = new DataSourceRegistry()
-		registry.registerDefault(mockDataSource)
-		def context = createTestContextWithExclusions(registry)
-
-		and: 'a mock ExpectedDataSet annotation'
-		def expectedDataSet = Mock(ExpectedDataSet)
+		expectedDataSet.sources() >> ([] as String[])
+		expectedDataSet.tableOrdering() >> TableOrderingStrategy.AUTO
 		expectedDataSet.retryCount() >> 0
 		expectedDataSet.retryDelayMillis() >> -1
 		expectedDataSet.rowOrdering() >> RowOrdering.ORDERED
-
-		when: 'verifying expectation'
-		verifier.verify(context, expectedDataSet)
-
-		then: 'verification is executed with exclusions'
-		1 * mockExpectationProvider.verifyExpectation(_, mockDataSource, { it.contains('CREATED_AT') }, _, _, _)
-	}
-
-	/**
-	 * Creates a TestContext with expected datasets.
-	 *
-	 * @param registry the registry to use
-	 * @return the test context
-	 */
-	private TestContext createTestContextWithExpectedDatasets(DataSourceRegistry registry) {
-		def testClass = SampleTestClass
-		def testMethod = SampleTestClass.getMethod('sampleMethod')
-
-		// Create a simple table set
-		def table = Table.of(
-				new TableName('users'),
-				[
-					new ColumnName('id'),
-					new ColumnName('name')
-				],
-				[
-					Row.of([(new ColumnName('id')): new CellValue('1'), (new ColumnName('name')): new CellValue('John')])
-				]
-				)
-		def tableSet = TableSet.of(table)
-		def expectedTableSet = new ExpectedTableSet(tableSet, [] as Set, [:])
-
-		def loader = new DataSetLoader() {
-					@Override
-					List loadPreparationDataSets(TestContext ctx) {
-						return []
-					}
-
-					@Override
-					List loadExpectationDataSets(TestContext ctx) {
-						return [tableSet]
-					}
-
-					@Override
-					List loadExpectationDataSetsWithExclusions(TestContext ctx) {
-						return [expectedTableSet]
-					}
-				}
-		def configuration = Configuration.builder()
-				.conventions(ConventionSettings.standard())
-				.operations(OperationDefaults.standard())
-				.loader(loader)
-				.build()
-		new TestContext(testClass, testMethod, configuration, registry)
-	}
-
-	/**
-	 * Creates a TestContext with exclusions.
-	 *
-	 * @param registry the registry to use
-	 * @return the test context
-	 */
-	private TestContext createTestContextWithExclusions(DataSourceRegistry registry) {
-		def testClass = SampleTestClass
-		def testMethod = SampleTestClass.getMethod('sampleMethod')
-
-		def table = Table.of(
-				new TableName('users'),
-				[
-					new ColumnName('id'),
-					new ColumnName('name'),
-					new ColumnName('created_at')
-				],
-				[
-					Row.of([(new ColumnName('id')): new CellValue('1'), (new ColumnName('name')): new CellValue('John')])
-				]
-				)
-		def tableSet = TableSet.of(table)
-		def expectedTableSet = new ExpectedTableSet(tableSet, ['CREATED_AT'] as Set, [:])
-
-		def loader = new DataSetLoader() {
-					@Override
-					List loadPreparationDataSets(TestContext ctx) {
-						return []
-					}
-
-					@Override
-					List loadExpectationDataSets(TestContext ctx) {
-						return [tableSet]
-					}
-
-					@Override
-					List loadExpectationDataSetsWithExclusions(TestContext ctx) {
-						return [expectedTableSet]
-					}
-				}
-		def configuration = Configuration.builder()
-				.conventions(ConventionSettings.standard())
-				.operations(OperationDefaults.standard())
-				.loader(loader)
-				.build()
-		new TestContext(testClass, testMethod, configuration, registry)
+		return expectedDataSet
 	}
 
 	/**

--- a/db-tester-spock/src/test/groovy/io/github/seijikohara/dbtester/spock/lifecycle/SpockPreparationExecutorSpec.groovy
+++ b/db-tester-spock/src/test/groovy/io/github/seijikohara/dbtester/spock/lifecycle/SpockPreparationExecutorSpec.groovy
@@ -6,17 +6,10 @@ import io.github.seijikohara.dbtester.api.config.ConventionSettings
 import io.github.seijikohara.dbtester.api.config.DataSourceRegistry
 import io.github.seijikohara.dbtester.api.config.OperationDefaults
 import io.github.seijikohara.dbtester.api.context.TestContext
-import io.github.seijikohara.dbtester.api.dataset.Row
-import io.github.seijikohara.dbtester.api.dataset.Table
-import io.github.seijikohara.dbtester.api.dataset.TableSet
-import io.github.seijikohara.dbtester.api.domain.CellValue
-import io.github.seijikohara.dbtester.api.domain.ColumnName
-import io.github.seijikohara.dbtester.api.domain.TableName
 import io.github.seijikohara.dbtester.api.loader.DataSetLoader
 import io.github.seijikohara.dbtester.api.operation.Operation
 import io.github.seijikohara.dbtester.api.operation.TableOrderingStrategy
-import io.github.seijikohara.dbtester.api.spi.OperationProvider
-import javax.sql.DataSource
+import io.github.seijikohara.dbtester.api.spi.PreparationSupport
 import spock.lang.Specification
 
 /**
@@ -27,16 +20,20 @@ import spock.lang.Specification
  */
 class SpockPreparationExecutorSpec extends Specification {
 
+	/** Mock preparation support for tests. */
+	PreparationSupport mockSupport
+
 	/** The executor under test. */
 	SpockPreparationExecutor executor
 
 	def setup() {
-		executor = new SpockPreparationExecutor()
+		mockSupport = Mock(PreparationSupport)
+		executor = new SpockPreparationExecutor(mockSupport)
 	}
 
 	def 'should create instance'() {
 		when: 'creating a new instance'
-		def instance = new SpockPreparationExecutor()
+		def instance = new SpockPreparationExecutor(mockSupport)
 
 		then: 'instance is created successfully'
 		instance != null
@@ -82,11 +79,44 @@ class SpockPreparationExecutorSpec extends Specification {
 
 	def 'should create multiple independent executors'() {
 		when: 'creating multiple executors'
-		def executor1 = new SpockPreparationExecutor()
-		def executor2 = new SpockPreparationExecutor()
+		def executor1 = new SpockPreparationExecutor(mockSupport)
+		def executor2 = new SpockPreparationExecutor(mockSupport)
 
 		then: 'executors are independent'
 		!executor1.is(executor2)
+	}
+
+	def 'should delegate to preparation support'() {
+		given: 'a context and data set'
+		def context = createTestContextWithEmptyDatasets()
+		def dataSet = createMockDataSet(Operation.CLEAN_INSERT)
+
+		when: 'executing preparation'
+		executor.execute(context, dataSet)
+
+		then: 'support is called'
+		1 * mockSupport.execute(context, dataSet)
+	}
+
+	def 'should handle datasets with different operations'() {
+		given: 'a context with datasets'
+		def context = createTestContextWithEmptyDatasets()
+
+		and: 'a mock DataSet annotation with specified operation'
+		def dataSet = createMockDataSet(operation)
+
+		when: 'executing preparation'
+		executor.execute(context, dataSet)
+
+		then: 'operation is executed with correct operation type'
+		1 * mockSupport.execute(context, dataSet)
+
+		where:
+		operation << [
+			Operation.INSERT,
+			Operation.DELETE_ALL,
+			Operation.TRUNCATE_INSERT
+		]
 	}
 
 	/**
@@ -106,7 +136,22 @@ class SpockPreparationExecutorSpec extends Specification {
 	private TestContext createTestContextWithEmptyDatasets() {
 		def testClass = SampleTestClass
 		def testMethod = SampleTestClass.getMethod('sampleMethod')
-		def loader = { ctx -> [] } as DataSetLoader
+		def loader = new DataSetLoader() {
+					@Override
+					List loadPreparationDataSets(TestContext ctx) {
+						return []
+					}
+
+					@Override
+					List loadExpectationDataSets(TestContext ctx) {
+						return []
+					}
+
+					@Override
+					List loadExpectationDataSetsWithExclusions(TestContext ctx) {
+						return []
+					}
+				}
 		def configuration = Configuration.builder()
 				.conventions(ConventionSettings.standard())
 				.operations(OperationDefaults.standard())
@@ -126,112 +171,8 @@ class SpockPreparationExecutorSpec extends Specification {
 		def dataSet = Mock(DataSet)
 		dataSet.operation() >> operation
 		dataSet.tableOrdering() >> TableOrderingStrategy.AUTO
-		dataSet.paths() >> ([] as String[])
+		dataSet.sources() >> ([] as String[])
 		return dataSet
-	}
-
-	def 'should execute operation when datasets are found'() {
-		given: 'a mock operation provider'
-		def mockOperationProvider = Mock(OperationProvider)
-		def mockDataSource = Mock(DataSource)
-
-		and: 'inject mock provider using reflection'
-		def providerField = SpockPreparationExecutor.getDeclaredField('operationProvider')
-		providerField.accessible = true
-		providerField.set(executor, mockOperationProvider)
-
-		and: 'a context with datasets'
-		def registry = new DataSourceRegistry()
-		registry.registerDefault(mockDataSource)
-		def context = createTestContextWithDatasets(registry)
-
-		and: 'a mock DataSet annotation'
-		def dataSet = createMockDataSet(Operation.CLEAN_INSERT)
-
-		when: 'executing preparation'
-		executor.execute(context, dataSet)
-
-		then: 'operation is executed'
-		1 * mockOperationProvider.execute(Operation.CLEAN_INSERT, _, mockDataSource, TableOrderingStrategy.AUTO, _, _)
-	}
-
-	def 'should handle datasets with different operations'() {
-		given: 'a mock operation provider'
-		def mockOperationProvider = Mock(OperationProvider)
-		def mockDataSource = Mock(DataSource)
-
-		and: 'inject mock provider using reflection'
-		def providerField = SpockPreparationExecutor.getDeclaredField('operationProvider')
-		providerField.accessible = true
-		providerField.set(executor, mockOperationProvider)
-
-		and: 'a context with datasets'
-		def registry = new DataSourceRegistry()
-		registry.registerDefault(mockDataSource)
-		def context = createTestContextWithDatasets(registry)
-
-		and: 'a mock DataSet annotation with specified operation'
-		def dataSet = createMockDataSet(operation)
-
-		when: 'executing preparation'
-		executor.execute(context, dataSet)
-
-		then: 'operation is executed with correct operation type'
-		1 * mockOperationProvider.execute(operation, _, mockDataSource, _, _, _)
-
-		where:
-		operation << [
-			Operation.INSERT,
-			Operation.DELETE_ALL,
-			Operation.TRUNCATE_INSERT
-		]
-	}
-
-	/**
-	 * Creates a TestContext with actual datasets.
-	 *
-	 * @param registry the registry to use
-	 * @return the test context
-	 */
-	private TestContext createTestContextWithDatasets(DataSourceRegistry registry) {
-		def testClass = SampleTestClass
-		def testMethod = SampleTestClass.getMethod('sampleMethod')
-
-		// Create a simple table set
-		def table = Table.of(
-				new TableName('users'),
-				[
-					new ColumnName('id'),
-					new ColumnName('name')
-				],
-				[
-					Row.of([(new ColumnName('id')): new CellValue('1'), (new ColumnName('name')): new CellValue('John')])
-				]
-				)
-		def tableSet = TableSet.of(table)
-
-		def loader = new DataSetLoader() {
-					@Override
-					List loadPreparationDataSets(TestContext ctx) {
-						return [tableSet]
-					}
-
-					@Override
-					List loadExpectationDataSets(TestContext ctx) {
-						return []
-					}
-
-					@Override
-					List loadExpectationDataSetsWithExclusions(TestContext ctx) {
-						return []
-					}
-				}
-		def configuration = Configuration.builder()
-				.conventions(ConventionSettings.standard())
-				.operations(OperationDefaults.standard())
-				.loader(loader)
-				.build()
-		new TestContext(testClass, testMethod, configuration, registry)
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR refactors the duplicated `PreparationExecutor` and `ExpectationVerifier` logic from JUnit, Spock, and Kotest modules into `db-tester-core` using a Service Provider Interface (SPI) pattern.

### Key Changes

- Added `PreparationSupport` and `ExpectationSupport` interfaces in `db-tester-api`
- Added `DefaultPreparationSupport` and `DefaultExpectationSupport` implementations in `db-tester-core`
- Updated JUnit/Spock/Kotest modules to delegate to SPI implementations via ServiceLoader
- Added META-INF/services files for ServiceLoader discovery
- Updated module-info.java files for JPMS compatibility
- Updated tests to use constructor injection for better testability
- Updated google-java-format to 1.34.0 for Java 25 compatibility

### Benefits

- **Single source of truth**: Preparation and expectation logic now lives in one place (`db-tester-core`)
- **Reduced duplication**: Net reduction of ~1225 lines of code
- **Easier maintenance**: Bug fixes and enhancements only need to be made once
- **Better testability**: Constructor injection enables easier unit testing with mocks
- **JPMS support**: Both JPMS and classpath-based service discovery supported

### Architecture

```
db-tester-api (SPI interfaces)
├── PreparationSupport
└── ExpectationSupport

db-tester-core (implementations)
├── DefaultPreparationSupport
└── DefaultExpectationSupport

db-tester-{junit,spock,kotest} (thin wrappers)
├── {Framework}PreparationExecutor → delegates to PreparationSupport
└── {Framework}ExpectationVerifier → delegates to ExpectationSupport
```

## Related Issue

Closes #120

## Test Plan

- [x] All existing tests pass
- [x] Spotless format check passes
- [x] Tests updated to use constructor injection with mocks
- [x] Integration tests in examples module verify end-to-end functionality