### PR TITLE
feat(core): add template expression processing for dynamic test data generation

### DIFF
--- a/db-tester-core/build.gradle.kts
+++ b/db-tester-core/build.gradle.kts
@@ -17,6 +17,9 @@ dependencies {
     implementation(platform(libs.jackson.bom))
     implementation(libs.jackson.dataformat.csv)
     implementation(libs.jackson.dataformat.yaml)
+
+    // Test data generation (optional runtime dependency - users opt in)
+    compileOnly(libs.datafaker)
 }
 
 testing {
@@ -26,6 +29,7 @@ testing {
                 implementation(platform(libs.mockito.bom))
                 implementation(libs.mockito.core)
                 implementation(libs.mockito.junit.jupiter)
+                implementation(libs.datafaker)
                 runtimeOnly(platform(libs.slf4j.bom))
                 runtimeOnly(libs.slf4j.simple)
             }

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/format/parser/DelimitedParser.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/format/parser/DelimitedParser.java
@@ -14,6 +14,7 @@ import io.github.seijikohara.dbtester.api.exception.DataSetLoadException;
 import io.github.seijikohara.dbtester.internal.dataset.SimpleRow;
 import io.github.seijikohara.dbtester.internal.dataset.SimpleTable;
 import io.github.seijikohara.dbtester.internal.dataset.SimpleTableSet;
+import io.github.seijikohara.dbtester.internal.template.TemplateProcessor;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -159,10 +160,11 @@ public final class DelimitedParser {
       final var columnNames = parseColumnNames(headerRow);
 
       // Remaining rows are data - convert iterator to stream
+      final var templateProcessor = new TemplateProcessor();
       final var rows =
           toStream(iterator)
               .filter(Predicate.not(this::isEmptyRow))
-              .map(values -> createRow(columnNames, values))
+              .map(values -> createRow(columnNames, values, templateProcessor))
               .toList();
 
       logger.debug(
@@ -228,16 +230,20 @@ public final class DelimitedParser {
    *
    * @param columnNames the column names
    * @param values the values array
+   * @param templateProcessor the template processor for resolving expressions
    * @return the created row
    */
-  private Row createRow(final List<ColumnName> columnNames, final String[] values) {
+  private Row createRow(
+      final List<ColumnName> columnNames,
+      final String[] values,
+      final TemplateProcessor templateProcessor) {
     final var rowValues =
         IntStream.range(0, columnNames.size())
             .boxed()
             .collect(
                 Collectors.toMap(
                     columnNames::get,
-                    i -> toCellValue(i < values.length ? values[i] : null),
+                    i -> toCellValue(i < values.length ? values[i] : null, templateProcessor),
                     (existing, replacement) -> existing,
                     LinkedHashMap::new));
 
@@ -247,14 +253,18 @@ public final class DelimitedParser {
   /**
    * Converts a raw string value to a CellValue.
    *
-   * <p>Empty or null strings are converted to {@link CellValue#NULL}.
+   * <p>Empty or null strings are converted to {@link CellValue#NULL}. Template expressions ({@code
+   * ${...}}) are resolved before creating the CellValue.
    *
    * @param rawValue the raw string value
+   * @param templateProcessor the template processor for resolving expressions
    * @return the CellValue
    */
-  private CellValue toCellValue(final @Nullable String rawValue) {
+  private CellValue toCellValue(
+      final @Nullable String rawValue, final TemplateProcessor templateProcessor) {
     return Optional.ofNullable(rawValue)
         .filter(Predicate.not(String::isEmpty))
+        .map(templateProcessor::process)
         .map(CellValue::new)
         .orElse(CellValue.NULL);
   }

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/template/TemplateProcessor.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/template/TemplateProcessor.java
@@ -1,0 +1,242 @@
+package io.github.seijikohara.dbtester.internal.template;
+
+import java.lang.reflect.Method;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Processes template expressions in CSV cell values.
+ *
+ * <p>This class resolves {@code ${...}} expressions in string values. Supported expression types:
+ *
+ * <ul>
+ *   <li>{@code ${sequence:N}} — sequence number starting from N
+ *   <li>{@code ${sequence}} — next sequence number (auto-increments)
+ *   <li>{@code ${uuid}} — random UUID
+ *   <li>{@code ${now}} — current date/time in ISO-8601 format
+ *   <li>{@code ${now+Xd}}, {@code ${now-Xd}} — relative date/time (d=days, h=hours, m=minutes,
+ *       s=seconds)
+ *   <li>{@code ${faker.xxx.yyy}} — Datafaker expression (requires Datafaker on classpath)
+ * </ul>
+ *
+ * <p>Instances are stateful due to sequence counters and should be created per table parse.
+ * Unrecognized expressions are returned unchanged.
+ *
+ * @see <a href="https://www.datafaker.net/">Datafaker</a>
+ */
+public final class TemplateProcessor {
+
+  /** Logger for this class. */
+  private static final Logger logger = LoggerFactory.getLogger(TemplateProcessor.class);
+
+  /** Pattern to detect {@code ${...}} expressions. */
+  private static final Pattern EXPRESSION_PATTERN = Pattern.compile("\\$\\{([^}]+)}");
+
+  /** Pattern to parse relative date/time expressions like {@code now-7d} or {@code now+1h}. */
+  private static final Pattern RELATIVE_TIME_PATTERN = Pattern.compile("now([+-])(\\d+)([dhms])");
+
+  /** ISO-8601 date/time formatter without offset. */
+  private static final DateTimeFormatter ISO_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+  /** Sequence counter for {@code ${sequence}} expressions. */
+  private final AtomicInteger sequenceCounter = new AtomicInteger(0);
+
+  /** Datafaker instance loaded via reflection, or null if unavailable. */
+  private final @Nullable Object faker;
+
+  /** Creates a new processor and attempts to load Datafaker via reflection. */
+  public TemplateProcessor() {
+    this.faker = loadFaker();
+  }
+
+  /**
+   * Checks whether the given value contains template expressions.
+   *
+   * @param value the value to check
+   * @return true if the value contains at least one {@code ${...}} expression
+   */
+  public static boolean containsExpression(final String value) {
+    return EXPRESSION_PATTERN.matcher(value).find();
+  }
+
+  /**
+   * Processes all template expressions in the given value.
+   *
+   * <p>If the value contains no expressions, it is returned unchanged. Each {@code ${...}}
+   * expression is resolved independently. Unrecognized expressions are returned as-is.
+   *
+   * @param value the value potentially containing template expressions
+   * @return the value with all recognized expressions resolved
+   */
+  public String process(final String value) {
+    final var matcher = EXPRESSION_PATTERN.matcher(value);
+    if (!matcher.find()) {
+      return value;
+    }
+
+    matcher.reset();
+    final var result = new StringBuilder();
+    while (matcher.find()) {
+      final var expression = matcher.group(1);
+      final var resolved = resolveExpression(expression);
+      matcher.appendReplacement(result, Matcher.quoteReplacement(resolved));
+    }
+    matcher.appendTail(result);
+    return result.toString();
+  }
+
+  /**
+   * Resolves a single expression (without the {@code ${}} wrapper).
+   *
+   * @param expression the expression to resolve
+   * @return the resolved value
+   */
+  private String resolveExpression(final String expression) {
+    if (expression.startsWith("sequence")) {
+      return resolveSequence(expression);
+    }
+    if ("uuid".equals(expression)) {
+      return UUID.randomUUID().toString();
+    }
+    if ("now".equals(expression)) {
+      return LocalDateTime.now(ZoneId.systemDefault()).format(ISO_FORMATTER);
+    }
+    if (expression.startsWith("now")) {
+      return resolveRelativeDateTime(expression);
+    }
+    if (expression.startsWith("faker.")) {
+      return resolveFaker(expression);
+    }
+    logger.debug("Unrecognized template expression: {}", expression);
+    return String.format("${%s}", expression);
+  }
+
+  /**
+   * Resolves a sequence expression.
+   *
+   * <p>{@code ${sequence:N}} sets the counter to N and returns N. {@code ${sequence}} increments
+   * the counter and returns the next value.
+   *
+   * @param expression the sequence expression
+   * @return the resolved sequence number as a string
+   */
+  private String resolveSequence(final String expression) {
+    if (expression.contains(":")) {
+      final var parts = expression.split(":", 2);
+      final var startValue = Integer.parseInt(parts[1].trim());
+      sequenceCounter.set(startValue);
+      return String.valueOf(startValue);
+    }
+    return String.valueOf(sequenceCounter.incrementAndGet());
+  }
+
+  /**
+   * Resolves a relative date/time expression.
+   *
+   * <p>Supports formats like {@code now-7d}, {@code now+1h}, {@code now-30m}, {@code now+10s}.
+   *
+   * @param expression the relative date/time expression
+   * @return the resolved date/time as an ISO-8601 string
+   */
+  private String resolveRelativeDateTime(final String expression) {
+    final var matcher = RELATIVE_TIME_PATTERN.matcher(expression);
+    if (!matcher.matches()) {
+      logger.debug("Invalid relative date/time expression: {}", expression);
+      return String.format("${%s}", expression);
+    }
+
+    final var sign = matcher.group(1);
+    final var amount = Long.parseLong(matcher.group(2));
+    final var unit = matcher.group(3);
+    final var signedAmount = "+".equals(sign) ? amount : -amount;
+
+    final var now = LocalDateTime.now(ZoneId.systemDefault());
+    final var resolved =
+        switch (unit) {
+          case "d" -> now.plusDays(signedAmount);
+          case "h" -> now.plusHours(signedAmount);
+          case "m" -> now.plusMinutes(signedAmount);
+          case "s" -> now.plusSeconds(signedAmount);
+          default -> now;
+        };
+    return resolved.format(ISO_FORMATTER);
+  }
+
+  /**
+   * Resolves a Datafaker expression via reflection.
+   *
+   * <p>Expressions like {@code faker.name.fullName} are resolved by chaining method calls on the
+   * Faker instance: {@code faker.name().fullName()}. If Datafaker is not on the classpath or
+   * resolution fails, the original expression is returned unchanged.
+   *
+   * @param expression the Faker expression (e.g., {@code faker.name.fullName})
+   * @return the generated value, or the original expression if resolution fails
+   */
+  private String resolveFaker(final String expression) {
+    if (faker == null) {
+      logger.debug(
+          "Datafaker not available on classpath; returning expression unchanged: {}", expression);
+      return String.format("${%s}", expression);
+    }
+
+    final var path = expression.substring("faker.".length());
+    final var parts = path.split("\\.", -1);
+
+    try {
+      Object current = faker;
+      for (final var part : parts) {
+        final var method = findMethod(current.getClass(), part);
+        if (method == null) {
+          logger.debug("Faker method not found: {} on {}", part, current.getClass().getName());
+          return String.format("${%s}", expression);
+        }
+        current = method.invoke(current);
+        if (current == null) {
+          return String.format("${%s}", expression);
+        }
+      }
+      return String.valueOf(current);
+    } catch (final ReflectiveOperationException e) {
+      logger.debug("Failed to resolve Faker expression: {}", expression, e);
+      return String.format("${%s}", expression);
+    }
+  }
+
+  /**
+   * Finds a no-argument method by name on the given class.
+   *
+   * @param clazz the class to search
+   * @param methodName the method name
+   * @return the method, or null if not found
+   */
+  private static @Nullable Method findMethod(final Class<?> clazz, final String methodName) {
+    try {
+      return clazz.getMethod(methodName);
+    } catch (final NoSuchMethodException e) {
+      return null;
+    }
+  }
+
+  /**
+   * Attempts to load the Datafaker {@code Faker} class via reflection.
+   *
+   * @return a Faker instance, or null if Datafaker is not on the classpath
+   */
+  private static @Nullable Object loadFaker() {
+    try {
+      final var fakerClass = Class.forName("net.datafaker.Faker");
+      return fakerClass.getDeclaredConstructor().newInstance();
+    } catch (final ReflectiveOperationException e) {
+      logger.debug("Datafaker not found on classpath; faker expressions will not be resolved");
+      return null;
+    }
+  }
+}

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/template/package-info.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/template/package-info.java
@@ -1,0 +1,11 @@
+/**
+ * Template expression processing for dynamic test data generation.
+ *
+ * <p>This package provides template expression resolution for CSV values. Expressions use the
+ * {@code ${...}} syntax and support sequence numbers, UUIDs, date/time values, and optional
+ * Datafaker integration for realistic test data.
+ */
+@NullMarked
+package io.github.seijikohara.dbtester.internal.template;
+
+import org.jspecify.annotations.NullMarked;

--- a/db-tester-core/src/main/java/module-info.java
+++ b/db-tester-core/src/main/java/module-info.java
@@ -12,6 +12,7 @@ module io.github.seijikohara.dbtester.core {
   requires transitive java.sql;
   requires transitive org.jspecify;
   requires static org.slf4j;
+  requires static net.datafaker;
   requires com.fasterxml.jackson.core;
   requires com.fasterxml.jackson.databind;
   requires com.fasterxml.jackson.dataformat.csv;

--- a/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/template/TemplateProcessorTest.java
+++ b/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/template/TemplateProcessorTest.java
@@ -1,0 +1,453 @@
+package io.github.seijikohara.dbtester.internal.template;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link TemplateProcessor}. */
+@DisplayName("TemplateProcessor")
+class TemplateProcessorTest {
+
+  /** Tests for the TemplateProcessor class. */
+  TemplateProcessorTest() {}
+
+  /** The processor instance under test. */
+  private TemplateProcessor processor;
+
+  /** Sets up test fixtures before each test. */
+  @BeforeEach
+  void setUp() {
+    processor = new TemplateProcessor();
+  }
+
+  /** Tests for the containsExpression() method. */
+  @Nested
+  @DisplayName("containsExpression(String) method")
+  class ContainsExpressionMethod {
+
+    /** Tests for the containsExpression method. */
+    ContainsExpressionMethod() {}
+
+    /** Verifies that containsExpression returns true when value contains expression. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return true when value contains expression")
+    void shouldReturnTrue_whenValueContainsExpression() {
+      // When
+      final var result = TemplateProcessor.containsExpression("${uuid}");
+
+      // Then
+      assertTrue(result, "should detect expression in value");
+    }
+
+    /** Verifies that containsExpression returns false when value has no expression. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return false when value has no expression")
+    void shouldReturnFalse_whenValueHasNoExpression() {
+      // When
+      final var result = TemplateProcessor.containsExpression("plain text");
+
+      // Then
+      assertFalse(result, "should not detect expression in plain text");
+    }
+
+    /** Verifies that containsExpression returns true when value has embedded expression. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return true when value has embedded expression")
+    void shouldReturnTrue_whenValueHasEmbeddedExpression() {
+      // When
+      final var result = TemplateProcessor.containsExpression("prefix-${uuid}-suffix");
+
+      // Then
+      assertTrue(result, "should detect embedded expression");
+    }
+  }
+
+  /** Tests for the process() method with plain values. */
+  @Nested
+  @DisplayName("process(String) method - plain values")
+  class ProcessPlainValuesMethod {
+
+    /** Tests for process method with plain values. */
+    ProcessPlainValuesMethod() {}
+
+    /** Verifies that process returns value unchanged when no expression present. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return value unchanged when no expression present")
+    void shouldReturnValueUnchanged_whenNoExpressionPresent() {
+      // When
+      final var result = processor.process("plain text");
+
+      // Then
+      assertEquals("plain text", result, "should return plain text unchanged");
+    }
+
+    /** Verifies that process returns empty string unchanged. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should return empty string unchanged")
+    void shouldReturnEmptyStringUnchanged() {
+      // When
+      final var result = processor.process("");
+
+      // Then
+      assertEquals("", result, "should return empty string unchanged");
+    }
+
+    /** Verifies that process returns unrecognized expression unchanged. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should return unrecognized expression unchanged")
+    void shouldReturnUnrecognizedExpressionUnchanged() {
+      // When
+      final var result = processor.process("${unknown}");
+
+      // Then
+      assertEquals("${unknown}", result, "should return unrecognized expression unchanged");
+    }
+  }
+
+  /** Tests for the process() method with sequence expressions. */
+  @Nested
+  @DisplayName("process(String) method - sequence expressions")
+  class ProcessSequenceMethod {
+
+    /** Tests for process method with sequence expressions. */
+    ProcessSequenceMethod() {}
+
+    /** Verifies that process resolves sequence with start value. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should resolve sequence with start value")
+    void shouldResolveSequence_whenStartValueProvided() {
+      // When
+      final var result = processor.process("${sequence:1}");
+
+      // Then
+      assertEquals("1", result, "should resolve sequence to start value");
+    }
+
+    /** Verifies that process auto-increments sequence after initial value. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should auto-increment sequence after initial value")
+    void shouldAutoIncrementSequence_afterInitialValue() {
+      // Given
+      processor.process("${sequence:1}");
+
+      // When
+      final var second = processor.process("${sequence}");
+      final var third = processor.process("${sequence}");
+
+      // Then
+      assertAll(
+          "sequence should auto-increment",
+          () -> assertEquals("2", second, "second call should return 2"),
+          () -> assertEquals("3", third, "third call should return 3"));
+    }
+
+    /** Verifies that process resolves sequence with custom start value. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should resolve sequence with custom start value")
+    void shouldResolveSequence_whenCustomStartValueProvided() {
+      // When
+      final var result = processor.process("${sequence:100}");
+      final var next = processor.process("${sequence}");
+
+      // Then
+      assertAll(
+          "sequence should start from custom value",
+          () -> assertEquals("100", result, "should start at 100"),
+          () -> assertEquals("101", next, "should increment to 101"));
+    }
+
+    /** Verifies that process resolves sequence embedded in text. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should resolve sequence embedded in text")
+    void shouldResolveSequence_whenEmbeddedInText() {
+      // Given
+      processor.process("${sequence:1}");
+
+      // When
+      final var result = processor.process("ID-${sequence}");
+
+      // Then
+      assertEquals("ID-2", result, "should resolve sequence within text");
+    }
+  }
+
+  /** Tests for the process() method with UUID expressions. */
+  @Nested
+  @DisplayName("process(String) method - UUID expressions")
+  class ProcessUuidMethod {
+
+    /** Tests for process method with UUID expressions. */
+    ProcessUuidMethod() {}
+
+    /** Verifies that process generates valid UUID. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should generate valid UUID")
+    void shouldGenerateValidUuid() {
+      // When
+      final var result = processor.process("${uuid}");
+
+      // Then
+      assertAll(
+          "should generate valid UUID",
+          () -> assertNotNull(result, "result should not be null"),
+          () -> assertNotNull(UUID.fromString(result), "should be parseable as UUID"));
+    }
+
+    /** Verifies that process generates unique UUIDs for each call. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should generate unique UUIDs for each call")
+    void shouldGenerateUniqueUuids_forEachCall() {
+      // When
+      final var first = processor.process("${uuid}");
+      final var second = processor.process("${uuid}");
+
+      // Then
+      assertFalse(first.equals(second), "UUIDs should be unique");
+    }
+  }
+
+  /** Tests for the process() method with date/time expressions. */
+  @Nested
+  @DisplayName("process(String) method - date/time expressions")
+  class ProcessDateTimeMethod {
+
+    /** Tests for process method with date/time expressions. */
+    ProcessDateTimeMethod() {}
+
+    /** Verifies that process resolves now to current date/time. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should resolve now to current date/time")
+    void shouldResolveNow_toCurrentDateTime() {
+      // Given
+      final var before = LocalDateTime.now(ZoneId.systemDefault());
+
+      // When
+      final var result = processor.process("${now}");
+
+      // Then
+      final var parsed = LocalDateTime.parse(result, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+      final var after = LocalDateTime.now(ZoneId.systemDefault());
+      assertAll(
+          "should resolve to current date/time",
+          () -> assertNotNull(parsed, "should be parseable as LocalDateTime"),
+          () ->
+              assertFalse(
+                  parsed.isBefore(before.minusSeconds(1)), "should not be before test start"),
+          () -> assertFalse(parsed.isAfter(after.plusSeconds(1)), "should not be after test end"));
+    }
+
+    /** Verifies that process resolves relative date/time with days. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should resolve relative date/time with days")
+    void shouldResolveRelativeDateTime_withDays() {
+      // Given
+      final var expectedApprox = LocalDateTime.now(ZoneId.systemDefault()).minusDays(7);
+
+      // When
+      final var result = processor.process("${now-7d}");
+
+      // Then
+      final var parsed = LocalDateTime.parse(result, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+      assertAll(
+          "should resolve to 7 days ago",
+          () -> assertNotNull(parsed, "should be parseable"),
+          () ->
+              assertTrue(
+                  Math.abs(Duration.between(expectedApprox, parsed).toSeconds()) < 5,
+                  "should be approximately 7 days ago"));
+    }
+
+    /** Verifies that process resolves relative date/time with hours. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should resolve relative date/time with hours")
+    void shouldResolveRelativeDateTime_withHours() {
+      // Given
+      final var expectedApprox = LocalDateTime.now(ZoneId.systemDefault()).plusHours(2);
+
+      // When
+      final var result = processor.process("${now+2h}");
+
+      // Then
+      final var parsed = LocalDateTime.parse(result, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+      assertTrue(
+          Math.abs(Duration.between(expectedApprox, parsed).toSeconds()) < 5,
+          "should be approximately 2 hours ahead");
+    }
+
+    /** Verifies that process resolves relative date/time with minutes. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should resolve relative date/time with minutes")
+    void shouldResolveRelativeDateTime_withMinutes() {
+      // Given
+      final var expectedApprox = LocalDateTime.now(ZoneId.systemDefault()).minusMinutes(30);
+
+      // When
+      final var result = processor.process("${now-30m}");
+
+      // Then
+      final var parsed = LocalDateTime.parse(result, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+      assertTrue(
+          Math.abs(Duration.between(expectedApprox, parsed).toSeconds()) < 5,
+          "should be approximately 30 minutes ago");
+    }
+
+    /** Verifies that process resolves relative date/time with seconds. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should resolve relative date/time with seconds")
+    void shouldResolveRelativeDateTime_withSeconds() {
+      // Given
+      final var expectedApprox = LocalDateTime.now(ZoneId.systemDefault()).plusSeconds(10);
+
+      // When
+      final var result = processor.process("${now+10s}");
+
+      // Then
+      final var parsed = LocalDateTime.parse(result, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+      assertTrue(
+          Math.abs(Duration.between(expectedApprox, parsed).toSeconds()) < 5,
+          "should be approximately 10 seconds ahead");
+    }
+
+    /** Verifies that process returns invalid relative expression unchanged. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should return invalid relative expression unchanged")
+    void shouldReturnInvalidRelativeExpressionUnchanged() {
+      // When
+      final var result = processor.process("${now-abc}");
+
+      // Then
+      assertEquals("${now-abc}", result, "should return invalid expression unchanged");
+    }
+  }
+
+  /** Tests for the process() method with Faker expressions. */
+  @Nested
+  @DisplayName("process(String) method - Faker expressions")
+  class ProcessFakerMethod {
+
+    /** Tests for process method with Faker expressions. */
+    ProcessFakerMethod() {}
+
+    /** Verifies that process resolves faker name expression. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should resolve faker name expression")
+    void shouldResolveFakerNameExpression() {
+      // When
+      final var result = processor.process("${faker.name.fullName}");
+
+      // Then
+      assertAll(
+          "should resolve to a non-empty name",
+          () -> assertNotNull(result, "result should not be null"),
+          () -> assertFalse(result.isEmpty(), "result should not be empty"),
+          () ->
+              assertFalse(
+                  result.startsWith("${"), "result should not contain unresolved expression"));
+    }
+
+    /** Verifies that process resolves faker internet expression. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should resolve faker internet expression")
+    void shouldResolveFakerInternetExpression() {
+      // When
+      final var result = processor.process("${faker.internet.emailAddress}");
+
+      // Then
+      assertAll(
+          "should resolve to an email-like string",
+          () -> assertNotNull(result, "result should not be null"),
+          () -> assertTrue(result.contains("@"), "result should contain @ symbol"));
+    }
+
+    /** Verifies that process returns unknown faker method unchanged. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should return unknown faker method unchanged")
+    void shouldReturnUnknownFakerMethodUnchanged() {
+      // When
+      final var result = processor.process("${faker.nonexistent.method}");
+
+      // Then
+      assertEquals(
+          "${faker.nonexistent.method}",
+          result,
+          "should return unknown faker expression unchanged");
+    }
+  }
+
+  /** Tests for the process() method with multiple expressions. */
+  @Nested
+  @DisplayName("process(String) method - multiple expressions")
+  class ProcessMultipleExpressionsMethod {
+
+    /** Tests for process method with multiple expressions. */
+    ProcessMultipleExpressionsMethod() {}
+
+    /** Verifies that process resolves multiple expressions in one value. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should resolve multiple expressions in one value")
+    void shouldResolveMultipleExpressions_inOneValue() {
+      // Given
+      processor.process("${sequence:1}");
+
+      // When
+      final var result = processor.process("${sequence}-${uuid}");
+
+      // Then
+      final var parts = result.split("-", 2);
+      assertAll(
+          "should resolve both expressions",
+          () -> assertEquals("2", parts[0], "first part should be sequence value"),
+          () -> assertNotNull(UUID.fromString(parts[1]), "second part should be valid UUID"));
+    }
+
+    /** Verifies that process handles mixed plain text and expressions. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should handle mixed plain text and expressions")
+    void shouldHandleMixedPlainTextAndExpressions() {
+      // Given
+      processor.process("${sequence:10}");
+
+      // When
+      final var result = processor.process("user_${sequence}@example.com");
+
+      // Then
+      assertEquals("user_11@example.com", result, "should resolve expression within plain text");
+    }
+  }
+}

--- a/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/template/package-info.java
+++ b/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/template/package-info.java
@@ -1,0 +1,5 @@
+/** Unit tests for the template expression processing package. */
+@NullMarked
+package io.github.seijikohara.dbtester.internal.template;
+
+import org.jspecify.annotations.NullMarked;

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 axion-release = "1.21.1"
 checker-qual = "3.53.0"
+datafaker = "2.4.2"
 derby = "10.17.1.0"
 dokka = "2.1.0"
 errorprone = "2.46.0"
@@ -33,6 +34,7 @@ version-catalog-update = "1.0.1"
 
 [libraries]
 checker-qual = { module = "org.checkerframework:checker-qual", version.ref = "checker-qual" }
+datafaker = { module = "net.datafaker:datafaker", version.ref = "datafaker" }
 derby-client = { module = "org.apache.derby:derbyclient", version.ref = "derby" }
 derby-embedded = { module = "org.apache.derby:derby", version.ref = "derby" }
 derby-tools = { module = "org.apache.derby:derbytools", version.ref = "derby" }


### PR DESCRIPTION
## Summary

- Add `TemplateProcessor` class that resolves `${...}` template expressions in CSV cell values
- Support five expression types: `${sequence:N}`, `${uuid}`, `${now}`, `${now±Xd/h/m/s}`, and `${faker.xxx.yyy}`
- Integrate template processing into `DelimitedParser` for automatic resolution during CSV/TSV parsing
- Add Datafaker as optional `compileOnly` dependency with reflection-based integration

### Expression Types

| Expression | Description | Example Output |
|------------|-------------|----------------|
| `${sequence:N}` | Sequence starting from N | `1`, `2`, `3` |
| `${sequence}` | Auto-increment next | `2`, `3`, `4` |
| `${uuid}` | Random UUID | `550e8400-e29b-...` |
| `${now}` | Current date/time (ISO-8601) | `2026-02-08T15:30:00` |
| `${now-7d}` | Relative date/time | 7 days ago |
| `${faker.name.fullName}` | Datafaker expression | `John Smith` |

### Design Decisions

- Datafaker is `compileOnly` — users opt in by adding it to their classpath
- When Datafaker is absent, `${faker.xxx}` expressions are returned unchanged (graceful degradation)
- `TemplateProcessor` is created per table parse to maintain independent sequence state
- Reflection-based Faker integration avoids hard compile-time dependency

### Files Changed

| File | Change |
|------|--------|
| `gradle/libs.versions.toml` | Add Datafaker version catalog entry |
| `db-tester-core/build.gradle.kts` | Add `compileOnly` and test dependency |
| `module-info.java` | Add `requires static net.datafaker` |
| `TemplateProcessor.java` | **New** — expression resolution engine |
| `package-info.java` (template) | **New** — `@NullMarked` package |
| `DelimitedParser.java` | Integrate TemplateProcessor into parsing |
| `TemplateProcessorTest.java` | **New** — 22 tests covering all expression types |

## Test plan

- [x] TemplateProcessor unit tests (sequence, UUID, date/time, Faker, multiple expressions)
- [x] Existing DelimitedParser tests pass unchanged
- [x] All db-tester-core tests pass
- [x] JaCoCo coverage verification passes
- [x] spotlessApply + checkstyle + Error Prone pass

Closes #130