### PR TITLE
docs: add advanced scenario usage examples

### DIFF
--- a/docs/specs/advanced-usage.md
+++ b/docs/specs/advanced-usage.md
@@ -1,0 +1,469 @@
+---
+title: "Advanced Usage - DB Tester"
+description: "Implementation examples for complex test scenarios including foreign keys, scenario filtering, comparison strategies, and multiple data sources."
+---
+
+# Advanced Usage
+
+This guide demonstrates complex test scenarios with implementation examples.
+
+## 1. Foreign Key Constraint Handling
+
+When tables have foreign key relationships, configure the table ordering strategy
+to insert parent records before child records.
+
+### Table Ordering Strategies
+
+| Strategy | Description |
+|----------|-------------|
+| `AUTO` | Processes tables alphabetically (default) |
+| `FOREIGN_KEY` | Resolves insertion order based on foreign key constraints |
+| `TABLE_ORDERING_FILE` | Uses explicit ordering defined in `table-ordering.txt` |
+
+### Example: Parent-Child Tables
+
+```java
+@Test
+@DataSet(tableOrdering = TableOrderingStrategy.FOREIGN_KEY)
+@ExpectedDataSet(tableOrdering = TableOrderingStrategy.FOREIGN_KEY)
+void shouldInsertOrdersWithForeignKeys() throws SQLException {
+    // Inserts USERS first, then ORDERS (respecting FK constraint)
+    // Test logic here
+}
+```
+
+CSV files:
+
+`USERS.csv`:
+
+```csv
+ID,NAME,EMAIL
+1,Alice,alice@example.com
+2,Bob,bob@example.com
+```
+
+`ORDERS.csv`:
+
+```csv
+ID,USER_ID,AMOUNT,STATUS
+1001,1,99.99,PENDING
+1002,2,149.50,COMPLETED
+```
+
+### Using table-ordering.txt
+
+Create `table-ordering.txt` in the dataset directory to specify insertion order:
+
+```
+USERS
+ORDERS
+ORDER_ITEMS
+```
+
+```java
+@Test
+@DataSet(tableOrdering = TableOrderingStrategy.TABLE_ORDERING_FILE)
+void shouldFollowExplicitTableOrder() throws SQLException {
+    // Tables processed in the order listed in table-ordering.txt
+}
+```
+
+## 2. Scenario Filtering
+
+Scenario filtering allows multiple test methods to share a single data file.
+The `[Scenario]` marker column selects rows for each test.
+
+### Basic Scenario Usage
+
+`USERS.csv`:
+
+```csv
+[Scenario],ID,NAME,EMAIL
+shouldFindActiveUsers,1,Alice,alice@example.com
+shouldFindActiveUsers,2,Bob,bob@example.com
+shouldFindInactiveUsers,3,Charlie,charlie@example.com
+shouldFindInactiveUsers,4,Diana,diana@example.com
+```
+
+```java
+@Test
+@DataSet
+void shouldFindActiveUsers() throws SQLException {
+    // Loads only rows where [Scenario] = "shouldFindActiveUsers"
+    // Database contains: Alice (ID=1) and Bob (ID=2)
+}
+
+@Test
+@DataSet
+void shouldFindInactiveUsers() throws SQLException {
+    // Loads only rows where [Scenario] = "shouldFindInactiveUsers"
+    // Database contains: Charlie (ID=3) and Diana (ID=4)
+}
+```
+
+### Custom Scenario Names
+
+Override the default method-name matching with explicit scenario names:
+
+```java
+@Test
+@DataSet(sources = @DataSetSource(scenarioNames = {"basic", "premium"}))
+void shouldHandleMultipleUserTypes() throws SQLException {
+    // Loads rows matching either "basic" or "premium" scenario
+}
+```
+
+`USERS.csv`:
+
+```csv
+[Scenario],ID,NAME,PLAN
+basic,1,Alice,FREE
+basic,2,Bob,FREE
+premium,3,Charlie,GOLD
+premium,4,Diana,PLATINUM
+admin,5,Eve,ADMIN
+```
+
+This test loads users 1 through 4, excluding the "admin" row (Eve).
+
+### Shared Rows Across Scenarios
+
+Rows without a scenario value (blank or null) are included in all scenarios:
+
+```csv
+[Scenario],ID,NAME,ROLE
+,1,System,SYSTEM
+shouldTestAdmin,2,Admin,ADMIN
+shouldTestUser,3,User,USER
+```
+
+Both `shouldTestAdmin` and `shouldTestUser` include the System row (ID=1).
+
+## 3. Column Comparison Strategies
+
+The `@ColumnStrategy` annotation controls how individual columns are compared
+during expectation verification.
+
+### Ignoring Auto-Generated Columns
+
+```java
+@Test
+@DataSet
+@ExpectedDataSet(sources = @DataSetSource(
+    excludeColumns = {"CREATED_AT", "UPDATED_AT", "VERSION"}
+))
+void shouldCreateUser() throws SQLException {
+    // Verification ignores CREATED_AT, UPDATED_AT, and VERSION columns
+}
+```
+
+### Combining Multiple Strategies
+
+```java
+@Test
+@DataSet
+@ExpectedDataSet(sources = @DataSetSource(
+    columnStrategies = {
+        @ColumnStrategy(name = "ID", strategy = Strategy.REGEX, pattern = "[a-f0-9-]{36}"),
+        @ColumnStrategy(name = "EMAIL", strategy = Strategy.CASE_INSENSITIVE),
+        @ColumnStrategy(name = "CREATED_AT", strategy = Strategy.IGNORE),
+        @ColumnStrategy(name = "BALANCE", strategy = Strategy.NUMERIC)
+    }
+))
+void shouldProcessTransaction() throws SQLException {
+    // ID: validated as UUID format
+    // EMAIL: compared case-insensitively
+    // CREATED_AT: skipped entirely
+    // BALANCE: compared by numeric value (ignores type differences)
+}
+```
+
+### Flexible Date and Timestamp Comparison
+
+```java
+@Test
+@DataSet
+@ExpectedDataSet(sources = @DataSetSource(
+    columnStrategies = {
+        @ColumnStrategy(name = "BIRTH_DATE", strategy = Strategy.DATE_FLEXIBLE),
+        @ColumnStrategy(name = "LOGIN_AT", strategy = Strategy.TIMESTAMP_FLEXIBLE)
+    }
+))
+void shouldHandleDateFormats() throws SQLException {
+    // BIRTH_DATE: accepts "2024-01-15", "2024/01/15", "2024.01.15"
+    // LOGIN_AT: normalizes to UTC, ignores sub-second precision
+}
+```
+
+### JSON Structural Comparison
+
+```java
+@Test
+@DataSet
+@ExpectedDataSet(sources = @DataSetSource(
+    columnStrategies = {
+        @ColumnStrategy(name = "METADATA", strategy = Strategy.JSON_EQUIVALENT)
+    }
+))
+void shouldStoreJsonMetadata() throws SQLException {
+    // {"b":2,"a":1} and {"a":1,"b":2} are considered equal
+    // Ignores key order and insignificant whitespace
+}
+```
+
+### Range and Containment Verification
+
+```java
+@Test
+@DataSet
+@ExpectedDataSet(sources = @DataSetSource(
+    columnStrategies = {
+        @ColumnStrategy(name = "SCORE", strategy = Strategy.RANGE, options = "min=0,max=100"),
+        @ColumnStrategy(name = "DESCRIPTION", strategy = Strategy.CONTAINS)
+    }
+))
+void shouldValidateScoreAndDescription() throws SQLException {
+    // SCORE: actual value must be between 0 and 100 (inclusive)
+    // DESCRIPTION: actual value must contain the expected value as substring
+}
+```
+
+### Strategy Precedence
+
+The framework applies strategies in this order:
+
+1. `excludeColumns` - Columns listed here are excluded from comparison
+2. `columnStrategies` - Per-column strategies override the default
+3. `STRICT` - Default comparison for columns without explicit strategy
+
+## 4. Multiple DataSource Usage
+
+Register multiple data sources to test across databases.
+
+### Registering Multiple DataSources
+
+```java
+@BeforeAll
+static void setUp(ExtensionContext context) throws SQLException {
+    var primaryDs = createDataSource("jdbc:h2:mem:primary;DB_CLOSE_DELAY=-1");
+    var secondaryDs = createDataSource("jdbc:h2:mem:secondary;DB_CLOSE_DELAY=-1");
+
+    var registry = DatabaseTestExtension.getRegistry(context);
+    registry.registerDefault(primaryDs);
+    registry.register("secondary", secondaryDs);
+
+    createTables(primaryDs, "CREATE TABLE USERS (ID INT PRIMARY KEY, NAME VARCHAR(100))");
+    createTables(secondaryDs, "CREATE TABLE AUDIT_LOG (ID INT PRIMARY KEY, ACTION VARCHAR(255))");
+}
+```
+
+### Using Named DataSources in Annotations
+
+```java
+@Test
+@DataSet(sources = {
+    @DataSetSource(resourceLocation = "classpath:data/primary/"),
+    @DataSetSource(dataSourceName = "secondary", resourceLocation = "classpath:data/secondary/")
+})
+@ExpectedDataSet(sources = {
+    @DataSetSource(resourceLocation = "classpath:data/primary/expected/"),
+    @DataSetSource(dataSourceName = "secondary", resourceLocation = "classpath:data/secondary/expected/")
+})
+void shouldWriteToMultipleDatabases() throws SQLException {
+    // Primary DB: loads from classpath:data/primary/
+    // Secondary DB: loads from classpath:data/secondary/
+    // Both databases verified after test execution
+}
+```
+
+## 5. Retry for Eventual Consistency
+
+Configure retries for tests involving asynchronous operations.
+
+### Per-Method Retry
+
+```java
+@Test
+@DataSet
+@ExpectedDataSet(retryCount = 5, retryDelayMillis = 500)
+void shouldProcessAsyncEvent() throws SQLException {
+    // Trigger async operation
+    eventPublisher.publish(new UserCreatedEvent(1, "Alice"));
+
+    // @ExpectedDataSet retries up to 5 times with 500ms delay
+    // Total maximum wait: 2500ms
+}
+```
+
+### Global Retry Configuration
+
+```java
+var operations = OperationDefaults.builder()
+    .retryCount(3)
+    .retryDelay(Duration.ofMillis(200))
+    .build();
+
+var config = Configuration.builder()
+    .operations(operations)
+    .build();
+```
+
+Individual methods override global settings when `retryCount` or
+`retryDelayMillis` is explicitly set (not `-1`).
+
+## 6. Unordered Row Comparison
+
+When database queries return rows in unpredictable order, use unordered comparison.
+
+### Per-Method Configuration
+
+```java
+@Test
+@DataSet
+@ExpectedDataSet(rowOrdering = RowOrdering.UNORDERED)
+void shouldReturnUsersInAnyOrder() throws SQLException {
+    // Rows are compared as sets, ignoring positional order
+    // {Alice, Bob} matches {Bob, Alice}
+}
+```
+
+### Global Configuration
+
+```java
+var conventions = ConventionSettings.builder()
+    .rowOrdering(RowOrdering.UNORDERED)
+    .build();
+
+var config = Configuration.builder()
+    .conventions(conventions)
+    .build();
+```
+
+## 7. Spring Boot Integration
+
+The Spring Boot starters automatically register Spring-managed DataSource beans.
+
+### Dependencies
+
+::: code-group
+
+```kotlin [JUnit]
+dependencies {
+    testImplementation(platform("io.github.seijikohara:db-tester-bom:VERSION"))
+    testImplementation("io.github.seijikohara:db-tester-junit-spring-boot-starter")
+}
+```
+
+```groovy [Spock]
+dependencies {
+    testImplementation platform("io.github.seijikohara:db-tester-bom:VERSION")
+    testImplementation "io.github.seijikohara:db-tester-spock-spring-boot-starter"
+}
+```
+
+```kotlin [Kotest]
+dependencies {
+    testImplementation(platform("io.github.seijikohara:db-tester-bom:VERSION"))
+    testImplementation("io.github.seijikohara:db-tester-kotest-spring-boot-starter")
+}
+```
+
+:::
+
+### Test Class
+
+```java
+@SpringBootTest
+class UserServiceTest {
+
+    @Autowired
+    private UserService userService;
+
+    @Test
+    @DataSet
+    @ExpectedDataSet
+    void shouldCreateUser() {
+        // Spring Boot auto-configures DataSource registration
+        // No manual @BeforeAll setup required
+
+        userService.create(new User("Alice", "alice@example.com"));
+
+        // @ExpectedDataSet verifies the database state
+    }
+}
+```
+
+### application.yml Configuration
+
+```yaml
+spring:
+  datasource:
+    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+```
+
+### Multiple DataSources with Spring Boot
+
+```java
+@Configuration
+class DataSourceConfig {
+
+    @Bean
+    @Primary
+    DataSource primaryDataSource() {
+        return DataSourceBuilder.create()
+            .url("jdbc:h2:mem:primary;DB_CLOSE_DELAY=-1")
+            .build();
+    }
+
+    @Bean("secondary")
+    DataSource secondaryDataSource() {
+        return DataSourceBuilder.create()
+            .url("jdbc:h2:mem:secondary;DB_CLOSE_DELAY=-1")
+            .build();
+    }
+}
+```
+
+The starter registers all `DataSource` beans using their bean name.
+The `@Primary` bean becomes the default data source.
+
+## 8. Convention-Based vs Explicit Paths
+
+### Convention-Based (Default)
+
+```java
+@DataSet           // src/test/resources/com/example/MyTest/
+@ExpectedDataSet   // src/test/resources/com/example/MyTest/expected/
+```
+
+Directory structure:
+
+```
+src/test/resources/com/example/MyTest/
+├── USERS.csv
+├── ORDERS.csv
+└── expected/
+    ├── USERS.csv
+    └── ORDERS.csv
+```
+
+### Explicit Resource Location
+
+```java
+@DataSet(sources = @DataSetSource(resourceLocation = "classpath:shared/common-data/"))
+void testWithSharedData() { }
+```
+
+Explicit paths are useful for sharing datasets across test classes.
+
+## Related Documentation
+
+- [Getting Started](getting-started) - First test setup
+- [Public API](public-api) - Annotation and configuration reference
+- [Configuration](configuration) - Framework configuration details
+- [Data Formats](data-formats) - CSV and TSV format specification
+- [Comparison](comparison) - Comparison strategy details
+- [Test Frameworks](test-frameworks) - JUnit, Spock, and Kotest integration

--- a/docs/specs/ja/advanced-usage.md
+++ b/docs/specs/ja/advanced-usage.md
@@ -1,0 +1,468 @@
+---
+title: "応用例 - DB Tester"
+description: "外部キー、シナリオフィルタリング、比較戦略、複数データソースなど、複雑なテストシナリオの実装例。"
+---
+
+# 応用例
+
+複雑なテストシナリオの実装例を示します。
+
+## 1. 外部キー制約のあるテーブルの操作
+
+テーブル間に外部キー関係がある場合、テーブル処理順序を設定して
+親レコードを子レコードより先に挿入します。
+
+### テーブル順序戦略
+
+| 戦略 | 説明 |
+|------|------|
+| `AUTO` | テーブルをアルファベット順に処理（デフォルト） |
+| `FOREIGN_KEY` | 外部キー制約に基づいて挿入順序を解決 |
+| `TABLE_ORDERING_FILE` | `table-ordering.txt` で定義された順序を使用 |
+
+### 例: 親子テーブル
+
+```java
+@Test
+@DataSet(tableOrdering = TableOrderingStrategy.FOREIGN_KEY)
+@ExpectedDataSet(tableOrdering = TableOrderingStrategy.FOREIGN_KEY)
+void shouldInsertOrdersWithForeignKeys() throws SQLException {
+    // USERS を先に挿入し、次に ORDERS を挿入（FK制約を遵守）
+    // テストロジックをここに記述
+}
+```
+
+CSVファイル:
+
+`USERS.csv`:
+
+```csv
+ID,NAME,EMAIL
+1,Alice,alice@example.com
+2,Bob,bob@example.com
+```
+
+`ORDERS.csv`:
+
+```csv
+ID,USER_ID,AMOUNT,STATUS
+1001,1,99.99,PENDING
+1002,2,149.50,COMPLETED
+```
+
+### table-ordering.txt の使用
+
+データセットディレクトリに `table-ordering.txt` を作成して挿入順序を指定します:
+
+```
+USERS
+ORDERS
+ORDER_ITEMS
+```
+
+```java
+@Test
+@DataSet(tableOrdering = TableOrderingStrategy.TABLE_ORDERING_FILE)
+void shouldFollowExplicitTableOrder() throws SQLException {
+    // table-ordering.txt に記載された順序でテーブルを処理
+}
+```
+
+## 2. シナリオフィルタリング
+
+シナリオフィルタリングにより、複数のテストメソッドが単一のデータファイルを共有できます。
+`[Scenario]` マーカー列が各テストの行を選択します。
+
+### 基本的なシナリオの使用
+
+`USERS.csv`:
+
+```csv
+[Scenario],ID,NAME,EMAIL
+shouldFindActiveUsers,1,Alice,alice@example.com
+shouldFindActiveUsers,2,Bob,bob@example.com
+shouldFindInactiveUsers,3,Charlie,charlie@example.com
+shouldFindInactiveUsers,4,Diana,diana@example.com
+```
+
+```java
+@Test
+@DataSet
+void shouldFindActiveUsers() throws SQLException {
+    // [Scenario] = "shouldFindActiveUsers" の行のみロード
+    // データベースに Alice（ID=1）と Bob（ID=2）が格納される
+}
+
+@Test
+@DataSet
+void shouldFindInactiveUsers() throws SQLException {
+    // [Scenario] = "shouldFindInactiveUsers" の行のみロード
+    // データベースに Charlie（ID=3）と Diana（ID=4）が格納される
+}
+```
+
+### カスタムシナリオ名
+
+メソッド名の自動マッチングを明示的なシナリオ名で上書きします:
+
+```java
+@Test
+@DataSet(sources = @DataSetSource(scenarioNames = {"basic", "premium"}))
+void shouldHandleMultipleUserTypes() throws SQLException {
+    // "basic" または "premium" シナリオに一致する行をロード
+}
+```
+
+`USERS.csv`:
+
+```csv
+[Scenario],ID,NAME,PLAN
+basic,1,Alice,FREE
+basic,2,Bob,FREE
+premium,3,Charlie,GOLD
+premium,4,Diana,PLATINUM
+admin,5,Eve,ADMIN
+```
+
+このテストではユーザー1〜4がロードされ、"admin" 行（Eve）は除外されます。
+
+### シナリオ間で共有される行
+
+シナリオ値が空白またはnullの行は、全シナリオに含まれます:
+
+```csv
+[Scenario],ID,NAME,ROLE
+,1,System,SYSTEM
+shouldTestAdmin,2,Admin,ADMIN
+shouldTestUser,3,User,USER
+```
+
+`shouldTestAdmin` と `shouldTestUser` の両方にSystem行（ID=1）が含まれます。
+
+## 3. 列比較戦略
+
+`@ColumnStrategy` アノテーションにより、期待値検証時の個別列の比較方法を制御します。
+
+### 自動生成列の除外
+
+```java
+@Test
+@DataSet
+@ExpectedDataSet(sources = @DataSetSource(
+    excludeColumns = {"CREATED_AT", "UPDATED_AT", "VERSION"}
+))
+void shouldCreateUser() throws SQLException {
+    // CREATED_AT、UPDATED_AT、VERSION 列を検証から除外
+}
+```
+
+### 複数戦略の組み合わせ
+
+```java
+@Test
+@DataSet
+@ExpectedDataSet(sources = @DataSetSource(
+    columnStrategies = {
+        @ColumnStrategy(name = "ID", strategy = Strategy.REGEX, pattern = "[a-f0-9-]{36}"),
+        @ColumnStrategy(name = "EMAIL", strategy = Strategy.CASE_INSENSITIVE),
+        @ColumnStrategy(name = "CREATED_AT", strategy = Strategy.IGNORE),
+        @ColumnStrategy(name = "BALANCE", strategy = Strategy.NUMERIC)
+    }
+))
+void shouldProcessTransaction() throws SQLException {
+    // ID: UUID形式として検証
+    // EMAIL: 大文字小文字を無視して比較
+    // CREATED_AT: 比較を完全にスキップ
+    // BALANCE: 数値として比較（型の違いを無視）
+}
+```
+
+### 柔軟な日付・タイムスタンプ比較
+
+```java
+@Test
+@DataSet
+@ExpectedDataSet(sources = @DataSetSource(
+    columnStrategies = {
+        @ColumnStrategy(name = "BIRTH_DATE", strategy = Strategy.DATE_FLEXIBLE),
+        @ColumnStrategy(name = "LOGIN_AT", strategy = Strategy.TIMESTAMP_FLEXIBLE)
+    }
+))
+void shouldHandleDateFormats() throws SQLException {
+    // BIRTH_DATE: "2024-01-15"、"2024/01/15"、"2024.01.15" を受け入れる
+    // LOGIN_AT: UTCに正規化し、秒未満の精度を無視
+}
+```
+
+### JSON構造比較
+
+```java
+@Test
+@DataSet
+@ExpectedDataSet(sources = @DataSetSource(
+    columnStrategies = {
+        @ColumnStrategy(name = "METADATA", strategy = Strategy.JSON_EQUIVALENT)
+    }
+))
+void shouldStoreJsonMetadata() throws SQLException {
+    // {"b":2,"a":1} と {"a":1,"b":2} は等価と判定
+    // キーの順序と無意味な空白を無視
+}
+```
+
+### 範囲と包含の検証
+
+```java
+@Test
+@DataSet
+@ExpectedDataSet(sources = @DataSetSource(
+    columnStrategies = {
+        @ColumnStrategy(name = "SCORE", strategy = Strategy.RANGE, options = "min=0,max=100"),
+        @ColumnStrategy(name = "DESCRIPTION", strategy = Strategy.CONTAINS)
+    }
+))
+void shouldValidateScoreAndDescription() throws SQLException {
+    // SCORE: 実際の値が0〜100の範囲内であることを検証（両端含む）
+    // DESCRIPTION: 実際の値が期待値を部分文字列として含むことを検証
+}
+```
+
+### 戦略の優先順位
+
+フレームワークは以下の順序で戦略を適用します:
+
+1. `excludeColumns` - 指定された列を比較から除外
+2. `columnStrategies` - 列ごとの戦略がデフォルトを上書き
+3. `STRICT` - 明示的な戦略がない列のデフォルト比較
+
+## 4. 複数DataSourceの使用
+
+複数のデータソースを登録して、複数データベース間のテストを実行します。
+
+### 複数DataSourceの登録
+
+```java
+@BeforeAll
+static void setUp(ExtensionContext context) throws SQLException {
+    var primaryDs = createDataSource("jdbc:h2:mem:primary;DB_CLOSE_DELAY=-1");
+    var secondaryDs = createDataSource("jdbc:h2:mem:secondary;DB_CLOSE_DELAY=-1");
+
+    var registry = DatabaseTestExtension.getRegistry(context);
+    registry.registerDefault(primaryDs);
+    registry.register("secondary", secondaryDs);
+
+    createTables(primaryDs, "CREATE TABLE USERS (ID INT PRIMARY KEY, NAME VARCHAR(100))");
+    createTables(secondaryDs, "CREATE TABLE AUDIT_LOG (ID INT PRIMARY KEY, ACTION VARCHAR(255))");
+}
+```
+
+### アノテーションでの名前付きDataSourceの使用
+
+```java
+@Test
+@DataSet(sources = {
+    @DataSetSource(resourceLocation = "classpath:data/primary/"),
+    @DataSetSource(dataSourceName = "secondary", resourceLocation = "classpath:data/secondary/")
+})
+@ExpectedDataSet(sources = {
+    @DataSetSource(resourceLocation = "classpath:data/primary/expected/"),
+    @DataSetSource(dataSourceName = "secondary", resourceLocation = "classpath:data/secondary/expected/")
+})
+void shouldWriteToMultipleDatabases() throws SQLException {
+    // プライマリDB: classpath:data/primary/ からロード
+    // セカンダリDB: classpath:data/secondary/ からロード
+    // テスト実行後に両データベースを検証
+}
+```
+
+## 5. 結果整合性のためのリトライ
+
+非同期処理を含むテストでリトライを設定します。
+
+### メソッド単位のリトライ
+
+```java
+@Test
+@DataSet
+@ExpectedDataSet(retryCount = 5, retryDelayMillis = 500)
+void shouldProcessAsyncEvent() throws SQLException {
+    // 非同期処理をトリガー
+    eventPublisher.publish(new UserCreatedEvent(1, "Alice"));
+
+    // @ExpectedDataSet が500msの間隔で最大5回リトライ
+    // 最大待機時間: 2500ms
+}
+```
+
+### グローバルリトライ設定
+
+```java
+var operations = OperationDefaults.builder()
+    .retryCount(3)
+    .retryDelay(Duration.ofMillis(200))
+    .build();
+
+var config = Configuration.builder()
+    .operations(operations)
+    .build();
+```
+
+メソッドで `retryCount` や `retryDelayMillis` を明示的に設定（`-1` 以外）した場合、
+グローバル設定を上書きします。
+
+## 6. 順序なし行比較
+
+データベースクエリが行を不定な順序で返す場合、順序なし比較を使用します。
+
+### メソッド単位の設定
+
+```java
+@Test
+@DataSet
+@ExpectedDataSet(rowOrdering = RowOrdering.UNORDERED)
+void shouldReturnUsersInAnyOrder() throws SQLException {
+    // 行を集合として比較し、位置順序を無視
+    // {Alice, Bob} は {Bob, Alice} と一致
+}
+```
+
+### グローバル設定
+
+```java
+var conventions = ConventionSettings.builder()
+    .rowOrdering(RowOrdering.UNORDERED)
+    .build();
+
+var config = Configuration.builder()
+    .conventions(conventions)
+    .build();
+```
+
+## 7. Spring Boot連携
+
+Spring Bootスターターにより、Spring管理のDataSource Beanが自動登録されます。
+
+### 依存関係
+
+::: code-group
+
+```kotlin [JUnit]
+dependencies {
+    testImplementation(platform("io.github.seijikohara:db-tester-bom:VERSION"))
+    testImplementation("io.github.seijikohara:db-tester-junit-spring-boot-starter")
+}
+```
+
+```groovy [Spock]
+dependencies {
+    testImplementation platform("io.github.seijikohara:db-tester-bom:VERSION")
+    testImplementation "io.github.seijikohara:db-tester-spock-spring-boot-starter"
+}
+```
+
+```kotlin [Kotest]
+dependencies {
+    testImplementation(platform("io.github.seijikohara:db-tester-bom:VERSION"))
+    testImplementation("io.github.seijikohara:db-tester-kotest-spring-boot-starter")
+}
+```
+
+:::
+
+### テストクラス
+
+```java
+@SpringBootTest
+class UserServiceTest {
+
+    @Autowired
+    private UserService userService;
+
+    @Test
+    @DataSet
+    @ExpectedDataSet
+    void shouldCreateUser() {
+        // Spring Bootが自動的にDataSource登録を設定
+        // 手動の @BeforeAll セットアップは不要
+
+        userService.create(new User("Alice", "alice@example.com"));
+
+        // @ExpectedDataSet がデータベース状態を検証
+    }
+}
+```
+
+### application.yml 設定
+
+```yaml
+spring:
+  datasource:
+    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+```
+
+### Spring Bootでの複数DataSource
+
+```java
+@Configuration
+class DataSourceConfig {
+
+    @Bean
+    @Primary
+    DataSource primaryDataSource() {
+        return DataSourceBuilder.create()
+            .url("jdbc:h2:mem:primary;DB_CLOSE_DELAY=-1")
+            .build();
+    }
+
+    @Bean("secondary")
+    DataSource secondaryDataSource() {
+        return DataSourceBuilder.create()
+            .url("jdbc:h2:mem:secondary;DB_CLOSE_DELAY=-1")
+            .build();
+    }
+}
+```
+
+スターターは全ての `DataSource` Beanをbean名で登録します。
+`@Primary` のBeanがデフォルトデータソースになります。
+
+## 8. 規約ベース vs 明示的パス
+
+### 規約ベース（デフォルト）
+
+```java
+@DataSet           // src/test/resources/com/example/MyTest/
+@ExpectedDataSet   // src/test/resources/com/example/MyTest/expected/
+```
+
+ディレクトリ構造:
+
+```
+src/test/resources/com/example/MyTest/
+├── USERS.csv
+├── ORDERS.csv
+└── expected/
+    ├── USERS.csv
+    └── ORDERS.csv
+```
+
+### 明示的リソース指定
+
+```java
+@DataSet(sources = @DataSetSource(resourceLocation = "classpath:shared/common-data/"))
+void testWithSharedData() { }
+```
+
+明示的パスは、テストクラス間でデータセットを共有する場合に有用です。
+
+## 関連ドキュメント
+
+- [はじめに](getting-started) - 初回テストのセットアップ
+- [パブリックAPI](public-api) - アノテーションと設定のリファレンス
+- [設定](configuration) - フレームワーク設定の詳細
+- [データ形式](data-formats) - CSVとTSVの形式仕様
+- [比較](comparison) - 比較戦略の詳細
+- [テストフレームワーク](test-frameworks) - JUnit、Spock、Kotest連携


### PR DESCRIPTION
## Summary
- Add `docs/specs/advanced-usage.md` (English) and `docs/specs/ja/advanced-usage.md` (Japanese)
- Document 8 advanced scenarios: FK handling, scenario filtering, comparison strategies, multiple DataSources, retry, unordered comparison, Spring Boot integration, convention vs explicit paths
- Include code examples with actual API annotations and configuration classes

## Test plan
- [x] spotlessApply passes
- [ ] CI `test (21)` passes
- [ ] CI `test (25)` passes

Closes #128