### PR TITLE
feat(export): add data export functionality

### DIFF
--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/export/DataSetExporter.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/export/DataSetExporter.java
@@ -1,0 +1,219 @@
+package io.github.seijikohara.dbtester.api.export;
+
+import io.github.seijikohara.dbtester.api.config.DataFormat;
+import io.github.seijikohara.dbtester.api.exception.DatabaseTesterException;
+import io.github.seijikohara.dbtester.api.spi.ExportProvider;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.ServiceLoader;
+import javax.sql.DataSource;
+
+/**
+ * Facade for exporting database content to files.
+ *
+ * <p>This class provides static methods for exporting database tables to various file formats. It
+ * uses the {@link ExportProvider} SPI to delegate the actual export work to format-specific
+ * implementations.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * // Export tables to CSV files
+ * DataSetExporter.csv(dataSource, List.of("USERS", "ORDERS"), Paths.get("export"));
+ *
+ * // Export with custom configuration
+ * var config = ExportConfiguration.builder()
+ *     .lobHandling(LobHandling.OMIT)
+ *     .writeLoadOrderFile(true)
+ *     .build();
+ * DataSetExporter.export(dataSource, List.of("USERS"), Paths.get("export"), DataFormat.JSON, config);
+ *
+ * // Export query result
+ * DataSetExporter.exportQuery(
+ *     dataSource,
+ *     "SELECT * FROM USERS WHERE active = true",
+ *     "ACTIVE_USERS",
+ *     Paths.get("export"),
+ *     DataFormat.CSV);
+ * }</pre>
+ *
+ * @see ExportProvider
+ * @see ExportConfiguration
+ * @see DataFormat
+ */
+public final class DataSetExporter {
+
+  /** Private constructor to prevent instantiation. */
+  private DataSetExporter() {}
+
+  /**
+   * Exports database tables to files in the specified format.
+   *
+   * <p>Each table is exported to a separate file in the output directory. The file name is the
+   * table name with the format-specific extension.
+   *
+   * @param dataSource the data source to read from
+   * @param tableNames the names of tables to export
+   * @param outputDirectory the directory to write files to
+   * @param format the export format
+   * @throws DatabaseTesterException if export fails or no provider is found for the format
+   */
+  public static void export(
+      final DataSource dataSource,
+      final List<String> tableNames,
+      final Path outputDirectory,
+      final DataFormat format) {
+    export(dataSource, tableNames, outputDirectory, format, ExportConfiguration.defaults());
+  }
+
+  /**
+   * Exports database tables to files in the specified format with custom configuration.
+   *
+   * <p>Each table is exported to a separate file in the output directory. The file name is the
+   * table name with the format-specific extension.
+   *
+   * @param dataSource the data source to read from
+   * @param tableNames the names of tables to export
+   * @param outputDirectory the directory to write files to
+   * @param format the export format
+   * @param config the export configuration
+   * @throws DatabaseTesterException if export fails or no provider is found for the format
+   */
+  public static void export(
+      final DataSource dataSource,
+      final List<String> tableNames,
+      final Path outputDirectory,
+      final DataFormat format,
+      final ExportConfiguration config) {
+    final var provider = findProvider(format);
+    provider.export(dataSource, tableNames, outputDirectory, config);
+  }
+
+  /**
+   * Exports the result of a SQL query to a file in the specified format.
+   *
+   * <p>The query result is exported to a file named after the specified table name.
+   *
+   * @param dataSource the data source to execute the query on
+   * @param query the SQL query to execute
+   * @param tableName the table name to use for the output file
+   * @param outputDirectory the directory to write the file to
+   * @param format the export format
+   * @throws DatabaseTesterException if export fails or no provider is found for the format
+   */
+  public static void exportQuery(
+      final DataSource dataSource,
+      final String query,
+      final String tableName,
+      final Path outputDirectory,
+      final DataFormat format) {
+    exportQuery(
+        dataSource, query, tableName, outputDirectory, format, ExportConfiguration.defaults());
+  }
+
+  /**
+   * Exports the result of a SQL query to a file in the specified format with custom configuration.
+   *
+   * <p>The query result is exported to a file named after the specified table name.
+   *
+   * @param dataSource the data source to execute the query on
+   * @param query the SQL query to execute
+   * @param tableName the table name to use for the output file
+   * @param outputDirectory the directory to write the file to
+   * @param format the export format
+   * @param config the export configuration
+   * @throws DatabaseTesterException if export fails or no provider is found for the format
+   */
+  public static void exportQuery(
+      final DataSource dataSource,
+      final String query,
+      final String tableName,
+      final Path outputDirectory,
+      final DataFormat format,
+      final ExportConfiguration config) {
+    final var provider = findProvider(format);
+    provider.exportQuery(dataSource, query, tableName, outputDirectory, config);
+  }
+
+  /**
+   * Exports database tables to CSV files.
+   *
+   * <p>Convenience method equivalent to {@code export(dataSource, tableNames, outputDirectory,
+   * DataFormat.CSV)}.
+   *
+   * @param dataSource the data source to read from
+   * @param tableNames the names of tables to export
+   * @param outputDirectory the directory to write files to
+   * @throws DatabaseTesterException if export fails
+   */
+  public static void csv(
+      final DataSource dataSource, final List<String> tableNames, final Path outputDirectory) {
+    export(dataSource, tableNames, outputDirectory, DataFormat.CSV);
+  }
+
+  /**
+   * Exports database tables to TSV files.
+   *
+   * <p>Convenience method equivalent to {@code export(dataSource, tableNames, outputDirectory,
+   * DataFormat.TSV)}.
+   *
+   * @param dataSource the data source to read from
+   * @param tableNames the names of tables to export
+   * @param outputDirectory the directory to write files to
+   * @throws DatabaseTesterException if export fails
+   */
+  public static void tsv(
+      final DataSource dataSource, final List<String> tableNames, final Path outputDirectory) {
+    export(dataSource, tableNames, outputDirectory, DataFormat.TSV);
+  }
+
+  /**
+   * Exports database tables to JSON files.
+   *
+   * <p>Convenience method equivalent to {@code export(dataSource, tableNames, outputDirectory,
+   * DataFormat.JSON)}.
+   *
+   * @param dataSource the data source to read from
+   * @param tableNames the names of tables to export
+   * @param outputDirectory the directory to write files to
+   * @throws DatabaseTesterException if export fails
+   */
+  public static void json(
+      final DataSource dataSource, final List<String> tableNames, final Path outputDirectory) {
+    export(dataSource, tableNames, outputDirectory, DataFormat.JSON);
+  }
+
+  /**
+   * Exports database tables to YAML files.
+   *
+   * <p>Convenience method equivalent to {@code export(dataSource, tableNames, outputDirectory,
+   * DataFormat.YAML)}.
+   *
+   * @param dataSource the data source to read from
+   * @param tableNames the names of tables to export
+   * @param outputDirectory the directory to write files to
+   * @throws DatabaseTesterException if export fails
+   */
+  public static void yaml(
+      final DataSource dataSource, final List<String> tableNames, final Path outputDirectory) {
+    export(dataSource, tableNames, outputDirectory, DataFormat.YAML);
+  }
+
+  /**
+   * Finds an export provider for the specified format.
+   *
+   * @param format the data format
+   * @return the export provider
+   * @throws DatabaseTesterException if no provider is found for the format
+   */
+  private static ExportProvider findProvider(final DataFormat format) {
+    return ServiceLoader.load(ExportProvider.class).stream()
+        .map(ServiceLoader.Provider::get)
+        .filter(provider -> provider.supportedFormat() == format)
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new DatabaseTesterException(
+                    String.format("No ExportProvider found for format: %s", format)));
+  }
+}

--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/export/ExportConfiguration.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/export/ExportConfiguration.java
@@ -1,0 +1,284 @@
+package io.github.seijikohara.dbtester.api.export;
+
+import io.github.seijikohara.dbtester.api.config.ConventionSettings;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+
+/**
+ * Configuration for data export operations.
+ *
+ * <p>This class defines how database values are formatted when exporting to files. It includes
+ * settings for null representation, date/time formatting, LOB handling, and load order file
+ * generation.
+ *
+ * <p>Use {@link #defaults()} to obtain an instance with default values, or {@link #builder()} to
+ * create a customized configuration.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * // Using defaults
+ * var config = ExportConfiguration.defaults();
+ *
+ * // Custom configuration
+ * var config = ExportConfiguration.builder()
+ *     .nullValue("NULL")
+ *     .lobHandling(LobHandling.OMIT)
+ *     .writeLoadOrderFile(true)
+ *     .build();
+ * }</pre>
+ *
+ * @see DataSetExporter
+ * @see LobHandling
+ */
+public final class ExportConfiguration {
+
+  /** Default null value representation for delimited formats. */
+  public static final String DEFAULT_NULL_VALUE = "";
+
+  /** Default date formatter (ISO local date: yyyy-MM-dd). */
+  public static final DateTimeFormatter DEFAULT_DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
+
+  /** Default time formatter (ISO local time: HH:mm:ss). */
+  public static final DateTimeFormatter DEFAULT_TIME_FORMATTER = DateTimeFormatter.ISO_LOCAL_TIME;
+
+  /** Default timestamp formatter (JDBC timestamp: yyyy-MM-dd HH:mm:ss). */
+  public static final DateTimeFormatter DEFAULT_TIMESTAMP_FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+  /** The string representation for null values in delimited formats. */
+  private final String nullValue;
+
+  /** The formatter for date values. */
+  private final DateTimeFormatter dateFormatter;
+
+  /** The formatter for time values. */
+  private final DateTimeFormatter timeFormatter;
+
+  /** The formatter for timestamp values. */
+  private final DateTimeFormatter timestampFormatter;
+
+  /** The handling strategy for LOB columns. */
+  private final LobHandling lobHandling;
+
+  /** Whether to generate a load order file. */
+  private final boolean writeLoadOrderFile;
+
+  /** The name of the load order file. */
+  private final String loadOrderFileName;
+
+  /**
+   * Creates a new configuration from the builder.
+   *
+   * @param builder the builder containing configuration values
+   */
+  private ExportConfiguration(final Builder builder) {
+    this.nullValue = builder.nullValue;
+    this.dateFormatter = builder.dateFormatter;
+    this.timeFormatter = builder.timeFormatter;
+    this.timestampFormatter = builder.timestampFormatter;
+    this.lobHandling = builder.lobHandling;
+    this.writeLoadOrderFile = builder.writeLoadOrderFile;
+    this.loadOrderFileName = builder.loadOrderFileName;
+  }
+
+  /**
+   * Creates a new builder for constructing ExportConfiguration instances.
+   *
+   * @return a new builder with default values
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Creates a configuration instance with default values.
+   *
+   * @return a configuration with default settings
+   */
+  public static ExportConfiguration defaults() {
+    return builder().build();
+  }
+
+  /**
+   * Returns the string representation for null values.
+   *
+   * <p>This setting applies only to delimited formats (CSV, TSV). JSON and YAML use their native
+   * null representation.
+   *
+   * @return the null value representation
+   */
+  public String nullValue() {
+    return nullValue;
+  }
+
+  /**
+   * Returns the formatter for date values.
+   *
+   * @return the date formatter
+   */
+  public DateTimeFormatter dateFormatter() {
+    return dateFormatter;
+  }
+
+  /**
+   * Returns the formatter for time values.
+   *
+   * @return the time formatter
+   */
+  public DateTimeFormatter timeFormatter() {
+    return timeFormatter;
+  }
+
+  /**
+   * Returns the formatter for timestamp values.
+   *
+   * @return the timestamp formatter
+   */
+  public DateTimeFormatter timestampFormatter() {
+    return timestampFormatter;
+  }
+
+  /**
+   * Returns the handling strategy for LOB columns.
+   *
+   * @return the LOB handling strategy
+   */
+  public LobHandling lobHandling() {
+    return lobHandling;
+  }
+
+  /**
+   * Returns whether to generate a load order file.
+   *
+   * @return true if a load order file should be generated
+   */
+  public boolean writeLoadOrderFile() {
+    return writeLoadOrderFile;
+  }
+
+  /**
+   * Returns the name of the load order file.
+   *
+   * @return the load order file name
+   */
+  public String loadOrderFileName() {
+    return loadOrderFileName;
+  }
+
+  /** Builder for constructing {@link ExportConfiguration} instances. */
+  public static final class Builder {
+
+    /** The string representation for null values. */
+    private String nullValue = DEFAULT_NULL_VALUE;
+
+    /** The formatter for date values. */
+    private DateTimeFormatter dateFormatter = DEFAULT_DATE_FORMATTER;
+
+    /** The formatter for time values. */
+    private DateTimeFormatter timeFormatter = DEFAULT_TIME_FORMATTER;
+
+    /** The formatter for timestamp values. */
+    private DateTimeFormatter timestampFormatter = DEFAULT_TIMESTAMP_FORMATTER;
+
+    /** The handling strategy for LOB columns. */
+    private LobHandling lobHandling = LobHandling.BASE64;
+
+    /** Whether to generate a load order file. */
+    private boolean writeLoadOrderFile = false;
+
+    /** The name of the load order file. */
+    private String loadOrderFileName = ConventionSettings.DEFAULT_LOAD_ORDER_FILE_NAME;
+
+    /** Creates a new builder with default values. */
+    public Builder() {}
+
+    /**
+     * Sets the string representation for null values.
+     *
+     * <p>This setting applies only to delimited formats (CSV, TSV).
+     *
+     * @param nullValue the null value representation
+     * @return this builder
+     */
+    public Builder nullValue(final String nullValue) {
+      this.nullValue = Objects.requireNonNull(nullValue, "nullValue");
+      return this;
+    }
+
+    /**
+     * Sets the formatter for date values.
+     *
+     * @param dateFormatter the date formatter
+     * @return this builder
+     */
+    public Builder dateFormatter(final DateTimeFormatter dateFormatter) {
+      this.dateFormatter = Objects.requireNonNull(dateFormatter, "dateFormatter");
+      return this;
+    }
+
+    /**
+     * Sets the formatter for time values.
+     *
+     * @param timeFormatter the time formatter
+     * @return this builder
+     */
+    public Builder timeFormatter(final DateTimeFormatter timeFormatter) {
+      this.timeFormatter = Objects.requireNonNull(timeFormatter, "timeFormatter");
+      return this;
+    }
+
+    /**
+     * Sets the formatter for timestamp values.
+     *
+     * @param timestampFormatter the timestamp formatter
+     * @return this builder
+     */
+    public Builder timestampFormatter(final DateTimeFormatter timestampFormatter) {
+      this.timestampFormatter = Objects.requireNonNull(timestampFormatter, "timestampFormatter");
+      return this;
+    }
+
+    /**
+     * Sets the handling strategy for LOB columns.
+     *
+     * @param lobHandling the LOB handling strategy
+     * @return this builder
+     */
+    public Builder lobHandling(final LobHandling lobHandling) {
+      this.lobHandling = Objects.requireNonNull(lobHandling, "lobHandling");
+      return this;
+    }
+
+    /**
+     * Sets whether to generate a load order file.
+     *
+     * @param writeLoadOrderFile true to generate a load order file
+     * @return this builder
+     */
+    public Builder writeLoadOrderFile(final boolean writeLoadOrderFile) {
+      this.writeLoadOrderFile = writeLoadOrderFile;
+      return this;
+    }
+
+    /**
+     * Sets the name of the load order file.
+     *
+     * @param loadOrderFileName the load order file name
+     * @return this builder
+     */
+    public Builder loadOrderFileName(final String loadOrderFileName) {
+      this.loadOrderFileName = Objects.requireNonNull(loadOrderFileName, "loadOrderFileName");
+      return this;
+    }
+
+    /**
+     * Builds a new {@link ExportConfiguration} instance with the configured values.
+     *
+     * @return a new ExportConfiguration instance
+     */
+    public ExportConfiguration build() {
+      return new ExportConfiguration(this);
+    }
+  }
+}

--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/export/LobHandling.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/export/LobHandling.java
@@ -1,0 +1,28 @@
+package io.github.seijikohara.dbtester.api.export;
+
+/**
+ * Defines how LOB (Large Object) columns are handled during export.
+ *
+ * <p>BLOB and CLOB columns require special handling because they can contain large amounts of data
+ * that may not be suitable for text-based export formats.
+ *
+ * @see ExportConfiguration
+ */
+public enum LobHandling {
+
+  /**
+   * Export LOB values as Base64-encoded strings.
+   *
+   * <p>The exported value includes the {@code [BASE64]} prefix for compatibility with the import
+   * format. This allows round-trip export and import of binary data.
+   */
+  BASE64,
+
+  /**
+   * Omit LOB columns from export.
+   *
+   * <p>Columns containing BLOB or CLOB values are excluded from the exported data. Use this option
+   * when binary data is not needed or to reduce export file size.
+   */
+  OMIT
+}

--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/export/package-info.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/export/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Data export API for exporting database content to files.
+ *
+ * <p>This package provides the public API for exporting database tables to various file formats
+ * (CSV, TSV, JSON, YAML). The main entry point is {@link
+ * io.github.seijikohara.dbtester.api.export.DataSetExporter}.
+ *
+ * @see io.github.seijikohara.dbtester.api.export.DataSetExporter
+ * @see io.github.seijikohara.dbtester.api.export.ExportConfiguration
+ */
+@NullMarked
+package io.github.seijikohara.dbtester.api.export;
+
+import org.jspecify.annotations.NullMarked;

--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/spi/ExportProvider.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/spi/ExportProvider.java
@@ -1,0 +1,72 @@
+package io.github.seijikohara.dbtester.api.spi;
+
+import io.github.seijikohara.dbtester.api.config.DataFormat;
+import io.github.seijikohara.dbtester.api.export.ExportConfiguration;
+import java.nio.file.Path;
+import java.util.List;
+import javax.sql.DataSource;
+
+/**
+ * SPI for exporting database content to files in various formats.
+ *
+ * <p>Implementations of this interface define how to export database tables to specific file
+ * formats (e.g., CSV, TSV, JSON, YAML). Each implementation handles a single format and is
+ * responsible for formatting values according to the provided configuration.
+ *
+ * <p>Providers are discovered automatically using Java's {@link java.util.ServiceLoader} mechanism.
+ * Configure service providers in {@code
+ * META-INF/services/io.github.seijikohara.dbtester.api.spi.ExportProvider}.
+ *
+ * <p>Implementations must be thread-safe and stateless (or use immutable state).
+ *
+ * @see DataFormat
+ * @see ExportConfiguration
+ */
+public interface ExportProvider {
+
+  /**
+   * Returns the data format supported by this provider.
+   *
+   * @return the supported data format
+   */
+  DataFormat supportedFormat();
+
+  /**
+   * Exports database tables to files in the specified directory.
+   *
+   * <p>Each table is exported to a separate file named after the table with the appropriate file
+   * extension. The output directory structure follows the convention used by format providers for
+   * loading datasets.
+   *
+   * @param dataSource the data source to read from
+   * @param tableNames the names of tables to export
+   * @param outputDirectory the directory to write files to
+   * @param config the export configuration
+   * @throws io.github.seijikohara.dbtester.api.exception.DatabaseTesterException if export fails
+   */
+  void export(
+      DataSource dataSource,
+      List<String> tableNames,
+      Path outputDirectory,
+      ExportConfiguration config);
+
+  /**
+   * Exports the result of a SQL query to a file.
+   *
+   * <p>The query result is exported to a file named after the specified table name with the
+   * appropriate file extension.
+   *
+   * @param dataSource the data source to execute the query on
+   * @param query the SQL query to execute
+   * @param tableName the table name to use for the output file
+   * @param outputDirectory the directory to write the file to
+   * @param config the export configuration
+   * @throws io.github.seijikohara.dbtester.api.exception.DatabaseTesterException if export fails
+   */
+  void exportQuery(
+      DataSource dataSource,
+      String query,
+      String tableName,
+      Path outputDirectory,
+      ExportConfiguration config);
+}

--- a/db-tester-api/src/main/java/module-info.java
+++ b/db-tester-api/src/main/java/module-info.java
@@ -19,6 +19,7 @@ module io.github.seijikohara.dbtester.api {
   exports io.github.seijikohara.dbtester.api.dataset;
   exports io.github.seijikohara.dbtester.api.domain;
   exports io.github.seijikohara.dbtester.api.exception;
+  exports io.github.seijikohara.dbtester.api.export;
   exports io.github.seijikohara.dbtester.api.loader;
   exports io.github.seijikohara.dbtester.api.operation;
   exports io.github.seijikohara.dbtester.api.scenario;
@@ -27,6 +28,7 @@ module io.github.seijikohara.dbtester.api {
   // SPI for implementations
   uses io.github.seijikohara.dbtester.api.spi.AssertionProvider;
   uses io.github.seijikohara.dbtester.api.spi.DataSetLoaderProvider;
+  uses io.github.seijikohara.dbtester.api.spi.ExportProvider;
   uses io.github.seijikohara.dbtester.api.spi.ExpectationProvider;
   uses io.github.seijikohara.dbtester.api.spi.ExpectationSupport;
   uses io.github.seijikohara.dbtester.api.spi.OperationProvider;

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/export/AbstractExportProvider.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/export/AbstractExportProvider.java
@@ -1,0 +1,266 @@
+package io.github.seijikohara.dbtester.internal.export;
+
+import io.github.seijikohara.dbtester.api.dataset.Row;
+import io.github.seijikohara.dbtester.api.dataset.Table;
+import io.github.seijikohara.dbtester.api.domain.CellValue;
+import io.github.seijikohara.dbtester.api.domain.ColumnName;
+import io.github.seijikohara.dbtester.api.exception.DatabaseTesterException;
+import io.github.seijikohara.dbtester.api.export.ExportConfiguration;
+import io.github.seijikohara.dbtester.api.export.LobHandling;
+import io.github.seijikohara.dbtester.api.spi.ExportProvider;
+import io.github.seijikohara.dbtester.internal.domain.InternalConstants;
+import io.github.seijikohara.dbtester.internal.jdbc.read.TableReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Base64;
+import java.util.List;
+import javax.sql.DataSource;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Abstract base class for export providers.
+ *
+ * <p>This class provides common functionality for exporting database tables to files, including
+ * table reading, value formatting, and load order file generation.
+ *
+ * <p>Subclasses must implement {@link #writeTable(Table, Path, ExportConfiguration)} to handle
+ * format-specific file writing.
+ */
+abstract class AbstractExportProvider implements ExportProvider {
+
+  /** Logger for this class. */
+  private static final Logger logger = LoggerFactory.getLogger(AbstractExportProvider.class);
+
+  /** The table reader for fetching data from the database. */
+  private final TableReader tableReader;
+
+  /** Creates a new export provider with a default table reader. */
+  protected AbstractExportProvider() {
+    this.tableReader = new TableReader();
+  }
+
+  /**
+   * Creates a new export provider with the specified table reader.
+   *
+   * @param tableReader the table reader to use
+   */
+  protected AbstractExportProvider(final TableReader tableReader) {
+    this.tableReader = tableReader;
+  }
+
+  @Override
+  public void export(
+      final DataSource dataSource,
+      final List<String> tableNames,
+      final Path outputDirectory,
+      final ExportConfiguration config) {
+    logger.debug("Exporting {} tables to {}", tableNames.size(), outputDirectory);
+
+    createDirectoryIfNeeded(outputDirectory);
+
+    tableNames.forEach(
+        tableName -> {
+          final var table = tableReader.fetchTable(dataSource, tableName);
+          final var outputPath = resolveOutputPath(outputDirectory, tableName);
+          writeTable(table, outputPath, config);
+          logger.debug("Exported table {} to {}", tableName, outputPath);
+        });
+
+    if (config.writeLoadOrderFile()) {
+      writeLoadOrderFile(outputDirectory, tableNames, config.loadOrderFileName());
+    }
+  }
+
+  @Override
+  public void exportQuery(
+      final DataSource dataSource,
+      final String query,
+      final String tableName,
+      final Path outputDirectory,
+      final ExportConfiguration config) {
+    logger.debug("Exporting query result as {} to {}", tableName, outputDirectory);
+
+    createDirectoryIfNeeded(outputDirectory);
+
+    final var table = tableReader.executeQuery(dataSource, query, tableName);
+    final var outputPath = resolveOutputPath(outputDirectory, tableName);
+    writeTable(table, outputPath, config);
+    logger.debug("Exported query result to {}", outputPath);
+  }
+
+  /**
+   * Writes a table to a file.
+   *
+   * <p>Subclasses must implement this method to handle format-specific file writing.
+   *
+   * @param table the table to write
+   * @param outputPath the output file path
+   * @param config the export configuration
+   */
+  protected abstract void writeTable(Table table, Path outputPath, ExportConfiguration config);
+
+  /**
+   * Returns the file extension for this format.
+   *
+   * @return the file extension including the leading dot (e.g., ".csv")
+   */
+  protected abstract String fileExtension();
+
+  /**
+   * Resolves the output file path for a table.
+   *
+   * @param outputDirectory the output directory
+   * @param tableName the table name
+   * @return the output file path
+   */
+  protected Path resolveOutputPath(final Path outputDirectory, final String tableName) {
+    return outputDirectory.resolve(tableName + fileExtension());
+  }
+
+  /**
+   * Formats a cell value for export.
+   *
+   * @param value the cell value
+   * @param config the export configuration
+   * @return the formatted value, or null if the value should be omitted
+   */
+  protected @Nullable String formatValue(final CellValue value, final ExportConfiguration config) {
+    if (value.isNull()) {
+      return null;
+    }
+
+    final var rawValue = value.value();
+    if (rawValue == null) {
+      return null;
+    }
+
+    return formatRawValue(rawValue, config);
+  }
+
+  /**
+   * Formats a raw value for export.
+   *
+   * @param value the raw value
+   * @param config the export configuration
+   * @return the formatted value, or null if the value should be omitted
+   */
+  protected @Nullable String formatRawValue(final Object value, final ExportConfiguration config) {
+    // Handle Base64-encoded LOB values
+    if (value instanceof String stringValue
+        && stringValue.startsWith(InternalConstants.BASE64_PREFIX)) {
+      if (config.lobHandling() == LobHandling.OMIT) {
+        return null;
+      }
+      return stringValue;
+    }
+
+    // Handle byte arrays (BLOB)
+    if (value instanceof byte[] bytes) {
+      if (config.lobHandling() == LobHandling.OMIT) {
+        return null;
+      }
+      return InternalConstants.BASE64_PREFIX + Base64.getEncoder().encodeToString(bytes);
+    }
+
+    // Handle date/time types
+    if (value instanceof Timestamp timestamp) {
+      return config.timestampFormatter().format(timestamp.toLocalDateTime());
+    }
+    if (value instanceof Date date) {
+      return config.dateFormatter().format(date.toLocalDate());
+    }
+    if (value instanceof Time time) {
+      return config.timeFormatter().format(time.toLocalTime());
+    }
+    if (value instanceof LocalDateTime localDateTime) {
+      return config.timestampFormatter().format(localDateTime);
+    }
+    if (value instanceof LocalDate localDate) {
+      return config.dateFormatter().format(localDate);
+    }
+    if (value instanceof LocalTime localTime) {
+      return config.timeFormatter().format(localTime);
+    }
+
+    return value.toString();
+  }
+
+  /**
+   * Checks if a column should be omitted from export.
+   *
+   * @param row a sample row to check
+   * @param columnName the column name
+   * @param config the export configuration
+   * @return true if the column should be omitted
+   */
+  protected boolean shouldOmitColumn(
+      final Row row, final ColumnName columnName, final ExportConfiguration config) {
+    if (config.lobHandling() != LobHandling.OMIT) {
+      return false;
+    }
+
+    final var value = row.getValues().get(columnName);
+    if (value == null || value.isNull()) {
+      return false;
+    }
+
+    final var rawValue = value.value();
+    if (rawValue == null) {
+      return false;
+    }
+
+    // Check if the value is a LOB
+    if (rawValue instanceof byte[]) {
+      return true;
+    }
+    if (rawValue instanceof String stringValue
+        && stringValue.startsWith(InternalConstants.BASE64_PREFIX)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Creates the output directory if it does not exist.
+   *
+   * @param directory the directory to create
+   */
+  private void createDirectoryIfNeeded(final Path directory) {
+    try {
+      Files.createDirectories(directory);
+    } catch (final IOException e) {
+      throw new DatabaseTesterException(
+          String.format("Failed to create output directory: %s", directory), e);
+    }
+  }
+
+  /**
+   * Writes a load order file.
+   *
+   * @param outputDirectory the output directory
+   * @param tableNames the table names in order
+   * @param fileName the load order file name
+   */
+  private void writeLoadOrderFile(
+      final Path outputDirectory, final List<String> tableNames, final String fileName) {
+    final var loadOrderPath = outputDirectory.resolve(fileName);
+    try {
+      Files.write(loadOrderPath, tableNames, StandardCharsets.UTF_8);
+      logger.debug("Wrote load order file to {}", loadOrderPath);
+    } catch (final IOException e) {
+      throw new DatabaseTesterException(
+          String.format("Failed to write load order file: %s", loadOrderPath), e);
+    }
+  }
+}

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/export/DelimitedExportProvider.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/export/DelimitedExportProvider.java
@@ -1,0 +1,241 @@
+package io.github.seijikohara.dbtester.internal.export;
+
+import io.github.seijikohara.dbtester.api.config.DataFormat;
+import io.github.seijikohara.dbtester.api.dataset.Row;
+import io.github.seijikohara.dbtester.api.dataset.Table;
+import io.github.seijikohara.dbtester.api.domain.ColumnName;
+import io.github.seijikohara.dbtester.api.exception.DatabaseTesterException;
+import io.github.seijikohara.dbtester.api.export.ExportConfiguration;
+import io.github.seijikohara.dbtester.internal.format.parser.DelimiterConfig;
+import io.github.seijikohara.dbtester.internal.jdbc.read.TableReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Export provider for delimited file formats (CSV, TSV).
+ *
+ * <p>This class handles exporting tables to comma-separated or tab-separated files with proper
+ * escaping and quoting of values.
+ */
+abstract class DelimitedExportProvider extends AbstractExportProvider {
+
+  /** The delimiter configuration. */
+  private final DelimiterConfig delimiterConfig;
+
+  /**
+   * Creates a new delimited export provider.
+   *
+   * @param delimiterConfig the delimiter configuration
+   */
+  protected DelimitedExportProvider(final DelimiterConfig delimiterConfig) {
+    this.delimiterConfig = delimiterConfig;
+  }
+
+  /**
+   * Creates a new delimited export provider with the specified table reader.
+   *
+   * <p>This constructor is package-private for testing purposes.
+   *
+   * @param delimiterConfig the delimiter configuration
+   * @param tableReader the table reader to use
+   */
+  DelimitedExportProvider(final DelimiterConfig delimiterConfig, final TableReader tableReader) {
+    super(tableReader);
+    this.delimiterConfig = delimiterConfig;
+  }
+
+  @Override
+  protected void writeTable(
+      final Table table, final Path outputPath, final ExportConfiguration config) {
+    final var columns = getExportableColumns(table, config);
+
+    try (final var writer = Files.newBufferedWriter(outputPath, StandardCharsets.UTF_8)) {
+      // Write header row
+      writeHeaderRow(writer, columns.stream().map(ColumnName::value).toList());
+
+      // Write data rows
+      table
+          .getRows()
+          .forEach(
+              row -> {
+                final List<@Nullable String> values = new java.util.ArrayList<>();
+                columns.forEach(col -> values.add(formatCellValue(row, col, config)));
+                writeDataRow(writer, values);
+              });
+    } catch (final IOException e) {
+      throw new DatabaseTesterException(
+          String.format("Failed to write table to: %s", outputPath), e);
+    }
+  }
+
+  @Override
+  protected String fileExtension() {
+    return "." + delimiterConfig.extension();
+  }
+
+  /**
+   * Gets the columns that should be exported.
+   *
+   * @param table the table
+   * @param config the export configuration
+   * @return the list of exportable columns
+   */
+  private List<ColumnName> getExportableColumns(
+      final Table table, final ExportConfiguration config) {
+    final var columns = table.getColumns();
+
+    // If not omitting LOBs, return all columns
+    if (!table.getRows().isEmpty()) {
+      final var firstRow = table.getRows().getFirst();
+      return columns.stream().filter(col -> !shouldOmitColumn(firstRow, col, config)).toList();
+    }
+
+    return columns;
+  }
+
+  /**
+   * Formats a cell value for the delimited output.
+   *
+   * @param row the row containing the value
+   * @param columnName the column name
+   * @param config the export configuration
+   * @return the formatted value
+   */
+  private @Nullable String formatCellValue(
+      final Row row, final ColumnName columnName, final ExportConfiguration config) {
+    final var cellValue = row.getValues().get(columnName);
+    if (cellValue == null || cellValue.isNull()) {
+      return config.nullValue();
+    }
+    final var formatted = formatValue(cellValue, config);
+    return formatted != null ? formatted : config.nullValue();
+  }
+
+  /**
+   * Writes a header row to the output.
+   *
+   * @param writer the writer
+   * @param values the header values to write
+   */
+  private void writeHeaderRow(final BufferedWriter writer, final List<String> values) {
+    try {
+      final var line =
+          values.stream()
+              .map(this::escapeValue)
+              .reduce((a, b) -> a + delimiterConfig.delimiter() + b)
+              .orElse("");
+      writer.write(line);
+      writer.newLine();
+    } catch (final IOException e) {
+      throw new DatabaseTesterException("Failed to write header row", e);
+    }
+  }
+
+  /**
+   * Writes a data row to the output.
+   *
+   * @param writer the writer
+   * @param values the values to write (may contain nulls)
+   */
+  private void writeDataRow(final BufferedWriter writer, final List<@Nullable String> values) {
+    try {
+      final var line =
+          values.stream()
+              .map(v -> v != null ? escapeValue(v) : "")
+              .reduce((a, b) -> a + delimiterConfig.delimiter() + b)
+              .orElse("");
+      writer.write(line);
+      writer.newLine();
+    } catch (final IOException e) {
+      throw new DatabaseTesterException("Failed to write data row", e);
+    }
+  }
+
+  /**
+   * Escapes a value for the delimited format.
+   *
+   * <p>Values containing the delimiter, quotes, or newlines are quoted and internal quotes are
+   * doubled.
+   *
+   * @param value the value to escape
+   * @return the escaped value
+   */
+  private String escapeValue(final String value) {
+    final var delimiter = delimiterConfig.delimiter();
+    final var needsQuoting =
+        value.indexOf(delimiter) >= 0
+            || value.indexOf('"') >= 0
+            || value.indexOf('\n') >= 0
+            || value.indexOf('\r') >= 0;
+
+    if (!needsQuoting) {
+      return value;
+    }
+
+    // Escape quotes by doubling them and wrap in quotes
+    return "\"" + value.replace("\"", "\"\"") + "\"";
+  }
+
+  /**
+   * CSV export provider.
+   *
+   * <p>Exports tables to comma-separated value files.
+   */
+  public static final class Csv extends DelimitedExportProvider {
+
+    /** Creates a new CSV export provider. */
+    public Csv() {
+      super(DelimiterConfig.CSV);
+    }
+
+    /**
+     * Creates a new CSV export provider with the specified table reader.
+     *
+     * <p>This constructor is package-private for testing purposes.
+     *
+     * @param tableReader the table reader to use
+     */
+    Csv(final TableReader tableReader) {
+      super(DelimiterConfig.CSV, tableReader);
+    }
+
+    @Override
+    public DataFormat supportedFormat() {
+      return DataFormat.CSV;
+    }
+  }
+
+  /**
+   * TSV export provider.
+   *
+   * <p>Exports tables to tab-separated value files.
+   */
+  public static final class Tsv extends DelimitedExportProvider {
+
+    /** Creates a new TSV export provider. */
+    public Tsv() {
+      super(DelimiterConfig.TSV);
+    }
+
+    /**
+     * Creates a new TSV export provider with the specified table reader.
+     *
+     * <p>This constructor is package-private for testing purposes.
+     *
+     * @param tableReader the table reader to use
+     */
+    Tsv(final TableReader tableReader) {
+      super(DelimiterConfig.TSV, tableReader);
+    }
+
+    @Override
+    public DataFormat supportedFormat() {
+      return DataFormat.TSV;
+    }
+  }
+}

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/export/JsonExportProvider.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/export/JsonExportProvider.java
@@ -1,0 +1,176 @@
+package io.github.seijikohara.dbtester.internal.export;
+
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import io.github.seijikohara.dbtester.api.config.DataFormat;
+import io.github.seijikohara.dbtester.api.dataset.Row;
+import io.github.seijikohara.dbtester.api.dataset.Table;
+import io.github.seijikohara.dbtester.api.domain.ColumnName;
+import io.github.seijikohara.dbtester.api.exception.DatabaseTesterException;
+import io.github.seijikohara.dbtester.api.export.ExportConfiguration;
+import io.github.seijikohara.dbtester.internal.jdbc.read.TableReader;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Export provider for JSON (JavaScript Object Notation) files.
+ *
+ * <p>This provider exports tables to JSON files in an array-of-objects format, compatible with
+ * {@link io.github.seijikohara.dbtester.internal.format.json.JsonFormatProvider}.
+ *
+ * <p>Example output:
+ *
+ * <pre>{@code
+ * [
+ *   {"ID": 1, "NAME": "Alice", "EMAIL": "alice@example.com"},
+ *   {"ID": 2, "NAME": "Bob", "EMAIL": "bob@example.com"}
+ * ]
+ * }</pre>
+ */
+public final class JsonExportProvider extends AbstractExportProvider {
+
+  /** The JSON object mapper. */
+  private final ObjectMapper objectMapper;
+
+  /** Creates a new JSON export provider. */
+  public JsonExportProvider() {
+    this.objectMapper = createObjectMapper();
+  }
+
+  /**
+   * Creates a new JSON export provider with the specified table reader.
+   *
+   * <p>This constructor is package-private for testing purposes.
+   *
+   * @param tableReader the table reader to use
+   */
+  JsonExportProvider(final TableReader tableReader) {
+    super(tableReader);
+    this.objectMapper = createObjectMapper();
+  }
+
+  /**
+   * Creates and configures the object mapper.
+   *
+   * @return the configured object mapper
+   */
+  private static ObjectMapper createObjectMapper() {
+    final var mapper = new ObjectMapper();
+    mapper.enable(SerializationFeature.INDENT_OUTPUT);
+    return mapper;
+  }
+
+  @Override
+  public DataFormat supportedFormat() {
+    return DataFormat.JSON;
+  }
+
+  @Override
+  protected void writeTable(
+      final Table table, final Path outputPath, final ExportConfiguration config) {
+    final var columns = getExportableColumns(table, config);
+
+    try (final var generator =
+        objectMapper.createGenerator(outputPath.toFile(), JsonEncoding.UTF8)) {
+      generator.useDefaultPrettyPrinter();
+      generator.writeStartArray();
+
+      table.getRows().forEach(row -> writeRow(generator, row, columns, config));
+
+      generator.writeEndArray();
+    } catch (final IOException e) {
+      throw new DatabaseTesterException(
+          String.format("Failed to write table to: %s", outputPath), e);
+    }
+  }
+
+  @Override
+  protected String fileExtension() {
+    return ".json";
+  }
+
+  /**
+   * Gets the columns that should be exported.
+   *
+   * @param table the table
+   * @param config the export configuration
+   * @return the list of exportable columns
+   */
+  private List<ColumnName> getExportableColumns(
+      final Table table, final ExportConfiguration config) {
+    final var columns = table.getColumns();
+
+    if (!table.getRows().isEmpty()) {
+      final var firstRow = table.getRows().getFirst();
+      return columns.stream().filter(col -> !shouldOmitColumn(firstRow, col, config)).toList();
+    }
+
+    return columns;
+  }
+
+  /**
+   * Writes a row as a JSON object.
+   *
+   * @param generator the JSON generator
+   * @param row the row to write
+   * @param columns the columns to include
+   * @param config the export configuration
+   */
+  private void writeRow(
+      final JsonGenerator generator,
+      final Row row,
+      final List<ColumnName> columns,
+      final ExportConfiguration config) {
+    try {
+      generator.writeStartObject();
+
+      columns.forEach(
+          column -> {
+            try {
+              generator.writeFieldName(column.value());
+              writeValue(generator, row, column, config);
+            } catch (final IOException e) {
+              throw new DatabaseTesterException(
+                  String.format("Failed to write column: %s", column.value()), e);
+            }
+          });
+
+      generator.writeEndObject();
+    } catch (final IOException e) {
+      throw new DatabaseTesterException("Failed to write row", e);
+    }
+  }
+
+  /**
+   * Writes a value to the JSON generator.
+   *
+   * @param generator the JSON generator
+   * @param row the row
+   * @param column the column
+   * @param config the export configuration
+   * @throws IOException if writing fails
+   */
+  private void writeValue(
+      final JsonGenerator generator,
+      final Row row,
+      final ColumnName column,
+      final ExportConfiguration config)
+      throws IOException {
+    final var cellValue = row.getValues().get(column);
+
+    if (cellValue == null || cellValue.isNull()) {
+      generator.writeNull();
+      return;
+    }
+
+    final var formatted = formatValue(cellValue, config);
+    if (formatted == null) {
+      generator.writeNull();
+    } else {
+      generator.writeString(formatted);
+    }
+  }
+}

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/export/YamlExportProvider.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/export/YamlExportProvider.java
@@ -1,0 +1,177 @@
+package io.github.seijikohara.dbtester.internal.export;
+
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import io.github.seijikohara.dbtester.api.config.DataFormat;
+import io.github.seijikohara.dbtester.api.dataset.Row;
+import io.github.seijikohara.dbtester.api.dataset.Table;
+import io.github.seijikohara.dbtester.api.domain.ColumnName;
+import io.github.seijikohara.dbtester.api.exception.DatabaseTesterException;
+import io.github.seijikohara.dbtester.api.export.ExportConfiguration;
+import io.github.seijikohara.dbtester.internal.jdbc.read.TableReader;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Export provider for YAML (YAML Ain't Markup Language) files.
+ *
+ * <p>This provider exports tables to YAML files in a list-of-mappings format, compatible with
+ * {@link io.github.seijikohara.dbtester.internal.format.yaml.YamlFormatProvider}.
+ *
+ * <p>Example output:
+ *
+ * <pre>{@code
+ * - ID: 1
+ *   NAME: Alice
+ *   EMAIL: alice@example.com
+ * - ID: 2
+ *   NAME: Bob
+ *   EMAIL: bob@example.com
+ * }</pre>
+ */
+public final class YamlExportProvider extends AbstractExportProvider {
+
+  /** The YAML object mapper. */
+  private final YAMLMapper yamlMapper;
+
+  /** Creates a new YAML export provider. */
+  public YamlExportProvider() {
+    this.yamlMapper = createYamlMapper();
+  }
+
+  /**
+   * Creates a new YAML export provider with the specified table reader.
+   *
+   * <p>This constructor is package-private for testing purposes.
+   *
+   * @param tableReader the table reader to use
+   */
+  YamlExportProvider(final TableReader tableReader) {
+    super(tableReader);
+    this.yamlMapper = createYamlMapper();
+  }
+
+  /**
+   * Creates and configures the YAML mapper.
+   *
+   * @return the configured YAML mapper
+   */
+  private static YAMLMapper createYamlMapper() {
+    final var factory = new YAMLFactory();
+    factory.disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
+    return new YAMLMapper(factory);
+  }
+
+  @Override
+  public DataFormat supportedFormat() {
+    return DataFormat.YAML;
+  }
+
+  @Override
+  protected void writeTable(
+      final Table table, final Path outputPath, final ExportConfiguration config) {
+    final var columns = getExportableColumns(table, config);
+
+    try (final var generator = yamlMapper.createGenerator(outputPath.toFile(), JsonEncoding.UTF8)) {
+      generator.writeStartArray();
+
+      table.getRows().forEach(row -> writeRow(generator, row, columns, config));
+
+      generator.writeEndArray();
+    } catch (final IOException e) {
+      throw new DatabaseTesterException(
+          String.format("Failed to write table to: %s", outputPath), e);
+    }
+  }
+
+  @Override
+  protected String fileExtension() {
+    return ".yaml";
+  }
+
+  /**
+   * Gets the columns that should be exported.
+   *
+   * @param table the table
+   * @param config the export configuration
+   * @return the list of exportable columns
+   */
+  private List<ColumnName> getExportableColumns(
+      final Table table, final ExportConfiguration config) {
+    final var columns = table.getColumns();
+
+    if (!table.getRows().isEmpty()) {
+      final var firstRow = table.getRows().getFirst();
+      return columns.stream().filter(col -> !shouldOmitColumn(firstRow, col, config)).toList();
+    }
+
+    return columns;
+  }
+
+  /**
+   * Writes a row as a YAML mapping.
+   *
+   * @param generator the JSON generator (YAML uses Jackson's JSON generator)
+   * @param row the row to write
+   * @param columns the columns to include
+   * @param config the export configuration
+   */
+  private void writeRow(
+      final JsonGenerator generator,
+      final Row row,
+      final List<ColumnName> columns,
+      final ExportConfiguration config) {
+    try {
+      generator.writeStartObject();
+
+      columns.forEach(
+          column -> {
+            try {
+              generator.writeFieldName(column.value());
+              writeValue(generator, row, column, config);
+            } catch (final IOException e) {
+              throw new DatabaseTesterException(
+                  String.format("Failed to write column: %s", column.value()), e);
+            }
+          });
+
+      generator.writeEndObject();
+    } catch (final IOException e) {
+      throw new DatabaseTesterException("Failed to write row", e);
+    }
+  }
+
+  /**
+   * Writes a value to the YAML generator.
+   *
+   * @param generator the generator
+   * @param row the row
+   * @param column the column
+   * @param config the export configuration
+   * @throws IOException if writing fails
+   */
+  private void writeValue(
+      final JsonGenerator generator,
+      final Row row,
+      final ColumnName column,
+      final ExportConfiguration config)
+      throws IOException {
+    final var cellValue = row.getValues().get(column);
+
+    if (cellValue == null || cellValue.isNull()) {
+      generator.writeNull();
+      return;
+    }
+
+    final var formatted = formatValue(cellValue, config);
+    if (formatted == null) {
+      generator.writeNull();
+    } else {
+      generator.writeString(formatted);
+    }
+  }
+}

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/export/package-info.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/export/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * Internal implementation of data export functionality.
+ *
+ * <p>This package contains the default implementations of {@link
+ * io.github.seijikohara.dbtester.api.spi.ExportProvider} for various file formats.
+ */
+@NullMarked
+package io.github.seijikohara.dbtester.internal.export;
+
+import org.jspecify.annotations.NullMarked;

--- a/db-tester-core/src/main/java/module-info.java
+++ b/db-tester-core/src/main/java/module-info.java
@@ -35,6 +35,13 @@ module io.github.seijikohara.dbtester.core {
   provides io.github.seijikohara.dbtester.api.spi.PreparationSupport with
       io.github.seijikohara.dbtester.internal.lifecycle.DefaultPreparationSupport;
 
+  // Export providers
+  provides io.github.seijikohara.dbtester.api.spi.ExportProvider with
+      io.github.seijikohara.dbtester.internal.export.DelimitedExportProvider.Csv,
+      io.github.seijikohara.dbtester.internal.export.DelimitedExportProvider.Tsv,
+      io.github.seijikohara.dbtester.internal.export.JsonExportProvider,
+      io.github.seijikohara.dbtester.internal.export.YamlExportProvider;
+
   // Internal format providers
   provides io.github.seijikohara.dbtester.internal.format.spi.FormatProvider with
       io.github.seijikohara.dbtester.internal.format.csv.CsvFormatProvider,

--- a/db-tester-core/src/main/resources/META-INF/services/io.github.seijikohara.dbtester.api.spi.ExportProvider
+++ b/db-tester-core/src/main/resources/META-INF/services/io.github.seijikohara.dbtester.api.spi.ExportProvider
@@ -1,0 +1,4 @@
+io.github.seijikohara.dbtester.internal.export.DelimitedExportProvider$Csv
+io.github.seijikohara.dbtester.internal.export.DelimitedExportProvider$Tsv
+io.github.seijikohara.dbtester.internal.export.JsonExportProvider
+io.github.seijikohara.dbtester.internal.export.YamlExportProvider

--- a/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/export/DelimitedExportProviderTest.java
+++ b/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/export/DelimitedExportProviderTest.java
@@ -1,0 +1,277 @@
+package io.github.seijikohara.dbtester.internal.export;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.github.seijikohara.dbtester.api.config.DataFormat;
+import io.github.seijikohara.dbtester.api.dataset.Row;
+import io.github.seijikohara.dbtester.api.dataset.Table;
+import io.github.seijikohara.dbtester.api.domain.CellValue;
+import io.github.seijikohara.dbtester.api.domain.ColumnName;
+import io.github.seijikohara.dbtester.api.domain.TableName;
+import io.github.seijikohara.dbtester.api.export.ExportConfiguration;
+import io.github.seijikohara.dbtester.internal.jdbc.read.TableReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Unit tests for {@link DelimitedExportProvider}. */
+@DisplayName("DelimitedExportProvider")
+class DelimitedExportProviderTest {
+
+  /** Tests for the DelimitedExportProvider class. */
+  DelimitedExportProviderTest() {}
+
+  /** Tests for the Csv provider. */
+  @Nested
+  @DisplayName("Csv")
+  class CsvTests {
+
+    /** Tests for the Csv provider. */
+    CsvTests() {}
+
+    /** Temporary directory for test output. */
+    @TempDir Path tempDir;
+
+    /** Mock data source. */
+    private DataSource dataSource;
+
+    /** Mock table reader. */
+    private TableReader tableReader;
+
+    /** Sets up test fixtures. */
+    @BeforeEach
+    void setUp() {
+      dataSource = mock(DataSource.class);
+      tableReader = mock(TableReader.class);
+    }
+
+    /** Verifies that CSV provider returns CSV format. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return CSV format")
+    void shouldReturnCsvFormat() {
+      // When
+      final var provider = new DelimitedExportProvider.Csv();
+
+      // Then
+      assertEquals(DataFormat.CSV, provider.supportedFormat(), "should return CSV format");
+    }
+
+    /**
+     * Verifies that export creates CSV file with correct content.
+     *
+     * @throws Exception if test fails
+     */
+    @Test
+    @Tag("normal")
+    @DisplayName("should create CSV file with correct content")
+    void shouldCreateCsvFile_withCorrectContent() throws Exception {
+      // Given
+      final var table =
+          createMockTable(
+              "USERS",
+              List.of("ID", "NAME"),
+              List.of(
+                  createMockRow(Map.of("ID", "1", "NAME", "Alice")),
+                  createMockRow(Map.of("ID", "2", "NAME", "Bob"))));
+      when(tableReader.fetchTable(any(DataSource.class), anyString())).thenReturn(table);
+
+      final var provider = new DelimitedExportProvider.Csv(tableReader);
+      final var config = ExportConfiguration.defaults();
+
+      // When
+      provider.export(dataSource, List.of("USERS"), tempDir, config);
+
+      // Then
+      final var exportedFile = tempDir.resolve("USERS.csv");
+      assertTrue(Files.exists(exportedFile), "should create CSV file");
+
+      final var lines = Files.readAllLines(exportedFile);
+      assertEquals(3, lines.size(), "should have header and 2 data rows");
+      assertEquals("ID,NAME", lines.get(0), "should have correct header");
+      assertEquals("1,Alice", lines.get(1), "should have correct first row");
+      assertEquals("2,Bob", lines.get(2), "should have correct second row");
+    }
+
+    /**
+     * Verifies that values with commas are escaped.
+     *
+     * @throws Exception if test fails
+     */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should escape values with commas")
+    void shouldEscapeValuesWithCommas() throws Exception {
+      // Given
+      final var table =
+          createMockTable(
+              "USERS",
+              List.of("ID", "NAME"),
+              List.of(createMockRow(Map.of("ID", "1", "NAME", "Doe, John"))));
+      when(tableReader.fetchTable(any(DataSource.class), anyString())).thenReturn(table);
+
+      final var provider = new DelimitedExportProvider.Csv(tableReader);
+      final var config = ExportConfiguration.defaults();
+
+      // When
+      provider.export(dataSource, List.of("USERS"), tempDir, config);
+
+      // Then
+      final var content = Files.readString(tempDir.resolve("USERS.csv"));
+      assertTrue(content.contains("\"Doe, John\""), "should escape value with comma");
+    }
+
+    /**
+     * Verifies that null values are represented as empty strings.
+     *
+     * @throws Exception if test fails
+     */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should represent null values as empty strings")
+    void shouldRepresentNullAsEmptyString() throws Exception {
+      // Given
+      final var col1 = new ColumnName("ID");
+      final var col2 = new ColumnName("NAME");
+      final var row = mock(Row.class);
+      when(row.getValues()).thenReturn(Map.of(col1, new CellValue("1"), col2, CellValue.NULL));
+
+      final var table = mock(Table.class);
+      when(table.getName()).thenReturn(new TableName("USERS"));
+      when(table.getColumns()).thenReturn(List.of(col1, col2));
+      when(table.getRows()).thenReturn(List.of(row));
+
+      when(tableReader.fetchTable(any(DataSource.class), anyString())).thenReturn(table);
+
+      final var provider = new DelimitedExportProvider.Csv(tableReader);
+      final var config = ExportConfiguration.defaults();
+
+      // When
+      provider.export(dataSource, List.of("USERS"), tempDir, config);
+
+      // Then
+      final var lines = Files.readAllLines(tempDir.resolve("USERS.csv"));
+      assertEquals("1,", lines.get(1), "should represent null as empty string");
+    }
+
+    /**
+     * Verifies that load order file is generated when configured.
+     *
+     * @throws Exception if test fails
+     */
+    @Test
+    @Tag("normal")
+    @DisplayName("should generate load order file when configured")
+    void shouldGenerateLoadOrderFile_whenConfigured() throws Exception {
+      // Given
+      final var table = createMockTable("USERS", List.of("ID"), List.of());
+      when(tableReader.fetchTable(any(DataSource.class), anyString())).thenReturn(table);
+
+      final var provider = new DelimitedExportProvider.Csv(tableReader);
+      final var config = ExportConfiguration.builder().writeLoadOrderFile(true).build();
+
+      // When
+      provider.export(dataSource, List.of("USERS"), tempDir, config);
+
+      // Then
+      final var loadOrderFile = tempDir.resolve("load-order.txt");
+      assertTrue(Files.exists(loadOrderFile), "should create load order file");
+      assertEquals("USERS", Files.readAllLines(loadOrderFile).get(0), "should contain table name");
+    }
+
+    /**
+     * Verifies that load order file is not generated by default.
+     *
+     * @throws Exception if test fails
+     */
+    @Test
+    @Tag("normal")
+    @DisplayName("should not generate load order file by default")
+    void shouldNotGenerateLoadOrderFile_byDefault() throws Exception {
+      // Given
+      final var table = createMockTable("USERS", List.of("ID"), List.of());
+      when(tableReader.fetchTable(any(DataSource.class), anyString())).thenReturn(table);
+
+      final var provider = new DelimitedExportProvider.Csv(tableReader);
+      final var config = ExportConfiguration.defaults();
+
+      // When
+      provider.export(dataSource, List.of("USERS"), tempDir, config);
+
+      // Then
+      assertFalse(
+          Files.exists(tempDir.resolve("load-order.txt")),
+          "should not create load order file by default");
+    }
+  }
+
+  /** Tests for the Tsv provider. */
+  @Nested
+  @DisplayName("Tsv")
+  class TsvTests {
+
+    /** Tests for the Tsv provider. */
+    TsvTests() {}
+
+    /** Verifies that TSV provider returns TSV format. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return TSV format")
+    void shouldReturnTsvFormat() {
+      // When
+      final var provider = new DelimitedExportProvider.Tsv();
+
+      // Then
+      assertEquals(DataFormat.TSV, provider.supportedFormat(), "should return TSV format");
+    }
+  }
+
+  /**
+   * Creates a mock table with the specified properties.
+   *
+   * @param tableName the table name
+   * @param columnNames the column names
+   * @param rows the rows
+   * @return the mock table
+   */
+  private static Table createMockTable(
+      final String tableName, final List<String> columnNames, final List<Row> rows) {
+    final var table = mock(Table.class);
+    when(table.getName()).thenReturn(new TableName(tableName));
+    when(table.getColumns()).thenReturn(columnNames.stream().map(ColumnName::new).toList());
+    when(table.getRows()).thenReturn(rows);
+    return table;
+  }
+
+  /**
+   * Creates a mock row with the specified values.
+   *
+   * @param values the column-value pairs
+   * @return the mock row
+   */
+  private static Row createMockRow(final Map<String, String> values) {
+    final var row = mock(Row.class);
+    final Map<ColumnName, CellValue> cellValues =
+        values.entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    e -> new ColumnName(e.getKey()), e -> new CellValue(e.getValue())));
+    when(row.getValues()).thenReturn(cellValues);
+    return row;
+  }
+}

--- a/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/export/JsonExportProviderTest.java
+++ b/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/export/JsonExportProviderTest.java
@@ -1,0 +1,218 @@
+package io.github.seijikohara.dbtester.internal.export;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.seijikohara.dbtester.api.config.DataFormat;
+import io.github.seijikohara.dbtester.api.dataset.Row;
+import io.github.seijikohara.dbtester.api.dataset.Table;
+import io.github.seijikohara.dbtester.api.domain.CellValue;
+import io.github.seijikohara.dbtester.api.domain.ColumnName;
+import io.github.seijikohara.dbtester.api.domain.TableName;
+import io.github.seijikohara.dbtester.api.export.ExportConfiguration;
+import io.github.seijikohara.dbtester.internal.jdbc.read.TableReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Unit tests for {@link JsonExportProvider}. */
+@DisplayName("JsonExportProvider")
+class JsonExportProviderTest {
+
+  /** Tests for the JsonExportProvider class. */
+  JsonExportProviderTest() {}
+
+  /** Tests for the export functionality. */
+  @Nested
+  @DisplayName("export()")
+  class ExportMethod {
+
+    /** Tests for the export method. */
+    ExportMethod() {}
+
+    /** Temporary directory for test output. */
+    @TempDir Path tempDir;
+
+    /** Mock data source. */
+    private DataSource dataSource;
+
+    /** Mock table reader. */
+    private TableReader tableReader;
+
+    /** JSON object mapper. */
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /** Sets up test fixtures. */
+    @BeforeEach
+    void setUp() {
+      dataSource = mock(DataSource.class);
+      tableReader = mock(TableReader.class);
+    }
+
+    /** Verifies that JSON provider returns JSON format. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return JSON format")
+    void shouldReturnJsonFormat() {
+      // When
+      final var provider = new JsonExportProvider();
+
+      // Then
+      assertEquals(DataFormat.JSON, provider.supportedFormat(), "should return JSON format");
+    }
+
+    /**
+     * Verifies that export creates JSON file with correct content.
+     *
+     * @throws Exception if test fails
+     */
+    @Test
+    @Tag("normal")
+    @DisplayName("should create JSON file with correct content")
+    void shouldCreateJsonFile_withCorrectContent() throws Exception {
+      // Given
+      final var table =
+          createMockTable(
+              "PRODUCTS",
+              List.of("ID", "NAME"),
+              List.of(
+                  createMockRow(Map.of("ID", "1", "NAME", "Widget")),
+                  createMockRow(Map.of("ID", "2", "NAME", "Gadget"))));
+      when(tableReader.fetchTable(any(DataSource.class), anyString())).thenReturn(table);
+
+      final var provider = new JsonExportProvider(tableReader);
+      final var config = ExportConfiguration.defaults();
+
+      // When
+      provider.export(dataSource, List.of("PRODUCTS"), tempDir, config);
+
+      // Then
+      final var exportedFile = tempDir.resolve("PRODUCTS.json");
+      assertTrue(Files.exists(exportedFile), "should create JSON file");
+
+      final JsonNode root = objectMapper.readTree(exportedFile.toFile());
+      assertTrue(root.isArray(), "should be a JSON array");
+      assertEquals(2, root.size(), "should have 2 rows");
+      assertEquals("Widget", root.get(0).get("NAME").asText(), "should have correct first row");
+      assertEquals("Gadget", root.get(1).get("NAME").asText(), "should have correct second row");
+    }
+
+    /**
+     * Verifies that null values are represented as JSON null.
+     *
+     * @throws Exception if test fails
+     */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should represent null values as JSON null")
+    void shouldRepresentNullAsJsonNull() throws Exception {
+      // Given
+      final var col1 = new ColumnName("ID");
+      final var col2 = new ColumnName("NAME");
+      final var row = mock(Row.class);
+      when(row.getValues()).thenReturn(Map.of(col1, new CellValue("1"), col2, CellValue.NULL));
+
+      final var table = mock(Table.class);
+      when(table.getName()).thenReturn(new TableName("USERS"));
+      when(table.getColumns()).thenReturn(List.of(col1, col2));
+      when(table.getRows()).thenReturn(List.of(row));
+
+      when(tableReader.fetchTable(any(DataSource.class), anyString())).thenReturn(table);
+
+      final var provider = new JsonExportProvider(tableReader);
+      final var config = ExportConfiguration.defaults();
+
+      // When
+      provider.export(dataSource, List.of("USERS"), tempDir, config);
+
+      // Then
+      final var exportedFile = tempDir.resolve("USERS.json");
+      final JsonNode root = objectMapper.readTree(exportedFile.toFile());
+      assertTrue(root.get(0).get("NAME").isNull(), "should represent null as JSON null");
+    }
+
+    /**
+     * Verifies that exportQuery creates JSON file with query results.
+     *
+     * @throws Exception if test fails
+     */
+    @Test
+    @Tag("normal")
+    @DisplayName("should export query result to JSON file")
+    void shouldExportQueryResult() throws Exception {
+      // Given
+      final var table =
+          createMockTable(
+              "QUERY_RESULT",
+              List.of("ID", "NAME"),
+              List.of(createMockRow(Map.of("ID", "1", "NAME", "Alice"))));
+      when(tableReader.executeQuery(any(DataSource.class), anyString(), anyString()))
+          .thenReturn(table);
+
+      final var provider = new JsonExportProvider(tableReader);
+      final var config = ExportConfiguration.defaults();
+
+      // When
+      provider.exportQuery(
+          dataSource, "SELECT * FROM USERS WHERE ID = 1", "SINGLE_USER", tempDir, config);
+
+      // Then
+      final var exportedFile = tempDir.resolve("SINGLE_USER.json");
+      assertTrue(Files.exists(exportedFile), "should create JSON file");
+
+      final JsonNode root = objectMapper.readTree(exportedFile.toFile());
+      assertTrue(root.isArray(), "should be a JSON array");
+      assertEquals(1, root.size(), "should have 1 row");
+      assertEquals("Alice", root.get(0).get("NAME").asText(), "should have correct value");
+    }
+  }
+
+  /**
+   * Creates a mock table with the specified properties.
+   *
+   * @param tableName the table name
+   * @param columnNames the column names
+   * @param rows the rows
+   * @return the mock table
+   */
+  private static Table createMockTable(
+      final String tableName, final List<String> columnNames, final List<Row> rows) {
+    final var table = mock(Table.class);
+    when(table.getName()).thenReturn(new TableName(tableName));
+    when(table.getColumns()).thenReturn(columnNames.stream().map(ColumnName::new).toList());
+    when(table.getRows()).thenReturn(rows);
+    return table;
+  }
+
+  /**
+   * Creates a mock row with the specified values.
+   *
+   * @param values the column-value pairs
+   * @return the mock row
+   */
+  private static Row createMockRow(final Map<String, String> values) {
+    final var row = mock(Row.class);
+    final Map<ColumnName, CellValue> cellValues =
+        values.entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    e -> new ColumnName(e.getKey()), e -> new CellValue(e.getValue())));
+    when(row.getValues()).thenReturn(cellValues);
+    return row;
+  }
+}

--- a/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/export/YamlExportProviderTest.java
+++ b/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/export/YamlExportProviderTest.java
@@ -1,0 +1,218 @@
+package io.github.seijikohara.dbtester.internal.export;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import io.github.seijikohara.dbtester.api.config.DataFormat;
+import io.github.seijikohara.dbtester.api.dataset.Row;
+import io.github.seijikohara.dbtester.api.dataset.Table;
+import io.github.seijikohara.dbtester.api.domain.CellValue;
+import io.github.seijikohara.dbtester.api.domain.ColumnName;
+import io.github.seijikohara.dbtester.api.domain.TableName;
+import io.github.seijikohara.dbtester.api.export.ExportConfiguration;
+import io.github.seijikohara.dbtester.internal.jdbc.read.TableReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Unit tests for {@link YamlExportProvider}. */
+@DisplayName("YamlExportProvider")
+class YamlExportProviderTest {
+
+  /** Tests for the YamlExportProvider class. */
+  YamlExportProviderTest() {}
+
+  /** Tests for the export functionality. */
+  @Nested
+  @DisplayName("export()")
+  class ExportMethod {
+
+    /** Tests for the export method. */
+    ExportMethod() {}
+
+    /** Temporary directory for test output. */
+    @TempDir Path tempDir;
+
+    /** Mock data source. */
+    private DataSource dataSource;
+
+    /** Mock table reader. */
+    private TableReader tableReader;
+
+    /** YAML mapper for parsing output. */
+    private final YAMLMapper yamlMapper = new YAMLMapper();
+
+    /** Sets up test fixtures. */
+    @BeforeEach
+    void setUp() {
+      dataSource = mock(DataSource.class);
+      tableReader = mock(TableReader.class);
+    }
+
+    /** Verifies that YAML provider returns YAML format. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return YAML format")
+    void shouldReturnYamlFormat() {
+      // When
+      final var provider = new YamlExportProvider();
+
+      // Then
+      assertEquals(DataFormat.YAML, provider.supportedFormat(), "should return YAML format");
+    }
+
+    /**
+     * Verifies that export creates YAML file with correct content.
+     *
+     * @throws Exception if test fails
+     */
+    @Test
+    @Tag("normal")
+    @DisplayName("should create YAML file with correct content")
+    void shouldCreateYamlFile_withCorrectContent() throws Exception {
+      // Given
+      final var table =
+          createMockTable(
+              "ORDERS",
+              List.of("ID", "CUSTOMER"),
+              List.of(
+                  createMockRow(Map.of("ID", "1", "CUSTOMER", "Alice")),
+                  createMockRow(Map.of("ID", "2", "CUSTOMER", "Bob"))));
+      when(tableReader.fetchTable(any(DataSource.class), anyString())).thenReturn(table);
+
+      final var provider = new YamlExportProvider(tableReader);
+      final var config = ExportConfiguration.defaults();
+
+      // When
+      provider.export(dataSource, List.of("ORDERS"), tempDir, config);
+
+      // Then
+      final var exportedFile = tempDir.resolve("ORDERS.yaml");
+      assertTrue(Files.exists(exportedFile), "should create YAML file");
+
+      final JsonNode root = yamlMapper.readTree(exportedFile.toFile());
+      assertTrue(root.isArray(), "should be a YAML array");
+      assertEquals(2, root.size(), "should have 2 rows");
+      assertEquals("Alice", root.get(0).get("CUSTOMER").asText(), "should have correct first row");
+      assertEquals("Bob", root.get(1).get("CUSTOMER").asText(), "should have correct second row");
+    }
+
+    /**
+     * Verifies that null values are represented as YAML null.
+     *
+     * @throws Exception if test fails
+     */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should represent null values as YAML null")
+    void shouldRepresentNullAsYamlNull() throws Exception {
+      // Given
+      final var col1 = new ColumnName("ID");
+      final var col2 = new ColumnName("CUSTOMER");
+      final var row = mock(Row.class);
+      when(row.getValues()).thenReturn(Map.of(col1, new CellValue("1"), col2, CellValue.NULL));
+
+      final var table = mock(Table.class);
+      when(table.getName()).thenReturn(new TableName("ORDERS"));
+      when(table.getColumns()).thenReturn(List.of(col1, col2));
+      when(table.getRows()).thenReturn(List.of(row));
+
+      when(tableReader.fetchTable(any(DataSource.class), anyString())).thenReturn(table);
+
+      final var provider = new YamlExportProvider(tableReader);
+      final var config = ExportConfiguration.defaults();
+
+      // When
+      provider.export(dataSource, List.of("ORDERS"), tempDir, config);
+
+      // Then
+      final var exportedFile = tempDir.resolve("ORDERS.yaml");
+      final JsonNode root = yamlMapper.readTree(exportedFile.toFile());
+      assertTrue(root.get(0).get("CUSTOMER").isNull(), "should represent null as YAML null");
+    }
+
+    /**
+     * Verifies that exportQuery creates YAML file with query results.
+     *
+     * @throws Exception if test fails
+     */
+    @Test
+    @Tag("normal")
+    @DisplayName("should export query result to YAML file")
+    void shouldExportQueryResult() throws Exception {
+      // Given
+      final var table =
+          createMockTable(
+              "QUERY_RESULT",
+              List.of("ID", "CUSTOMER"),
+              List.of(createMockRow(Map.of("ID", "1", "CUSTOMER", "Alice"))));
+      when(tableReader.executeQuery(any(DataSource.class), anyString(), anyString()))
+          .thenReturn(table);
+
+      final var provider = new YamlExportProvider(tableReader);
+      final var config = ExportConfiguration.defaults();
+
+      // When
+      provider.exportQuery(
+          dataSource, "SELECT * FROM ORDERS WHERE ID = 1", "SINGLE_ORDER", tempDir, config);
+
+      // Then
+      final var exportedFile = tempDir.resolve("SINGLE_ORDER.yaml");
+      assertTrue(Files.exists(exportedFile), "should create YAML file");
+
+      final JsonNode root = yamlMapper.readTree(exportedFile.toFile());
+      assertTrue(root.isArray(), "should be a YAML array");
+      assertEquals(1, root.size(), "should have 1 row");
+      assertEquals("Alice", root.get(0).get("CUSTOMER").asText(), "should have correct value");
+    }
+  }
+
+  /**
+   * Creates a mock table with the specified properties.
+   *
+   * @param tableName the table name
+   * @param columnNames the column names
+   * @param rows the rows
+   * @return the mock table
+   */
+  private static Table createMockTable(
+      final String tableName, final List<String> columnNames, final List<Row> rows) {
+    final var table = mock(Table.class);
+    when(table.getName()).thenReturn(new TableName(tableName));
+    when(table.getColumns()).thenReturn(columnNames.stream().map(ColumnName::new).toList());
+    when(table.getRows()).thenReturn(rows);
+    return table;
+  }
+
+  /**
+   * Creates a mock row with the specified values.
+   *
+   * @param values the column-value pairs
+   * @return the mock row
+   */
+  private static Row createMockRow(final Map<String, String> values) {
+    final var row = mock(Row.class);
+    final Map<ColumnName, CellValue> cellValues =
+        values.entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    e -> new ColumnName(e.getKey()), e -> new CellValue(e.getValue())));
+    when(row.getValues()).thenReturn(cellValues);
+    return row;
+  }
+}

--- a/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/export/package-info.java
+++ b/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/export/package-info.java
@@ -1,0 +1,5 @@
+/** Unit tests for the export package. */
+@NullMarked
+package io.github.seijikohara.dbtester.internal.export;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
## Summary
- Add ability to export current database state to CSV, TSV, JSON, and YAML files
- Implement SPI pattern (ExportProvider) similar to existing ExpectationSupport
- Provide static facade (DataSetExporter) for user-friendly API
- Support configurable export settings via ExportConfiguration builder

## Changes
### db-tester-api
- `DataSetExporter`: Static facade with convenience methods (`export()`, `exportQuery()`, `csv()`, `tsv()`, `json()`, `yaml()`)
- `ExportConfiguration`: Builder-based configuration for null handling, date/time formatters, LOB handling
- `LobHandling`: Enum for BLOB/CLOB export strategies (BASE64, OMIT)
- `ExportProvider`: SPI interface for format implementations

### db-tester-core
- `AbstractExportProvider`: Base class with common export logic
- `DelimitedExportProvider`: CSV/TSV implementation with proper escaping
- `JsonExportProvider`: JSON export using Jackson
- `YamlExportProvider`: YAML export using Jackson

## Test plan
- [x] Unit tests for DelimitedExportProvider (CSV/TSV)
- [x] Unit tests for JsonExportProvider
- [x] Unit tests for YamlExportProvider
- [x] All existing tests pass
- [x] spotlessCheck passes
- [x] verifyNullMarkedPackages passes

Closes #122