### PR TITLE
feat(spi): add custom type handler SPI

### DIFF
--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/spi/TypeHandler.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/spi/TypeHandler.java
@@ -1,0 +1,135 @@
+package io.github.seijikohara.dbtester.api.spi;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Service Provider Interface for custom database type handling.
+ *
+ * <p>This interface allows extensions to register handlers for database-specific types such as
+ * PostgreSQL JSON/JSONB, UUID, ARRAY, or user-defined types. Implementations are discovered via
+ * {@link java.util.ServiceLoader}.
+ *
+ * <p>Each handler declares which SQL types it supports and provides methods for reading values from
+ * result sets, writing values to prepared statements, and converting between Java objects and
+ * string representations for import/export.
+ *
+ * <h2>Usage Example</h2>
+ *
+ * <pre>{@code
+ * public class PostgresJsonHandler implements TypeHandler<JsonNode> {
+ *     @Override
+ *     public Class<JsonNode> getJavaType() {
+ *         return JsonNode.class;
+ *     }
+ *
+ *     @Override
+ *     public List<Integer> getSqlTypes() {
+ *         return List.of(Types.OTHER);  // PostgreSQL JSON/JSONB
+ *     }
+ *
+ *     @Override
+ *     public JsonNode read(ResultSet rs, int columnIndex) throws SQLException {
+ *         String json = rs.getString(columnIndex);
+ *         return json != null ? parseJson(json) : null;
+ *     }
+ *
+ *     @Override
+ *     public void write(PreparedStatement ps, int parameterIndex, JsonNode value)
+ *         throws SQLException {
+ *         ps.setObject(parameterIndex, value.toString(), Types.OTHER);
+ *     }
+ * }
+ * }</pre>
+ *
+ * @param <T> the Java type this handler produces and consumes
+ * @see java.util.ServiceLoader
+ */
+public interface TypeHandler<T> {
+
+  /**
+   * Returns the Java type this handler produces.
+   *
+   * @return the Java class for the handled type
+   */
+  Class<T> getJavaType();
+
+  /**
+   * Returns the SQL type codes this handler supports.
+   *
+   * <p>These values correspond to constants in {@link java.sql.Types}. A handler may support
+   * multiple SQL types (e.g., both BLOB and BINARY).
+   *
+   * @return list of SQL type codes
+   */
+  List<Integer> getSqlTypes();
+
+  /**
+   * Returns the database product names this handler is specialized for.
+   *
+   * <p>Return an empty list if this handler is database-agnostic. For database-specific handlers,
+   * return product names as returned by {@code DatabaseMetaData.getDatabaseProductName()}.
+   *
+   * <p>Examples: "PostgreSQL", "MySQL", "Oracle", "H2"
+   *
+   * @return list of supported database product names, or empty for all databases
+   */
+  default List<String> getSupportedDatabases() {
+    return List.of();
+  }
+
+  /**
+   * Returns the priority of this handler.
+   *
+   * <p>When multiple handlers support the same SQL type, the handler with the highest priority is
+   * selected. Database-specific handlers typically have higher priority than generic handlers.
+   *
+   * <p>Default priority is 0. Database-specific handlers should use positive values.
+   *
+   * @return the handler priority (higher values take precedence)
+   */
+  default int getPriority() {
+    return 0;
+  }
+
+  /**
+   * Reads a value from the result set.
+   *
+   * @param resultSet the result set positioned at the current row
+   * @param columnIndex the column index (1-based)
+   * @return the read value, or null if the database value is null
+   * @throws SQLException if reading fails
+   */
+  T read(ResultSet resultSet, int columnIndex) throws SQLException;
+
+  /**
+   * Writes a value to a prepared statement.
+   *
+   * @param preparedStatement the prepared statement
+   * @param parameterIndex the parameter index (1-based)
+   * @param value the value to write (never null)
+   * @throws SQLException if writing fails
+   */
+  void write(PreparedStatement preparedStatement, int parameterIndex, T value) throws SQLException;
+
+  /**
+   * Formats a value as a string for export (CSV, JSON, etc.).
+   *
+   * <p>The returned string should be parseable by {@link #parse(String)}.
+   *
+   * @param value the value to format (never null)
+   * @return the string representation
+   */
+  String format(T value);
+
+  /**
+   * Parses a string value from import (CSV, JSON, etc.).
+   *
+   * @param value the string value to parse (never null or empty)
+   * @return the parsed value
+   * @throws IllegalArgumentException if parsing fails
+   */
+  T parse(String value);
+}

--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/spi/package-info.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/spi/package-info.java
@@ -14,6 +14,7 @@
  *       execution
  *   <li>{@link io.github.seijikohara.dbtester.api.spi.ExpectationProvider} - Expectation
  *       verification
+ *   <li>{@link io.github.seijikohara.dbtester.api.spi.TypeHandler} - Custom database type handling
  * </ul>
  */
 @NullMarked

--- a/db-tester-api/src/main/java/module-info.java
+++ b/db-tester-api/src/main/java/module-info.java
@@ -33,5 +33,6 @@ module io.github.seijikohara.dbtester.api {
   uses io.github.seijikohara.dbtester.api.spi.ExpectationSupport;
   uses io.github.seijikohara.dbtester.api.spi.OperationProvider;
   uses io.github.seijikohara.dbtester.api.spi.PreparationSupport;
+  uses io.github.seijikohara.dbtester.api.spi.TypeHandler;
   uses io.github.seijikohara.dbtester.api.scenario.ScenarioNameResolver;
 }

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/jdbc/type/ArrayTypeHandler.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/jdbc/type/ArrayTypeHandler.java
@@ -1,0 +1,262 @@
+package io.github.seijikohara.dbtester.internal.jdbc.type;
+
+import io.github.seijikohara.dbtester.api.spi.TypeHandler;
+import java.sql.Array;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Type handler for SQL ARRAY values.
+ *
+ * <p>This handler reads and writes SQL arrays as Java Object arrays. It supports PostgreSQL and
+ * other databases with native array types.
+ *
+ * <p>When reading, the JDBC Array is converted to a Java Object array. When writing, the Java array
+ * is converted back to a JDBC Array using the connection's createArrayOf method.
+ *
+ * <p>For string serialization, arrays are formatted as comma-separated values enclosed in curly
+ * braces (PostgreSQL array literal syntax): {@code {value1,value2,value3}}
+ */
+public final class ArrayTypeHandler implements TypeHandler<Object[]> {
+
+  /** SQL types supported by this handler. */
+  private static final List<Integer> SUPPORTED_SQL_TYPES = List.of(Types.ARRAY);
+
+  /** Databases with native ARRAY support. */
+  private static final List<String> SUPPORTED_DATABASES = List.of("PostgreSQL", "H2");
+
+  /** Creates a new array type handler. */
+  public ArrayTypeHandler() {}
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Class<Object[]> getJavaType() {
+    return Object[].class;
+  }
+
+  @Override
+  public List<Integer> getSqlTypes() {
+    return SUPPORTED_SQL_TYPES;
+  }
+
+  @Override
+  public List<String> getSupportedDatabases() {
+    return SUPPORTED_DATABASES;
+  }
+
+  @Override
+  public int getPriority() {
+    return 10;
+  }
+
+  @Override
+  @SuppressWarnings("NullAway")
+  public Object @Nullable [] read(final ResultSet resultSet, final int columnIndex)
+      throws SQLException {
+    final var sqlArray = resultSet.getArray(columnIndex);
+    if (sqlArray == null || resultSet.wasNull()) {
+      return null;
+    }
+
+    try {
+      final var javaArray = sqlArray.getArray();
+      if (javaArray instanceof Object[] objectArray) {
+        return objectArray;
+      }
+      // Handle primitive arrays by boxing
+      return boxPrimitiveArray(javaArray);
+    } finally {
+      sqlArray.free();
+    }
+  }
+
+  @Override
+  public void write(
+      final PreparedStatement preparedStatement, final int parameterIndex, final Object[] value)
+      throws SQLException {
+    // Determine the SQL type name for the array elements
+    final var typeName = inferTypeName(value);
+    final var connection = preparedStatement.getConnection();
+    final Array sqlArray = connection.createArrayOf(typeName, value);
+    try {
+      preparedStatement.setArray(parameterIndex, sqlArray);
+    } catch (final SQLException e) {
+      sqlArray.free();
+      throw e;
+    }
+  }
+
+  @Override
+  public String format(final Object[] value) {
+    // Format as PostgreSQL array literal: {value1,value2,value3}
+    final var elements =
+        Arrays.stream(value).map(this::formatElement).collect(Collectors.joining(","));
+    return "{" + elements + "}";
+  }
+
+  @Override
+  public Object[] parse(final String value) {
+    final var trimmed = value.trim();
+
+    // Handle PostgreSQL array literal syntax: {value1,value2,value3}
+    if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
+      final var content = trimmed.substring(1, trimmed.length() - 1);
+      if (content.isEmpty()) {
+        return new Object[0];
+      }
+      return parseArrayContent(content);
+    }
+
+    // Handle comma-separated values
+    if (trimmed.contains(",")) {
+      return Arrays.stream(trimmed.split(",")).map(String::trim).toArray(Object[]::new);
+    }
+
+    // Single element
+    return new Object[] {trimmed};
+  }
+
+  /**
+   * Converts a primitive array to an Object array.
+   *
+   * @param primitiveArray the primitive array
+   * @return the boxed Object array
+   */
+  private Object[] boxPrimitiveArray(final Object primitiveArray) {
+    if (primitiveArray instanceof int[] intArray) {
+      return Arrays.stream(intArray).boxed().toArray();
+    }
+    if (primitiveArray instanceof long[] longArray) {
+      return Arrays.stream(longArray).boxed().toArray();
+    }
+    if (primitiveArray instanceof double[] doubleArray) {
+      return Arrays.stream(doubleArray).boxed().toArray();
+    }
+    if (primitiveArray instanceof boolean[] boolArray) {
+      final var result = new Object[boolArray.length];
+      for (var i = 0; i < boolArray.length; i++) {
+        result[i] = boolArray[i];
+      }
+      return result;
+    }
+    // Fallback: wrap in single-element array
+    return new Object[] {primitiveArray};
+  }
+
+  /**
+   * Infers the SQL type name for array elements.
+   *
+   * @param array the array to inspect
+   * @return the SQL type name
+   */
+  private String inferTypeName(final Object[] array) {
+    if (array.length == 0) {
+      return "varchar"; // Default for empty arrays
+    }
+
+    final var firstElement = array[0];
+    if (firstElement == null) {
+      return "varchar";
+    }
+
+    return switch (firstElement) {
+      case Integer i -> "integer";
+      case Long l -> "bigint";
+      case Double d -> "double precision";
+      case Float f -> "real";
+      case Boolean b -> "boolean";
+      case String s -> "varchar";
+      default -> "varchar";
+    };
+  }
+
+  /**
+   * Formats a single array element for string output.
+   *
+   * @param element the element to format
+   * @return the formatted string
+   */
+  private String formatElement(final @Nullable Object element) {
+    if (element == null) {
+      return "NULL";
+    }
+    if (element instanceof String strValue) {
+      // Escape quotes and wrap in double quotes if contains special characters
+      if (strValue.contains(",") || strValue.contains("\"") || strValue.contains("{")) {
+        return "\"" + strValue.replace("\"", "\\\"") + "\"";
+      }
+      return strValue;
+    }
+    return element.toString();
+  }
+
+  /**
+   * Parses the content of a PostgreSQL array literal.
+   *
+   * @param content the array content without braces
+   * @return the parsed array elements
+   */
+  private Object[] parseArrayContent(final String content) {
+    // Simple parsing for non-nested arrays
+    final var elements = new java.util.ArrayList<Object>();
+    final var current = new StringBuilder();
+    var inQuotes = false;
+    var escaped = false;
+
+    for (var i = 0; i < content.length(); i++) {
+      final var c = content.charAt(i);
+
+      if (escaped) {
+        current.append(c);
+        escaped = false;
+        continue;
+      }
+
+      if (c == '\\') {
+        escaped = true;
+        continue;
+      }
+
+      if (c == '"') {
+        inQuotes = !inQuotes;
+        continue;
+      }
+
+      if (c == ',' && !inQuotes) {
+        elements.add(parseElement(current.toString()));
+        current.setLength(0);
+        continue;
+      }
+
+      current.append(c);
+    }
+
+    // Add the last element
+    if (!current.isEmpty()) {
+      elements.add(parseElement(current.toString()));
+    }
+
+    return elements.toArray();
+  }
+
+  /**
+   * Parses a single array element value.
+   *
+   * @param element the element string
+   * @return the parsed value (null for "NULL", otherwise the string value)
+   */
+  @SuppressWarnings("NullAway")
+  private @Nullable Object parseElement(final String element) {
+    final var trimmed = element.trim();
+    if ("NULL".equalsIgnoreCase(trimmed)) {
+      return null;
+    }
+    return trimmed;
+  }
+}

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/jdbc/type/JsonTypeHandler.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/jdbc/type/JsonTypeHandler.java
@@ -1,0 +1,114 @@
+package io.github.seijikohara.dbtester.internal.jdbc.type;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.seijikohara.dbtester.api.spi.TypeHandler;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Type handler for JSON/JSONB values in PostgreSQL.
+ *
+ * <p>This handler reads and writes JSON data as Jackson {@link JsonNode} objects. PostgreSQL stores
+ * JSON and JSONB columns as Types.OTHER, which this handler supports.
+ *
+ * <p>When reading, JSON strings from the database are parsed into JsonNode trees. When writing, the
+ * JsonNode is serialized to a JSON string and set using setObject with Types.OTHER.
+ */
+public final class JsonTypeHandler implements TypeHandler<JsonNode> {
+
+  /** SQL types supported by this handler. */
+  private static final List<Integer> SUPPORTED_SQL_TYPES = List.of(Types.OTHER);
+
+  /** Databases with native JSON support handled by this handler. */
+  private static final List<String> SUPPORTED_DATABASES = List.of("PostgreSQL");
+
+  /** Jackson ObjectMapper for JSON parsing and serialization. */
+  private final ObjectMapper objectMapper;
+
+  /** Creates a new JSON type handler with a default ObjectMapper. */
+  public JsonTypeHandler() {
+    this.objectMapper = new ObjectMapper();
+  }
+
+  /**
+   * Creates a new JSON type handler with a custom ObjectMapper.
+   *
+   * @param objectMapper the ObjectMapper to use
+   */
+  JsonTypeHandler(final ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public Class<JsonNode> getJavaType() {
+    return JsonNode.class;
+  }
+
+  @Override
+  public List<Integer> getSqlTypes() {
+    return SUPPORTED_SQL_TYPES;
+  }
+
+  @Override
+  public List<String> getSupportedDatabases() {
+    return SUPPORTED_DATABASES;
+  }
+
+  @Override
+  public int getPriority() {
+    return 20; // Higher priority than UuidTypeHandler for PostgreSQL
+  }
+
+  @Override
+  @SuppressWarnings("NullAway")
+  public @Nullable JsonNode read(final ResultSet resultSet, final int columnIndex)
+      throws SQLException {
+    final var value = resultSet.getString(columnIndex);
+    if (value == null || resultSet.wasNull()) {
+      return null;
+    }
+
+    try {
+      return objectMapper.readTree(value);
+    } catch (final JsonProcessingException e) {
+      throw new SQLException(String.format("Failed to parse JSON value: %s", value), e);
+    }
+  }
+
+  @Override
+  public void write(
+      final PreparedStatement preparedStatement, final int parameterIndex, final JsonNode value)
+      throws SQLException {
+    try {
+      final var jsonString = objectMapper.writeValueAsString(value);
+      // PostgreSQL requires using setObject with Types.OTHER for JSON/JSONB columns
+      preparedStatement.setObject(parameterIndex, jsonString, Types.OTHER);
+    } catch (final JsonProcessingException e) {
+      throw new SQLException("Failed to serialize JSON value", e);
+    }
+  }
+
+  @Override
+  public String format(final JsonNode value) {
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (final JsonProcessingException e) {
+      throw new IllegalStateException("Failed to format JSON value", e);
+    }
+  }
+
+  @Override
+  public JsonNode parse(final String value) {
+    try {
+      return objectMapper.readTree(value);
+    } catch (final JsonProcessingException e) {
+      throw new IllegalArgumentException(String.format("Invalid JSON format: %s", value), e);
+    }
+  }
+}

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/jdbc/type/TypeHandlerRegistry.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/jdbc/type/TypeHandlerRegistry.java
@@ -1,0 +1,194 @@
+package io.github.seijikohara.dbtester.internal.jdbc.type;
+
+import io.github.seijikohara.dbtester.api.spi.TypeHandler;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.concurrent.ConcurrentHashMap;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Registry for custom type handlers discovered via ServiceLoader.
+ *
+ * <p>This registry discovers and manages {@link TypeHandler} implementations, selecting the
+ * appropriate handler based on SQL type and database product name.
+ *
+ * <p>Handler selection follows these rules:
+ *
+ * <ol>
+ *   <li>Database-specific handlers are preferred over generic handlers
+ *   <li>Among handlers for the same database, higher priority handlers are preferred
+ *   <li>If no specific handler is found, falls back to default type conversion
+ * </ol>
+ *
+ * <p>This class is thread-safe and uses lazy initialization with caching.
+ */
+public final class TypeHandlerRegistry {
+
+  /** Logger for this class. */
+  private static final Logger logger = LoggerFactory.getLogger(TypeHandlerRegistry.class);
+
+  /** All discovered handlers. */
+  private final List<TypeHandler<?>> handlers;
+
+  /** Cache for handler lookups by SQL type and database product name. */
+  private final Map<CacheKey, Optional<TypeHandler<?>>> cache = new ConcurrentHashMap<>();
+
+  /** Singleton instance. */
+  private static volatile @Nullable TypeHandlerRegistry instance;
+
+  /**
+   * Creates a new registry and discovers handlers via ServiceLoader.
+   *
+   * @param handlers the type handlers to register
+   */
+  TypeHandlerRegistry(final List<TypeHandler<?>> handlers) {
+    this.handlers = List.copyOf(handlers);
+    logger.debug("Registered {} type handlers", this.handlers.size());
+  }
+
+  /**
+   * Returns the singleton instance, discovering handlers on first access.
+   *
+   * @return the registry instance
+   */
+  public static TypeHandlerRegistry getInstance() {
+    var result = instance;
+    if (result == null) {
+      synchronized (TypeHandlerRegistry.class) {
+        result = instance;
+        if (result == null) {
+          final var discoveredHandlers = discoverHandlers();
+          result = new TypeHandlerRegistry(discoveredHandlers);
+          instance = result;
+        }
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Discovers type handlers via ServiceLoader.
+   *
+   * @return list of discovered handlers
+   */
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private static List<TypeHandler<?>> discoverHandlers() {
+    final ServiceLoader<TypeHandler> loader = ServiceLoader.load(TypeHandler.class);
+    final List<TypeHandler<?>> discovered =
+        (List<TypeHandler<?>>) (List) loader.stream().map(ServiceLoader.Provider::get).toList();
+    logger.debug("Discovered {} type handlers via ServiceLoader", discovered.size());
+    return discovered;
+  }
+
+  /**
+   * Finds the best matching handler for the given SQL type and database.
+   *
+   * @param sqlType the SQL type code from {@link java.sql.Types}
+   * @param databaseProductName the database product name, or null for generic lookup
+   * @return the best matching handler, or empty if none found
+   */
+  public Optional<TypeHandler<?>> findHandler(
+      final int sqlType, final @Nullable String databaseProductName) {
+    final var key = new CacheKey(sqlType, databaseProductName);
+    return cache.computeIfAbsent(
+        key, k -> findHandlerInternal(k.sqlType(), k.databaseProductName()));
+  }
+
+  /**
+   * Finds the best matching handler without database-specific filtering.
+   *
+   * @param sqlType the SQL type code from {@link java.sql.Types}
+   * @return the best matching handler, or empty if none found
+   */
+  public Optional<TypeHandler<?>> findHandler(final int sqlType) {
+    return findHandler(sqlType, null);
+  }
+
+  /**
+   * Internal handler lookup with priority-based selection.
+   *
+   * @param sqlType the SQL type code
+   * @param databaseProductName the database product name
+   * @return the best matching handler
+   */
+  private Optional<TypeHandler<?>> findHandlerInternal(
+      final int sqlType, final @Nullable String databaseProductName) {
+    // Find all handlers that support this SQL type
+    final var candidates =
+        handlers.stream().filter(h -> h.getSqlTypes().contains(sqlType)).toList();
+
+    if (candidates.isEmpty()) {
+      return Optional.empty();
+    }
+
+    // If database product name is specified, prefer database-specific handlers
+    if (databaseProductName != null) {
+      final var dbSpecificHandlers =
+          candidates.stream()
+              .filter(h -> h.getSupportedDatabases().contains(databaseProductName))
+              .max(Comparator.comparingInt(TypeHandler::getPriority));
+
+      if (dbSpecificHandlers.isPresent()) {
+        return dbSpecificHandlers.map(h -> (TypeHandler<?>) h);
+      }
+    }
+
+    // Fall back to generic handlers (those with empty database list)
+    return candidates.stream()
+        .filter(h -> h.getSupportedDatabases().isEmpty())
+        .max(Comparator.comparingInt(TypeHandler::getPriority))
+        .map(h -> (TypeHandler<?>) h);
+  }
+
+  /**
+   * Returns all registered handlers.
+   *
+   * @return immutable list of handlers
+   */
+  public List<TypeHandler<?>> getHandlers() {
+    return handlers;
+  }
+
+  /**
+   * Clears the handler cache.
+   *
+   * <p>This is primarily useful for testing.
+   */
+  public void clearCache() {
+    cache.clear();
+  }
+
+  /**
+   * Resets the singleton instance.
+   *
+   * <p>This is primarily useful for testing.
+   */
+  static void resetInstance() {
+    synchronized (TypeHandlerRegistry.class) {
+      instance = null;
+    }
+  }
+
+  /**
+   * Creates a registry with explicit handlers for testing.
+   *
+   * @param handlers the handlers to register
+   * @return a new registry instance
+   */
+  public static TypeHandlerRegistry forTesting(final List<TypeHandler<?>> handlers) {
+    return new TypeHandlerRegistry(handlers);
+  }
+
+  /**
+   * Cache key combining SQL type and database product name.
+   *
+   * @param sqlType the SQL type code
+   * @param databaseProductName the database product name (nullable)
+   */
+  private record CacheKey(int sqlType, @Nullable String databaseProductName) {}
+}

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/jdbc/type/UuidTypeHandler.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/jdbc/type/UuidTypeHandler.java
@@ -1,0 +1,93 @@
+package io.github.seijikohara.dbtester.internal.jdbc.type;
+
+import io.github.seijikohara.dbtester.api.spi.TypeHandler;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Type handler for UUID values.
+ *
+ * <p>This handler supports UUID columns in PostgreSQL and other databases that support UUID types.
+ * UUIDs are read as objects and written using setObject with Types.OTHER.
+ *
+ * <p>For databases that store UUIDs as strings (VARCHAR), this handler will convert between UUID
+ * objects and their string representations.
+ */
+public final class UuidTypeHandler implements TypeHandler<UUID> {
+
+  /** SQL types supported by this handler. */
+  private static final List<Integer> SUPPORTED_SQL_TYPES = List.of(Types.OTHER);
+
+  /** Databases with native UUID support. */
+  private static final List<String> SUPPORTED_DATABASES = List.of("PostgreSQL", "H2");
+
+  /** Creates a new UUID type handler. */
+  public UuidTypeHandler() {}
+
+  @Override
+  public Class<UUID> getJavaType() {
+    return UUID.class;
+  }
+
+  @Override
+  public List<Integer> getSqlTypes() {
+    return SUPPORTED_SQL_TYPES;
+  }
+
+  @Override
+  public List<String> getSupportedDatabases() {
+    return SUPPORTED_DATABASES;
+  }
+
+  @Override
+  public int getPriority() {
+    return 10;
+  }
+
+  @Override
+  @SuppressWarnings("NullAway")
+  public @Nullable UUID read(final ResultSet resultSet, final int columnIndex) throws SQLException {
+    final var value = resultSet.getObject(columnIndex);
+    if (value == null || resultSet.wasNull()) {
+      return null;
+    }
+
+    if (value instanceof UUID uuid) {
+      return uuid;
+    }
+
+    // Handle string representation
+    if (value instanceof String strValue) {
+      return UUID.fromString(strValue);
+    }
+
+    throw new SQLException(
+        String.format("Cannot convert value of type %s to UUID", value.getClass().getName()));
+  }
+
+  @Override
+  public void write(
+      final PreparedStatement preparedStatement, final int parameterIndex, final UUID value)
+      throws SQLException {
+    preparedStatement.setObject(parameterIndex, value, Types.OTHER);
+  }
+
+  @Override
+  public String format(final UUID value) {
+    return value.toString();
+  }
+
+  @Override
+  public UUID parse(final String value) {
+    try {
+      return UUID.fromString(value.trim());
+    } catch (final IllegalArgumentException e) {
+      throw new IllegalArgumentException(String.format("Invalid UUID format: %s", value), e);
+    }
+  }
+}

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/jdbc/type/package-info.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/jdbc/type/package-info.java
@@ -1,0 +1,16 @@
+/**
+ * Custom type handler registry and implementations.
+ *
+ * <p>This package provides infrastructure for custom database type handling via the {@link
+ * io.github.seijikohara.dbtester.api.spi.TypeHandler} SPI.
+ *
+ * <ul>
+ *   <li>{@link io.github.seijikohara.dbtester.internal.jdbc.type.TypeHandlerRegistry} - Registry
+ *       for discovering and selecting type handlers
+ *   <li>Database-specific handlers (e.g., PostgreSQL JSON, UUID, ARRAY)
+ * </ul>
+ */
+@NullMarked
+package io.github.seijikohara.dbtester.internal.jdbc.type;
+
+import org.jspecify.annotations.NullMarked;

--- a/db-tester-core/src/main/java/module-info.java
+++ b/db-tester-core/src/main/java/module-info.java
@@ -19,6 +19,7 @@ module io.github.seijikohara.dbtester.core {
 
   // Internal SPI uses
   uses io.github.seijikohara.dbtester.api.scenario.ScenarioNameResolver;
+  uses io.github.seijikohara.dbtester.api.spi.TypeHandler;
   uses io.github.seijikohara.dbtester.internal.format.spi.FormatProvider;
 
   // SPI implementations for API module
@@ -48,4 +49,10 @@ module io.github.seijikohara.dbtester.core {
       io.github.seijikohara.dbtester.internal.format.tsv.TsvFormatProvider,
       io.github.seijikohara.dbtester.internal.format.json.JsonFormatProvider,
       io.github.seijikohara.dbtester.internal.format.yaml.YamlFormatProvider;
+
+  // Type handlers for database-specific types
+  provides io.github.seijikohara.dbtester.api.spi.TypeHandler with
+      io.github.seijikohara.dbtester.internal.jdbc.type.UuidTypeHandler,
+      io.github.seijikohara.dbtester.internal.jdbc.type.JsonTypeHandler,
+      io.github.seijikohara.dbtester.internal.jdbc.type.ArrayTypeHandler;
 }

--- a/db-tester-core/src/main/resources/META-INF/services/io.github.seijikohara.dbtester.api.spi.TypeHandler
+++ b/db-tester-core/src/main/resources/META-INF/services/io.github.seijikohara.dbtester.api.spi.TypeHandler
@@ -1,0 +1,3 @@
+io.github.seijikohara.dbtester.internal.jdbc.type.UuidTypeHandler
+io.github.seijikohara.dbtester.internal.jdbc.type.JsonTypeHandler
+io.github.seijikohara.dbtester.internal.jdbc.type.ArrayTypeHandler

--- a/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/jdbc/type/JsonTypeHandlerTest.java
+++ b/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/jdbc/type/JsonTypeHandlerTest.java
@@ -1,0 +1,347 @@
+package io.github.seijikohara.dbtester.internal.jdbc.type;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link JsonTypeHandler}. */
+@DisplayName("JsonTypeHandler")
+class JsonTypeHandlerTest {
+
+  /** Tests for the JsonTypeHandler class. */
+  JsonTypeHandlerTest() {}
+
+  /** The handler under test. */
+  private JsonTypeHandler handler;
+
+  /** ObjectMapper for creating test data. */
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  /** Sets up test fixtures before each test. */
+  @BeforeEach
+  void setUp() {
+    handler = new JsonTypeHandler();
+  }
+
+  /** Tests for the getJavaType() method. */
+  @Nested
+  @DisplayName("getJavaType() method")
+  class GetJavaTypeMethod {
+
+    /** Tests for the getJavaType method. */
+    GetJavaTypeMethod() {}
+
+    /** Verifies that getJavaType returns JsonNode class. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return JsonNode class when called")
+    void shouldReturnJsonNodeClass_whenCalled() {
+      // When
+      final var result = handler.getJavaType();
+
+      // Then
+      assertEquals(JsonNode.class, result, "should return JsonNode class");
+    }
+  }
+
+  /** Tests for the getSqlTypes() method. */
+  @Nested
+  @DisplayName("getSqlTypes() method")
+  class GetSqlTypesMethod {
+
+    /** Tests for the getSqlTypes method. */
+    GetSqlTypesMethod() {}
+
+    /** Verifies that getSqlTypes returns OTHER type. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return OTHER type when called")
+    void shouldReturnOtherType_whenCalled() {
+      // When
+      final var result = handler.getSqlTypes();
+
+      // Then
+      assertAll(
+          "SQL types should be configured correctly",
+          () -> assertEquals(1, result.size(), "should have one SQL type"),
+          () -> assertTrue(result.contains(Types.OTHER), "should contain Types.OTHER"));
+    }
+  }
+
+  /** Tests for the getSupportedDatabases() method. */
+  @Nested
+  @DisplayName("getSupportedDatabases() method")
+  class GetSupportedDatabasesMethod {
+
+    /** Tests for the getSupportedDatabases method. */
+    GetSupportedDatabasesMethod() {}
+
+    /** Verifies that getSupportedDatabases includes PostgreSQL. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return PostgreSQL when called")
+    void shouldReturnPostgres_whenCalled() {
+      // When
+      final var result = handler.getSupportedDatabases();
+
+      // Then
+      assertAll(
+          "supported databases should be correct",
+          () -> assertEquals(1, result.size(), "should have one database"),
+          () -> assertTrue(result.contains("PostgreSQL"), "should contain PostgreSQL"));
+    }
+  }
+
+  /** Tests for the getPriority() method. */
+  @Nested
+  @DisplayName("getPriority() method")
+  class GetPriorityMethod {
+
+    /** Tests for the getPriority method. */
+    GetPriorityMethod() {}
+
+    /** Verifies that getPriority returns higher than UUID handler. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return higher priority than UUID handler")
+    void shouldReturnHigherPriority_thanUuidHandler() {
+      // When
+      final var jsonPriority = handler.getPriority();
+      final var uuidPriority = new UuidTypeHandler().getPriority();
+
+      // Then
+      assertTrue(
+          jsonPriority > uuidPriority,
+          "JSON handler should have higher priority than UUID handler");
+    }
+  }
+
+  /** Tests for the read() method. */
+  @Nested
+  @DisplayName("read(ResultSet, int) method")
+  class ReadMethod {
+
+    /** Tests for the read method. */
+    ReadMethod() {}
+
+    /** Mock ResultSet for testing. */
+    private ResultSet mockResultSet;
+
+    /** Sets up mock for read tests. */
+    @BeforeEach
+    void setUp() {
+      mockResultSet = mock(ResultSet.class);
+    }
+
+    /**
+     * Verifies that read returns JsonNode when ResultSet contains JSON string.
+     *
+     * @throws SQLException if database error occurs
+     */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return JsonNode when ResultSet contains JSON string")
+    void shouldReturnJsonNode_whenResultSetContainsJsonString() throws SQLException {
+      // Given
+      final var jsonString = "{\"name\":\"test\",\"value\":123}";
+      when(mockResultSet.getString(1)).thenReturn(jsonString);
+      when(mockResultSet.wasNull()).thenReturn(false);
+
+      // When
+      final var result = handler.read(mockResultSet, 1);
+
+      // Then
+      assertNotNull(result, "result should not be null");
+      final var jsonNode = result;
+      assertAll(
+          "JsonNode should be parsed correctly",
+          () -> assertEquals("test", jsonNode.get("name").asText(), "name should be test"),
+          () -> assertEquals(123, jsonNode.get("value").asInt(), "value should be 123"));
+    }
+
+    /**
+     * Verifies that read handles JSON array.
+     *
+     * @throws SQLException if database error occurs
+     */
+    @Test
+    @Tag("normal")
+    @DisplayName("should handle JSON array when reading")
+    void shouldHandleJsonArray_whenReading() throws SQLException {
+      // Given
+      final var jsonString = "[1,2,3]";
+      when(mockResultSet.getString(1)).thenReturn(jsonString);
+      when(mockResultSet.wasNull()).thenReturn(false);
+
+      // When
+      final var result = handler.read(mockResultSet, 1);
+
+      // Then
+      assertNotNull(result, "result should not be null");
+      final var jsonArray = result;
+      assertAll(
+          "JSON array should be parsed correctly",
+          () -> assertTrue(jsonArray.isArray(), "should be an array"),
+          () -> assertEquals(3, jsonArray.size(), "should have 3 elements"));
+    }
+
+    /**
+     * Verifies that read returns null when value is null.
+     *
+     * @throws SQLException if database error occurs
+     */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should return null when value is null")
+    void shouldReturnNull_whenValueIsNull() throws SQLException {
+      // Given
+      when(mockResultSet.getString(1)).thenReturn(null);
+      when(mockResultSet.wasNull()).thenReturn(true);
+
+      // When
+      final var result = handler.read(mockResultSet, 1);
+
+      // Then
+      assertNull(result, "should return null for null value");
+    }
+
+    /**
+     * Verifies that read throws SQLException for invalid JSON.
+     *
+     * @throws SQLException if database error occurs
+     */
+    @Test
+    @Tag("error")
+    @DisplayName("should throw SQLException when JSON is invalid")
+    void shouldThrowSqlException_whenJsonIsInvalid() throws SQLException {
+      // Given
+      when(mockResultSet.getString(1)).thenReturn("not valid json");
+      when(mockResultSet.wasNull()).thenReturn(false);
+
+      // When & Then
+      assertThrows(SQLException.class, () -> handler.read(mockResultSet, 1));
+    }
+  }
+
+  /** Tests for the write() method. */
+  @Nested
+  @DisplayName("write(PreparedStatement, int, JsonNode) method")
+  class WriteMethod {
+
+    /** Tests for the write method. */
+    WriteMethod() {}
+
+    /** Mock PreparedStatement for testing. */
+    private PreparedStatement mockStatement;
+
+    /** Sets up mock for write tests. */
+    @BeforeEach
+    void setUp() {
+      mockStatement = mock(PreparedStatement.class);
+    }
+
+    /**
+     * Verifies that write sets JSON string with Types.OTHER.
+     *
+     * @throws Exception if error occurs
+     */
+    @Test
+    @Tag("normal")
+    @DisplayName("should set JSON string with Types.OTHER when writing")
+    void shouldSetJsonStringWithTypesOther_whenWriting() throws Exception {
+      // Given
+      final var jsonNode = objectMapper.readTree("{\"key\":\"value\"}");
+
+      // When
+      handler.write(mockStatement, 1, jsonNode);
+
+      // Then
+      verify(mockStatement).setObject(1, "{\"key\":\"value\"}", Types.OTHER);
+    }
+  }
+
+  /** Tests for the format() method. */
+  @Nested
+  @DisplayName("format(JsonNode) method")
+  class FormatMethod {
+
+    /** Tests for the format method. */
+    FormatMethod() {}
+
+    /**
+     * Verifies that format returns JSON string representation.
+     *
+     * @throws Exception if parsing fails
+     */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return JSON string when formatting")
+    void shouldReturnJsonString_whenFormatting() throws Exception {
+      // Given
+      final var jsonNode = objectMapper.readTree("{\"name\":\"test\"}");
+
+      // When
+      final var result = handler.format(jsonNode);
+
+      // Then
+      assertEquals("{\"name\":\"test\"}", result, "should return JSON string");
+    }
+  }
+
+  /** Tests for the parse() method. */
+  @Nested
+  @DisplayName("parse(String) method")
+  class ParseMethod {
+
+    /** Tests for the parse method. */
+    ParseMethod() {}
+
+    /** Verifies that parse returns JsonNode from valid JSON string. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return JsonNode when parsing valid JSON")
+    void shouldReturnJsonNode_whenParsingValidJson() {
+      // Given
+      final var jsonString = "{\"key\":\"value\"}";
+
+      // When
+      final var result = handler.parse(jsonString);
+
+      // Then
+      assertEquals("value", result.get("key").asText(), "should parse JSON correctly");
+    }
+
+    /** Verifies that parse throws exception for invalid JSON. */
+    @Test
+    @Tag("error")
+    @DisplayName("should throw exception when JSON is invalid")
+    void shouldThrowException_whenJsonIsInvalid() {
+      // Given
+      final var invalidJson = "not valid json";
+
+      // When & Then
+      final var exception =
+          assertThrows(IllegalArgumentException.class, () -> handler.parse(invalidJson));
+
+      assertNotNull(exception.getMessage(), "exception should have message");
+    }
+  }
+}

--- a/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/jdbc/type/TypeHandlerRegistryTest.java
+++ b/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/jdbc/type/TypeHandlerRegistryTest.java
@@ -1,0 +1,264 @@
+package io.github.seijikohara.dbtester.internal.jdbc.type;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.seijikohara.dbtester.api.spi.TypeHandler;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link TypeHandlerRegistry}. */
+@DisplayName("TypeHandlerRegistry")
+class TypeHandlerRegistryTest {
+
+  /** Tests for the TypeHandlerRegistry class. */
+  TypeHandlerRegistryTest() {}
+
+  /** Resets the singleton instance after each test. */
+  @AfterEach
+  void tearDown() {
+    TypeHandlerRegistry.resetInstance();
+  }
+
+  /** Tests for the getInstance() method. */
+  @Nested
+  @DisplayName("getInstance() method")
+  class GetInstanceMethod {
+
+    /** Tests for the getInstance method. */
+    GetInstanceMethod() {}
+
+    /** Verifies that getInstance returns a non-null registry. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return non-null registry when called")
+    void shouldReturnNonNullRegistry_whenCalled() {
+      // When
+      final var registry = TypeHandlerRegistry.getInstance();
+
+      // Then
+      assertNotNull(registry, "registry should not be null");
+    }
+
+    /** Verifies that getInstance returns the same instance. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return same instance when called multiple times")
+    void shouldReturnSameInstance_whenCalledMultipleTimes() {
+      // When
+      final var registry1 = TypeHandlerRegistry.getInstance();
+      final var registry2 = TypeHandlerRegistry.getInstance();
+
+      // Then
+      assertSame(registry1, registry2, "should return the same instance");
+    }
+  }
+
+  /** Tests for the forTesting() method. */
+  @Nested
+  @DisplayName("forTesting(List) method")
+  class ForTestingMethod {
+
+    /** Tests for the forTesting method. */
+    ForTestingMethod() {}
+
+    /** Verifies that forTesting creates registry with specified handlers. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should create registry with specified handlers")
+    void shouldCreateRegistryWithSpecifiedHandlers() {
+      // Given
+      final var handler = new UuidTypeHandler();
+      final List<TypeHandler<?>> handlers = List.of(handler);
+
+      // When
+      final var registry = TypeHandlerRegistry.forTesting(handlers);
+
+      // Then
+      assertEquals(1, registry.getHandlers().size(), "should have one handler");
+    }
+  }
+
+  /** Tests for the findHandler() method. */
+  @Nested
+  @DisplayName("findHandler(int, String) method")
+  class FindHandlerMethod {
+
+    /** Tests for the findHandler method. */
+    FindHandlerMethod() {}
+
+    /** Registry instance for testing. */
+    private TypeHandlerRegistry registry;
+
+    /** Sets up registry with test handlers. */
+    @BeforeEach
+    void setUp() {
+      final List<TypeHandler<?>> handlers =
+          List.of(new UuidTypeHandler(), new JsonTypeHandler(), new ArrayTypeHandler());
+      registry = TypeHandlerRegistry.forTesting(handlers);
+    }
+
+    /** Verifies that findHandler returns handler for supported SQL type. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return handler for supported SQL type")
+    void shouldReturnHandler_whenSqlTypeIsSupported() {
+      // When
+      final var result = registry.findHandler(Types.ARRAY, "PostgreSQL");
+
+      // Then
+      assertTrue(result.isPresent(), "should find handler");
+      assertEquals(
+          ArrayTypeHandler.class, result.orElseThrow().getClass(), "should be ArrayTypeHandler");
+    }
+
+    /** Verifies that findHandler returns empty for unsupported SQL type. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should return empty when SQL type is not supported")
+    void shouldReturnEmpty_whenSqlTypeIsNotSupported() {
+      // When
+      final var result = registry.findHandler(Types.VARCHAR, "PostgreSQL");
+
+      // Then
+      assertTrue(result.isEmpty(), "should return empty for unsupported type");
+    }
+
+    /** Verifies that findHandler prefers database-specific handler. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should prefer database-specific handler when available")
+    void shouldPreferDatabaseSpecificHandler_whenAvailable() {
+      // Given - JsonTypeHandler has higher priority for PostgreSQL
+      // When
+      final var result = registry.findHandler(Types.OTHER, "PostgreSQL");
+
+      // Then
+      assertTrue(result.isPresent(), "should find handler");
+      assertEquals(
+          JsonTypeHandler.class,
+          result.orElseThrow().getClass(),
+          "should return JSON handler for PostgreSQL");
+    }
+
+    /** Verifies that findHandler falls back to generic handler. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should fall back to generic handler when no database-specific handler")
+    void shouldFallBackToGenericHandler_whenNoDatabaseSpecificHandler() {
+      // Given - ArrayTypeHandler supports PostgreSQL and H2
+      // When - Query for a different database that ArrayTypeHandler doesn't specifically support
+      final var result = registry.findHandler(Types.ARRAY, "MySQL");
+
+      // Then - Should still find a handler since there's no database-specific one for MySQL
+      assertTrue(result.isEmpty(), "should not find handler for unsupported database");
+    }
+  }
+
+  /** Tests for handler priority selection. */
+  @Nested
+  @DisplayName("handler priority selection")
+  class HandlerPrioritySelection {
+
+    /** Tests for handler priority selection. */
+    HandlerPrioritySelection() {}
+
+    /** Verifies that higher priority handler is selected. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should select handler with higher priority")
+    void shouldSelectHigherPriorityHandler() {
+      // Given
+      final var lowPriorityHandler = new TestHandler("low", 1);
+      final var highPriorityHandler = new TestHandler("high", 100);
+      final List<TypeHandler<?>> handlers = List.of(lowPriorityHandler, highPriorityHandler);
+      final var registry = TypeHandlerRegistry.forTesting(handlers);
+
+      // When
+      final var result = registry.findHandler(Types.OTHER, null);
+
+      // Then
+      assertTrue(result.isPresent(), "should find handler");
+      final var handler = (TestHandler) result.orElseThrow();
+      assertEquals("high", handler.getName(), "should select high priority handler");
+    }
+  }
+
+  /** Test handler for priority testing. */
+  private static class TestHandler implements TypeHandler<String> {
+
+    /** Handler name for identification. */
+    private final String name;
+
+    /** Handler priority. */
+    private final int priority;
+
+    /**
+     * Creates a test handler.
+     *
+     * @param name the handler name
+     * @param priority the handler priority
+     */
+    TestHandler(final String name, final int priority) {
+      this.name = name;
+      this.priority = priority;
+    }
+
+    /**
+     * Returns the handler name.
+     *
+     * @return the name
+     */
+    String getName() {
+      return name;
+    }
+
+    @Override
+    public Class<String> getJavaType() {
+      return String.class;
+    }
+
+    @Override
+    public List<Integer> getSqlTypes() {
+      return List.of(Types.OTHER);
+    }
+
+    @Override
+    public int getPriority() {
+      return priority;
+    }
+
+    @Override
+    public String read(final ResultSet resultSet, final int columnIndex) throws SQLException {
+      return resultSet.getString(columnIndex);
+    }
+
+    @Override
+    public void write(
+        final PreparedStatement preparedStatement, final int parameterIndex, final String value)
+        throws SQLException {
+      preparedStatement.setString(parameterIndex, value);
+    }
+
+    @Override
+    public String format(final String value) {
+      return value;
+    }
+
+    @Override
+    public String parse(final String value) {
+      return value;
+    }
+  }
+}

--- a/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/jdbc/type/UuidTypeHandlerTest.java
+++ b/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/jdbc/type/UuidTypeHandlerTest.java
@@ -1,0 +1,306 @@
+package io.github.seijikohara.dbtester.internal.jdbc.type;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link UuidTypeHandler}. */
+@DisplayName("UuidTypeHandler")
+class UuidTypeHandlerTest {
+
+  /** Tests for the UuidTypeHandler class. */
+  UuidTypeHandlerTest() {}
+
+  /** The handler under test. */
+  private UuidTypeHandler handler;
+
+  /** Sets up test fixtures before each test. */
+  @BeforeEach
+  void setUp() {
+    handler = new UuidTypeHandler();
+  }
+
+  /** Tests for the getJavaType() method. */
+  @Nested
+  @DisplayName("getJavaType() method")
+  class GetJavaTypeMethod {
+
+    /** Tests for the getJavaType method. */
+    GetJavaTypeMethod() {}
+
+    /** Verifies that getJavaType returns UUID class. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return UUID class when called")
+    void shouldReturnUuidClass_whenCalled() {
+      // When
+      final var result = handler.getJavaType();
+
+      // Then
+      assertEquals(UUID.class, result, "should return UUID class");
+    }
+  }
+
+  /** Tests for the getSqlTypes() method. */
+  @Nested
+  @DisplayName("getSqlTypes() method")
+  class GetSqlTypesMethod {
+
+    /** Tests for the getSqlTypes method. */
+    GetSqlTypesMethod() {}
+
+    /** Verifies that getSqlTypes returns OTHER type. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return OTHER type when called")
+    void shouldReturnOtherType_whenCalled() {
+      // When
+      final var result = handler.getSqlTypes();
+
+      // Then
+      assertAll(
+          "SQL types should be configured correctly",
+          () -> assertEquals(1, result.size(), "should have one SQL type"),
+          () -> assertTrue(result.contains(Types.OTHER), "should contain Types.OTHER"));
+    }
+  }
+
+  /** Tests for the getSupportedDatabases() method. */
+  @Nested
+  @DisplayName("getSupportedDatabases() method")
+  class GetSupportedDatabasesMethod {
+
+    /** Tests for the getSupportedDatabases method. */
+    GetSupportedDatabasesMethod() {}
+
+    /** Verifies that getSupportedDatabases includes PostgreSQL and H2. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return PostgreSQL and H2 when called")
+    void shouldReturnPostgresAndH2_whenCalled() {
+      // When
+      final var result = handler.getSupportedDatabases();
+
+      // Then
+      assertAll(
+          "supported databases should be correct",
+          () -> assertEquals(2, result.size(), "should have two databases"),
+          () -> assertTrue(result.contains("PostgreSQL"), "should contain PostgreSQL"),
+          () -> assertTrue(result.contains("H2"), "should contain H2"));
+    }
+  }
+
+  /** Tests for the read() method. */
+  @Nested
+  @DisplayName("read(ResultSet, int) method")
+  class ReadMethod {
+
+    /** Tests for the read method. */
+    ReadMethod() {}
+
+    /** Mock ResultSet for testing. */
+    private ResultSet mockResultSet;
+
+    /** Sets up mock for read tests. */
+    @BeforeEach
+    void setUp() {
+      mockResultSet = mock(ResultSet.class);
+    }
+
+    /**
+     * Verifies that read returns UUID when ResultSet contains UUID.
+     *
+     * @throws SQLException if database error occurs
+     */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return UUID when ResultSet contains UUID object")
+    void shouldReturnUuid_whenResultSetContainsUuidObject() throws SQLException {
+      // Given
+      final var expectedUuid = UUID.randomUUID();
+      when(mockResultSet.getObject(1)).thenReturn(expectedUuid);
+      when(mockResultSet.wasNull()).thenReturn(false);
+
+      // When
+      final var result = handler.read(mockResultSet, 1);
+
+      // Then
+      assertEquals(expectedUuid, result, "should return the UUID from ResultSet");
+    }
+
+    /**
+     * Verifies that read returns UUID when ResultSet contains String.
+     *
+     * @throws SQLException if database error occurs
+     */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return UUID when ResultSet contains String")
+    void shouldReturnUuid_whenResultSetContainsString() throws SQLException {
+      // Given
+      final var expectedUuid = UUID.randomUUID();
+      when(mockResultSet.getObject(1)).thenReturn(expectedUuid.toString());
+      when(mockResultSet.wasNull()).thenReturn(false);
+
+      // When
+      final var result = handler.read(mockResultSet, 1);
+
+      // Then
+      assertEquals(expectedUuid, result, "should parse String to UUID");
+    }
+
+    /**
+     * Verifies that read returns null when value is null.
+     *
+     * @throws SQLException if database error occurs
+     */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should return null when value is null")
+    void shouldReturnNull_whenValueIsNull() throws SQLException {
+      // Given
+      when(mockResultSet.getObject(1)).thenReturn(null);
+      when(mockResultSet.wasNull()).thenReturn(true);
+
+      // When
+      final var result = handler.read(mockResultSet, 1);
+
+      // Then
+      assertNull(result, "should return null for null value");
+    }
+  }
+
+  /** Tests for the write() method. */
+  @Nested
+  @DisplayName("write(PreparedStatement, int, UUID) method")
+  class WriteMethod {
+
+    /** Tests for the write method. */
+    WriteMethod() {}
+
+    /** Mock PreparedStatement for testing. */
+    private PreparedStatement mockStatement;
+
+    /** Sets up mock for write tests. */
+    @BeforeEach
+    void setUp() {
+      mockStatement = mock(PreparedStatement.class);
+    }
+
+    /**
+     * Verifies that write sets UUID with Types.OTHER.
+     *
+     * @throws SQLException if database error occurs
+     */
+    @Test
+    @Tag("normal")
+    @DisplayName("should set object with Types.OTHER when writing UUID")
+    void shouldSetObjectWithTypesOther_whenWritingUuid() throws SQLException {
+      // Given
+      final var uuid = UUID.randomUUID();
+
+      // When
+      handler.write(mockStatement, 1, uuid);
+
+      // Then
+      verify(mockStatement).setObject(1, uuid, Types.OTHER);
+    }
+  }
+
+  /** Tests for the format() method. */
+  @Nested
+  @DisplayName("format(UUID) method")
+  class FormatMethod {
+
+    /** Tests for the format method. */
+    FormatMethod() {}
+
+    /** Verifies that format returns UUID string representation. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return UUID string when formatting")
+    void shouldReturnUuidString_whenFormatting() {
+      // Given
+      final var uuid = UUID.randomUUID();
+
+      // When
+      final var result = handler.format(uuid);
+
+      // Then
+      assertEquals(uuid.toString(), result, "should return UUID string representation");
+    }
+  }
+
+  /** Tests for the parse() method. */
+  @Nested
+  @DisplayName("parse(String) method")
+  class ParseMethod {
+
+    /** Tests for the parse method. */
+    ParseMethod() {}
+
+    /** Verifies that parse returns UUID from valid string. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return UUID when parsing valid string")
+    void shouldReturnUuid_whenParsingValidString() {
+      // Given
+      final var uuid = UUID.randomUUID();
+      final var uuidString = uuid.toString();
+
+      // When
+      final var result = handler.parse(uuidString);
+
+      // Then
+      assertEquals(uuid, result, "should parse string to UUID");
+    }
+
+    /** Verifies that parse handles whitespace. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should handle whitespace when parsing")
+    void shouldHandleWhitespace_whenParsing() {
+      // Given
+      final var uuid = UUID.randomUUID();
+      final var uuidString = "  " + uuid + "  ";
+
+      // When
+      final var result = handler.parse(uuidString);
+
+      // Then
+      assertEquals(uuid, result, "should trim whitespace and parse");
+    }
+
+    /** Verifies that parse throws exception for invalid format. */
+    @Test
+    @Tag("error")
+    @DisplayName("should throw exception when format is invalid")
+    void shouldThrowException_whenFormatIsInvalid() {
+      // Given
+      final var invalidUuid = "not-a-valid-uuid";
+
+      // When & Then
+      final var exception =
+          assertThrows(IllegalArgumentException.class, () -> handler.parse(invalidUuid));
+
+      assertNotNull(exception.getMessage(), "exception should have message");
+    }
+  }
+}

--- a/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/jdbc/type/package-info.java
+++ b/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/jdbc/type/package-info.java
@@ -1,0 +1,5 @@
+/** Unit tests for the type handler package. */
+@NullMarked
+package io.github.seijikohara.dbtester.internal.jdbc.type;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
## Summary
- Add TypeHandler SPI interface for supporting database-specific types
- Implement TypeHandlerRegistry for ServiceLoader-based handler discovery
- Add handlers for PostgreSQL/H2 specific types: UUID, JSON/JSONB, ARRAY

## Changes
### db-tester-api
- `TypeHandler<T>`: SPI interface with the following methods:
  - `getJavaType()`: Returns the Java class for the handled type
  - `getSqlTypes()`: Returns supported SQL type codes
  - `getSupportedDatabases()`: Returns database product names (optional)
  - `getPriority()`: Returns handler priority for conflict resolution
  - `read()`: Reads value from ResultSet
  - `write()`: Writes value to PreparedStatement
  - `format()`: Formats value as String for export
  - `parse()`: Parses String value for import

### db-tester-core
- `TypeHandlerRegistry`: Singleton registry with ServiceLoader discovery
- `UuidTypeHandler`: UUID type support for PostgreSQL and H2
- `JsonTypeHandler`: JSON/JSONB type support for PostgreSQL using Jackson
- `ArrayTypeHandler`: SQL ARRAY type support for PostgreSQL and H2

## Design Decisions
- Priority-based handler selection allows database-specific handlers to override generic ones
- Handlers are discovered via ServiceLoader for extensibility
- Each handler supports read/write operations and format/parse for import/export

## Test plan
- [x] Unit tests for UuidTypeHandler
- [x] Unit tests for JsonTypeHandler
- [x] Unit tests for TypeHandlerRegistry
- [x] All existing tests pass
- [x] spotlessCheck passes
- [x] verifyNullMarkedPackages passes

Closes #123