### PR TITLE
docs(api): expand API reference documentation

### DIFF
--- a/docs/specs/ja/public-api.md
+++ b/docs/specs/ja/public-api.md
@@ -173,6 +173,16 @@ void testWithColumnStrategies() { }
 | `name` | `String` | (必須) | カラム名（大文字小文字を区別しない） |
 | `strategy` | `Strategy` | `STRICT` | 使用する比較戦略 |
 | `pattern` | `String` | `""` | `REGEX`戦略用の正規表現パターン |
+| `options` | `String` | `""` | 戦略固有のオプション（下記参照） |
+
+**options属性**:
+
+`options`属性はパラメータ化された戦略に設定を提供します：
+
+| 戦略 | オプション形式 | 例 |
+|------|---------------|-----|
+| `RANGE` | `"min=N,max=M"`（N, M: 数値、両端を含む） | `"min=100,max=200"` |
+| `CONTAINS` | 検索する部分文字列（任意。空の場合は期待値を使用） | `"expected-substring"` |
 
 
 ### Strategy
@@ -183,15 +193,33 @@ void testWithColumnStrategies() { }
 
 **値**:
 
-| 値 | 説明 |
-|-----|------|
-| `STRICT` | `equals()`を使用した完全一致（デフォルト） |
-| `IGNORE` | 比較を完全にスキップ |
-| `NUMERIC` | 型を考慮した数値比較 |
-| `CASE_INSENSITIVE` | 大文字小文字を区別しない文字列比較 |
-| `TIMESTAMP_FLEXIBLE` | UTCに変換しサブ秒精度を無視 |
-| `NOT_NULL` | 値がnullでないことを検証 |
-| `REGEX` | パターンマッチング（`pattern`属性が必要） |
+| 値 | 説明 | 必須属性 |
+|-----|------|---------|
+| `STRICT` | `equals()`を使用した完全一致（デフォルト） | — |
+| `IGNORE` | 比較を完全にスキップ | — |
+| `NUMERIC` | 型を考慮した数値比較 | — |
+| `CASE_INSENSITIVE` | 大文字小文字を区別しない文字列比較 | — |
+| `TIMESTAMP_FLEXIBLE` | UTCに変換しサブ秒精度を無視 | — |
+| `NOT_NULL` | 値がnullでないことを検証 | — |
+| `REGEX` | 正規表現を使用したパターンマッチング | `pattern` |
+| `DATE_FLEXIBLE` | 複数形式の日付比較（ISO-8601、スラッシュ区切り、ドット区切り） | — |
+| `JSON_EQUIVALENT` | JSON構造比較（キー順序と空白を無視） | — |
+| `CONTAINS` | 部分文字列包含チェック | `options`（任意） |
+| `RANGE` | 数値範囲検証（両端を含む） | `options` |
+
+**新しい戦略の使用例**:
+
+```java
+@ExpectedDataSet(sources = @DataSetSource(
+    columnStrategies = {
+        @ColumnStrategy(name = "BIRTH_DATE", strategy = Strategy.DATE_FLEXIBLE),
+        @ColumnStrategy(name = "METADATA", strategy = Strategy.JSON_EQUIVALENT),
+        @ColumnStrategy(name = "DESCRIPTION", strategy = Strategy.CONTAINS),
+        @ColumnStrategy(name = "PRICE", strategy = Strategy.RANGE, options = "min=100,max=200")
+    }
+))
+void testWithExtendedStrategies() { }
+```
 
 
 ### RowOrdering
@@ -449,6 +477,11 @@ JDBCから取得したデータベースカラムメタデータを表します�
 | `timestampFlexible(String)` | TIMESTAMP_FLEXIBLE戦略でマッピングを作成 |
 | `notNull(String)` | NOT_NULL戦略でマッピングを作成 |
 | `regex(String, String)` | REGEX戦略でマッピングを作成（パターン付き） |
+| `dateFlexible(String)` | DATE_FLEXIBLE戦略でマッピングを作成 |
+| `jsonEquivalent(String)` | JSON_EQUIVALENT戦略でマッピングを作成 |
+| `contains(String)` | CONTAINS戦略でマッピングを作成（期待値を使用） |
+| `contains(String, String)` | CONTAINS戦略でマッピングを作成（部分文字列指定） |
+| `range(String, double, double)` | RANGE戦略でマッピングを作成（最小値・最大値指定） |
 
 **例**:
 
@@ -457,7 +490,11 @@ JDBCから取得したデータベースカラムメタデータを表します�
 var strategies = List.of(
     ColumnStrategyMapping.ignore("CREATED_AT"),
     ColumnStrategyMapping.caseInsensitive("EMAIL"),
-    ColumnStrategyMapping.regex("TOKEN", "[a-f0-9-]{36}")
+    ColumnStrategyMapping.regex("TOKEN", "[a-f0-9-]{36}"),
+    ColumnStrategyMapping.dateFlexible("BIRTH_DATE"),
+    ColumnStrategyMapping.jsonEquivalent("METADATA"),
+    ColumnStrategyMapping.contains("DESCRIPTION"),
+    ColumnStrategyMapping.range("PRICE", 100.0, 200.0)
 );
 
 DatabaseAssertion.assertEqualsWithStrategies(expectedTable, actualTable, strategies);
@@ -479,14 +516,19 @@ DatabaseAssertion.assertEqualsWithStrategies(expectedTable, actualTable, strateg
 | `NUMERIC` | BigDecimalを使用した型を考慮した数値比較 |
 | `CASE_INSENSITIVE` | 大文字小文字を区別しない文字列比較 |
 | `TIMESTAMP_FLEXIBLE` | UTCに変換しサブ秒精度を無視 |
+| `DATE_FLEXIBLE` | 複数形式の日付比較（ISO-8601 `yyyy-MM-dd`、スラッシュ `yyyy/MM/dd`、ドット `yyyy.MM.dd`） |
+| `JSON_EQUIVALENT` | JSON構造比較（キー順序と空白を無視） |
 | `NOT_NULL` | 値がnullでないことを検証 |
-| `REGEX` | 正規表現を使用したパターンマッチング |
 
 **ファクトリメソッド**:
 
 | メソッド | 説明 |
 |----------|------|
 | `regex(String)` | 正規表現パターンマッチャーを作成 |
+| `contains()` | 部分文字列包含チェックを作成（期待値を使用） |
+| `contains(String)` | 部分文字列包含チェックを作成（部分文字列を指定） |
+| `range(double, double)` | 数値範囲チェックを作成（最小値・最大値を指定） |
+| `range(String)` | オプション文字列から数値範囲チェックを作成（`"min=N,max=M"`） |
 
 **比較動作**:
 
@@ -497,8 +539,12 @@ DatabaseAssertion.assertEqualsWithStrategies(expectedTable, actualTable, strateg
 | `NUMERIC` | true | false | false | BigDecimal比較 |
 | `CASE_INSENSITIVE` | true | false | false | equalsIgnoreCase() |
 | `TIMESTAMP_FLEXIBLE` | true | false | false | UTCエポック比較 |
+| `DATE_FLEXIBLE` | true | false | false | LocalDate比較 |
+| `JSON_EQUIVALENT` | true | false | false | 正規化JSON比較 |
 | `NOT_NULL` | false | false | false | true |
 | `REGEX` | false | false | false | Pattern.matches() |
+| `CONTAINS` | false | false | false | String.contains() |
+| `RANGE` | false | false | false | min <= value <= max |
 
 
 ## アサーションAPI
@@ -680,6 +726,45 @@ classDiagram
 
 **出力形式**: 検証エラーは人間が読みやすい要約に続いてYAML詳細を出力します。形式の詳細は[エラーハンドリング - 検証エラー](error-handling#検証エラー)を参照してください。
 
+
+## デフォルト値リファレンス
+
+すべての設定可能な属性のデフォルト値を一覧にしています。
+
+### アノテーション属性のデフォルト値
+
+| アノテーション | 属性 | デフォルト | 意味 |
+|---------------|------|-----------|------|
+| `@DataSet` | `sources` | `{}` | 規約ベースの検出 |
+| `@DataSet` | `operation` | `CLEAN_INSERT` | 全行削除後に挿入 |
+| `@DataSet` | `tableOrdering` | `AUTO` | 自動順序決定 |
+| `@ExpectedDataSet` | `sources` | `{}` | 規約ベースの検出 |
+| `@ExpectedDataSet` | `tableOrdering` | `AUTO` | 自動順序決定 |
+| `@ExpectedDataSet` | `rowOrdering` | `ORDERED` | 位置ベースの行比較 |
+| `@ExpectedDataSet` | `retryCount` | `-1` | グローバル設定を使用 |
+| `@ExpectedDataSet` | `retryDelayMillis` | `-1` | グローバル設定を使用 |
+| `@DataSetSource` | `resourceLocation` | `""` | 規約ベースの検出 |
+| `@DataSetSource` | `dataSourceName` | `""` | デフォルトDataSource |
+| `@DataSetSource` | `scenarioNames` | `{}` | テストメソッド名を使用 |
+| `@DataSetSource` | `excludeColumns` | `{}` | 除外なし |
+| `@DataSetSource` | `columnStrategies` | `{}` | 全カラムにデフォルトSTRICT |
+| `@ColumnStrategy` | `strategy` | `STRICT` | 完全一致 |
+| `@ColumnStrategy` | `pattern` | `""` | パターンなし |
+| `@ColumnStrategy` | `options` | `""` | オプションなし |
+
+**マジックバリュー: `-1`**
+
+デフォルト値が`-1`の属性は、`OperationDefaults`のグローバル設定に委譲します。テストスイート全体で一貫したデフォルト値を維持しながら、テストレベルでのオーバーライドが可能です。`0`以上の値を指定すると、その値が直接使用されます。
+
+## カラム比較の優先順位
+
+期待データベース状態の検証時、カラム比較は以下の優先順位に従います：
+
+1. **`excludeColumns`**: `excludeColumns`に記載されたカラムは完全にスキップされます。比較は行われません。
+2. **`columnStrategies`**: `@ColumnStrategy`アノテーションが設定されたカラムは指定された戦略を使用します。
+3. **`STRICT`（デフォルト）**: 残りのすべてのカラムは完全一致比較を使用します。
+
+アノテーションレベルの`columnStrategies`は`ConventionSettings`で設定されたグローバル戦略をオーバーライドします。`ConventionSettings`のグローバル除外はデータセットごとの`excludeColumns`と結合されます。
 
 ## 関連仕様
 

--- a/docs/specs/public-api.md
+++ b/docs/specs/public-api.md
@@ -170,6 +170,16 @@ Configures the comparison strategy for a column during expectation verification.
 | `name` | `String` | (required) | Column name (case-insensitive) |
 | `strategy` | `Strategy` | `STRICT` | Comparison strategy to use |
 | `pattern` | `String` | `""` | Regex pattern for `REGEX` strategy |
+| `options` | `String` | `""` | Strategy-specific options (see below) |
+
+**Options Attribute**:
+
+The `options` attribute provides configuration for parameterized strategies:
+
+| Strategy | Options Format | Example |
+|----------|---------------|---------|
+| `RANGE` | `"min=N,max=M"` (N, M: numeric, both inclusive) | `"min=100,max=200"` |
+| `CONTAINS` | Substring to search for (optional; if empty, uses expected value) | `"expected-substring"` |
 
 ### Strategy
 
@@ -179,15 +189,33 @@ Enum defining comparison strategy types for use in `@ColumnStrategy` annotations
 
 **Values**:
 
-| Value | Description |
-|-------|-------------|
-| `STRICT` | Exact match using `equals()` (default) |
-| `IGNORE` | Skip comparison entirely |
-| `NUMERIC` | Type-aware numeric comparison |
-| `CASE_INSENSITIVE` | Case-insensitive string comparison |
-| `TIMESTAMP_FLEXIBLE` | Converts to UTC and ignores sub-second precision |
-| `NOT_NULL` | Verifies value is not null |
-| `REGEX` | Pattern matching (requires `pattern` attribute) |
+| Value | Description | Required Attribute |
+|-------|-------------|-------------------|
+| `STRICT` | Exact match using `equals()` (default) | — |
+| `IGNORE` | Skip comparison entirely | — |
+| `NUMERIC` | Type-aware numeric comparison | — |
+| `CASE_INSENSITIVE` | Case-insensitive string comparison | — |
+| `TIMESTAMP_FLEXIBLE` | Converts to UTC and ignores sub-second precision | — |
+| `NOT_NULL` | Verifies value is not null | — |
+| `REGEX` | Pattern matching using regular expressions | `pattern` |
+| `DATE_FLEXIBLE` | Multi-format date comparison (ISO-8601, slashed, dot) | — |
+| `JSON_EQUIVALENT` | JSON structural comparison (ignores key order and whitespace) | — |
+| `CONTAINS` | Substring containment check | `options` (optional) |
+| `RANGE` | Numeric range verification (inclusive bounds) | `options` |
+
+**Examples with New Strategies**:
+
+```java
+@ExpectedDataSet(sources = @DataSetSource(
+    columnStrategies = {
+        @ColumnStrategy(name = "BIRTH_DATE", strategy = Strategy.DATE_FLEXIBLE),
+        @ColumnStrategy(name = "METADATA", strategy = Strategy.JSON_EQUIVALENT),
+        @ColumnStrategy(name = "DESCRIPTION", strategy = Strategy.CONTAINS),
+        @ColumnStrategy(name = "PRICE", strategy = Strategy.RANGE, options = "min=100,max=200")
+    }
+))
+void testWithExtendedStrategies() { }
+```
 
 ### RowOrdering
 
@@ -433,6 +461,11 @@ Represents programmatic column comparison strategy configuration.
 | `timestampFlexible(String)` | Creates mapping with TIMESTAMP_FLEXIBLE strategy |
 | `notNull(String)` | Creates mapping with NOT_NULL strategy |
 | `regex(String, String)` | Creates mapping with REGEX strategy and pattern |
+| `dateFlexible(String)` | Creates mapping with DATE_FLEXIBLE strategy |
+| `jsonEquivalent(String)` | Creates mapping with JSON_EQUIVALENT strategy |
+| `contains(String)` | Creates mapping with CONTAINS strategy (uses expected value) |
+| `contains(String, String)` | Creates mapping with CONTAINS strategy and specific substring |
+| `range(String, double, double)` | Creates mapping with RANGE strategy and min/max bounds |
 
 **Example**:
 
@@ -441,7 +474,11 @@ Represents programmatic column comparison strategy configuration.
 var strategies = List.of(
     ColumnStrategyMapping.ignore("CREATED_AT"),
     ColumnStrategyMapping.caseInsensitive("EMAIL"),
-    ColumnStrategyMapping.regex("TOKEN", "[a-f0-9-]{36}")
+    ColumnStrategyMapping.regex("TOKEN", "[a-f0-9-]{36}"),
+    ColumnStrategyMapping.dateFlexible("BIRTH_DATE"),
+    ColumnStrategyMapping.jsonEquivalent("METADATA"),
+    ColumnStrategyMapping.contains("DESCRIPTION"),
+    ColumnStrategyMapping.range("PRICE", 100.0, 200.0)
 );
 
 DatabaseAssertion.assertEqualsWithStrategies(expectedTable, actualTable, strategies);
@@ -462,14 +499,19 @@ Defines value comparison behavior during assertion.
 | `NUMERIC` | Type-aware numeric comparison using BigDecimal |
 | `CASE_INSENSITIVE` | Case-insensitive string comparison |
 | `TIMESTAMP_FLEXIBLE` | Converts to UTC and ignores sub-second precision |
+| `DATE_FLEXIBLE` | Multi-format date comparison (ISO-8601 `yyyy-MM-dd`, slashed `yyyy/MM/dd`, dot `yyyy.MM.dd`) |
+| `JSON_EQUIVALENT` | JSON structural comparison (ignores key order and whitespace) |
 | `NOT_NULL` | Verifies value is not null |
-| `REGEX` | Pattern matching using regular expressions |
 
 **Factory Methods**:
 
 | Method | Description |
 |--------|-------------|
 | `regex(String)` | Creates regex pattern matcher with the specified pattern |
+| `contains()` | Creates substring containment check using expected value |
+| `contains(String)` | Creates substring containment check with specific substring |
+| `range(double, double)` | Creates numeric range check with min and max bounds |
+| `range(String)` | Creates numeric range check from options string (`"min=N,max=M"`) |
 
 **Comparison Behavior**:
 
@@ -480,8 +522,12 @@ Defines value comparison behavior during assertion.
 | `NUMERIC` | true | false | false | BigDecimal comparison |
 | `CASE_INSENSITIVE` | true | false | false | equalsIgnoreCase() |
 | `TIMESTAMP_FLEXIBLE` | true | false | false | UTC epoch comparison |
+| `DATE_FLEXIBLE` | true | false | false | LocalDate comparison |
+| `JSON_EQUIVALENT` | true | false | false | Normalized JSON comparison |
 | `NOT_NULL` | false | false | false | true |
 | `REGEX` | false | false | false | Pattern.matches() |
+| `CONTAINS` | false | false | false | String.contains() |
+| `RANGE` | false | false | false | min <= value <= max |
 
 ## Assertion API
 
@@ -655,6 +701,45 @@ Indicates assertion or validation failure.
 - Column value mismatches
 
 **Output Format**: Validation errors output a human-readable summary followed by YAML details. See [Error Handling - Validation Errors](error-handling#validation-errors) for format details.
+
+## Default Values Reference
+
+This table lists the default values for all configurable attributes.
+
+### Annotation Attribute Defaults
+
+| Annotation | Attribute | Default | Meaning |
+|------------|-----------|---------|---------|
+| `@DataSet` | `sources` | `{}` | Convention-based discovery |
+| `@DataSet` | `operation` | `CLEAN_INSERT` | Delete all rows then insert |
+| `@DataSet` | `tableOrdering` | `AUTO` | Automatic ordering |
+| `@ExpectedDataSet` | `sources` | `{}` | Convention-based discovery |
+| `@ExpectedDataSet` | `tableOrdering` | `AUTO` | Automatic ordering |
+| `@ExpectedDataSet` | `rowOrdering` | `ORDERED` | Positional row comparison |
+| `@ExpectedDataSet` | `retryCount` | `-1` | Use global setting |
+| `@ExpectedDataSet` | `retryDelayMillis` | `-1` | Use global setting |
+| `@DataSetSource` | `resourceLocation` | `""` | Convention-based discovery |
+| `@DataSetSource` | `dataSourceName` | `""` | Default DataSource |
+| `@DataSetSource` | `scenarioNames` | `{}` | Use test method name |
+| `@DataSetSource` | `excludeColumns` | `{}` | No exclusions |
+| `@DataSetSource` | `columnStrategies` | `{}` | Default STRICT for all columns |
+| `@ColumnStrategy` | `strategy` | `STRICT` | Exact match |
+| `@ColumnStrategy` | `pattern` | `""` | No pattern |
+| `@ColumnStrategy` | `options` | `""` | No options |
+
+**Magic Value: `-1`**
+
+Attributes with a default of `-1` delegate to the global configuration in `OperationDefaults`. This allows test-level overrides while maintaining consistent defaults across the test suite. A value of `0` or higher uses the specified value directly.
+
+## Column Comparison Precedence
+
+When verifying expected database state, column comparison follows this precedence order:
+
+1. **`excludeColumns`**: Columns listed in `excludeColumns` are skipped entirely. No comparison occurs for these columns.
+2. **`columnStrategies`**: Columns with a `@ColumnStrategy` annotation use the specified strategy.
+3. **`STRICT` (default)**: All remaining columns use exact match comparison.
+
+Annotation-level `columnStrategies` override global strategies configured in `ConventionSettings`. Global exclusions from `ConventionSettings` are combined with per-dataset `excludeColumns`.
 
 ## Related Specifications
 


### PR DESCRIPTION
## Summary
- Add documentation for DATE_FLEXIBLE, JSON_EQUIVALENT, CONTAINS, and RANGE comparison strategies introduced in #124
- Add default values reference table for all annotation attributes
- Add magic value (`-1`) explanation and column comparison precedence section
- Update both English and Japanese versions of `public-api.md`

## Test plan
- [x] `./gradlew build` passes (documentation-only change, no code impact)
- [x] English and Japanese versions are consistent

Closes #125