### PR TITLE
fix(core): add template expression processing to JSON/YAML parser

### DIFF
--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/format/parser/StructuredFormatParser.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/format/parser/StructuredFormatParser.java
@@ -12,6 +12,7 @@ import io.github.seijikohara.dbtester.api.exception.DataSetLoadException;
 import io.github.seijikohara.dbtester.internal.dataset.SimpleRow;
 import io.github.seijikohara.dbtester.internal.dataset.SimpleTable;
 import io.github.seijikohara.dbtester.internal.dataset.SimpleTableSet;
+import io.github.seijikohara.dbtester.internal.template.TemplateProcessor;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -34,6 +35,10 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Column order is determined by the first row's key order. Null values in JSON/YAML are
  * converted to {@link CellValue#NULL}. All non-null values are converted to strings.
+ *
+ * <p>Template expressions ({@code ${uuid}}, {@code ${sequence}}, {@code ${now}}, {@code
+ * ${faker.*}}) in cell values are resolved during parsing, consistent with the behavior of {@link
+ * DelimitedParser} for CSV/TSV formats.
  *
  * <p>This class is stateless and thread-safe. Instances can be safely shared between threads.
  *
@@ -143,8 +148,12 @@ public final class StructuredFormatParser {
       // Determine column order from the first row
       final var columnNames = extractColumnNames(rawRows.getFirst());
 
-      // Convert all rows
-      final var rows = rawRows.stream().map(rawRow -> createRow(columnNames, rawRow)).toList();
+      // Convert all rows with template expression processing
+      final var templateProcessor = new TemplateProcessor();
+      final var rows =
+          rawRows.stream()
+              .map(rawRow -> createRow(columnNames, rawRow, templateProcessor))
+              .toList();
 
       logger.debug(
           "Parsed table {} with {} columns and {} rows",
@@ -186,14 +195,18 @@ public final class StructuredFormatParser {
    *
    * @param columnNames the column names
    * @param rawRow the raw row map from JSON/YAML
+   * @param templateProcessor the template processor for resolving expressions
    * @return the created row
    */
-  private Row createRow(final List<ColumnName> columnNames, final Map<String, Object> rawRow) {
+  private Row createRow(
+      final List<ColumnName> columnNames,
+      final Map<String, Object> rawRow,
+      final TemplateProcessor templateProcessor) {
     final var rowValues = new LinkedHashMap<ColumnName, CellValue>();
 
     for (final var columnName : columnNames) {
       final var rawValue = rawRow.get(columnName.value());
-      rowValues.put(columnName, toCellValue(rawValue));
+      rowValues.put(columnName, toCellValue(rawValue, templateProcessor));
     }
 
     return new SimpleRow(rowValues);
@@ -203,15 +216,19 @@ public final class StructuredFormatParser {
    * Converts a raw object value to a CellValue.
    *
    * <p>Null values are converted to {@link CellValue#NULL}. All non-null values are converted to
-   * their string representation.
+   * their string representation. Template expressions ({@code ${...}}) are resolved before creating
+   * the CellValue.
    *
    * @param rawValue the raw object value
+   * @param templateProcessor the template processor for resolving expressions
    * @return the CellValue
    */
-  private CellValue toCellValue(final @Nullable Object rawValue) {
+  private CellValue toCellValue(
+      final @Nullable Object rawValue, final TemplateProcessor templateProcessor) {
     if (rawValue == null) {
       return CellValue.NULL;
     }
-    return new CellValue(rawValue.toString());
+    final var stringValue = rawValue.toString();
+    return new CellValue(templateProcessor.process(stringValue));
   }
 }

--- a/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/format/json/JsonFormatProviderTest.java
+++ b/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/format/json/JsonFormatProviderTest.java
@@ -2,6 +2,7 @@ package io.github.seijikohara.dbtester.internal.format.json;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -319,6 +320,149 @@ class JsonFormatProviderTest {
           DataSetLoadException.class,
           () -> provider.parse(file),
           "should throw DataSetLoadException when path is a file");
+    }
+  }
+
+  /** Tests for template expression processing. */
+  @Nested
+  @DisplayName("template expression processing")
+  class TemplateExpressionProcessing {
+
+    /** Tests for template expression processing. */
+    TemplateExpressionProcessing() {}
+
+    /**
+     * Verifies that parse resolves UUID template expressions.
+     *
+     * @param tempDir temporary directory for test files
+     * @throws IOException if file operations fail
+     */
+    @Test
+    @Tag("normal")
+    @DisplayName("should resolve UUID template expression when ${uuid} is used")
+    void shouldResolveUuidExpression_whenUuidTemplateUsed(final @TempDir Path tempDir)
+        throws IOException {
+      // Given
+      createJsonFile(
+          tempDir,
+          "users.json",
+          """
+          [
+            {"ID": "${uuid}", "NAME": "John"}
+          ]
+          """);
+
+      // When
+      final var result = provider.parse(tempDir);
+
+      // Then
+      final var table = result.getTables().getFirst();
+      final var row = table.getRows().getFirst();
+      final var idString = (String) row.getValue(new ColumnName("ID")).value();
+
+      assertAll(
+          "UUID expression should be resolved",
+          () -> assertNotNull(idString, "ID value should not be null"),
+          () ->
+              assertFalse(
+                  idString != null && idString.contains("${uuid}"),
+                  "should not contain template expression"),
+          () ->
+              assertTrue(
+                  idString != null
+                      && idString.matches(
+                          "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"),
+                  "should be a valid UUID format"));
+    }
+
+    /**
+     * Verifies that parse resolves sequence template expressions.
+     *
+     * @param tempDir temporary directory for test files
+     * @throws IOException if file operations fail
+     */
+    @Test
+    @Tag("normal")
+    @DisplayName("should resolve sequence template expression when ${sequence} is used")
+    void shouldResolveSequenceExpression_whenSequenceTemplateUsed(final @TempDir Path tempDir)
+        throws IOException {
+      // Given
+      createJsonFile(
+          tempDir,
+          "users.json",
+          """
+          [
+            {"ID": "${sequence}", "NAME": "Alice"},
+            {"ID": "${sequence}", "NAME": "Bob"}
+          ]
+          """);
+
+      // When
+      final var result = provider.parse(tempDir);
+
+      // Then
+      final var table = result.getTables().getFirst();
+      final var rows = table.getRows();
+
+      assertAll(
+          "sequence expressions should be resolved incrementally",
+          () ->
+              assertEquals(
+                  "1",
+                  rows.getFirst().getValue(new ColumnName("ID")).value(),
+                  "first row should have sequence value 1"),
+          () ->
+              assertEquals(
+                  "2",
+                  rows.get(1).getValue(new ColumnName("ID")).value(),
+                  "second row should have sequence value 2"));
+    }
+
+    /**
+     * Verifies that parse passes through numeric values without modification.
+     *
+     * @param tempDir temporary directory for test files
+     * @throws IOException if file operations fail
+     */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should pass through numeric values when no template expression present")
+    void shouldPassThroughNumericValues_whenNoTemplateExpression(final @TempDir Path tempDir)
+        throws IOException {
+      // Given
+      createJsonFile(
+          tempDir,
+          "products.json",
+          """
+          [
+            {"ID": 42, "PRICE": 99.99, "NAME": "${uuid}"}
+          ]
+          """);
+
+      // When
+      final var result = provider.parse(tempDir);
+
+      // Then
+      final var table = result.getTables().getFirst();
+      final var row = table.getRows().getFirst();
+      final var nameString = (String) row.getValue(new ColumnName("NAME")).value();
+
+      assertAll(
+          "numeric values should be passed through unchanged",
+          () ->
+              assertEquals(
+                  "42",
+                  row.getValue(new ColumnName("ID")).value(),
+                  "integer should be converted to string"),
+          () ->
+              assertEquals(
+                  "99.99",
+                  row.getValue(new ColumnName("PRICE")).value(),
+                  "decimal should be converted to string"),
+          () ->
+              assertFalse(
+                  nameString != null && nameString.contains("${uuid}"),
+                  "UUID template should be resolved"));
     }
   }
 

--- a/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/format/yaml/YamlFormatProviderTest.java
+++ b/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/format/yaml/YamlFormatProviderTest.java
@@ -2,6 +2,7 @@ package io.github.seijikohara.dbtester.internal.format.yaml;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -396,6 +397,148 @@ class YamlFormatProviderTest {
           DataSetLoadException.class,
           () -> provider.parse(file),
           "should throw DataSetLoadException when path is a file");
+    }
+  }
+
+  /** Tests for template expression processing. */
+  @Nested
+  @DisplayName("template expression processing")
+  class TemplateExpressionProcessing {
+
+    /** Tests for template expression processing. */
+    TemplateExpressionProcessing() {}
+
+    /**
+     * Verifies that parse resolves UUID template expressions.
+     *
+     * @param tempDir temporary directory for test files
+     * @throws IOException if file operations fail
+     */
+    @Test
+    @Tag("normal")
+    @DisplayName("should resolve UUID template expression when ${uuid} is used")
+    void shouldResolveUuidExpression_whenUuidTemplateUsed(final @TempDir Path tempDir)
+        throws IOException {
+      // Given
+      createYamlFile(
+          tempDir,
+          "users.yaml",
+          """
+          - ID: "${uuid}"
+            NAME: John
+          """);
+
+      // When
+      final var result = provider.parse(tempDir);
+
+      // Then
+      final var table = result.getTables().getFirst();
+      final var row = table.getRows().getFirst();
+      final var idString = (String) row.getValue(new ColumnName("ID")).value();
+
+      assertAll(
+          "UUID expression should be resolved",
+          () -> assertNotNull(idString, "ID value should not be null"),
+          () ->
+              assertFalse(
+                  idString != null && idString.contains("${uuid}"),
+                  "should not contain template expression"),
+          () ->
+              assertTrue(
+                  idString != null
+                      && idString.matches(
+                          "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"),
+                  "should be a valid UUID format"));
+    }
+
+    /**
+     * Verifies that parse resolves sequence template expressions.
+     *
+     * @param tempDir temporary directory for test files
+     * @throws IOException if file operations fail
+     */
+    @Test
+    @Tag("normal")
+    @DisplayName("should resolve sequence template expression when ${sequence} is used")
+    void shouldResolveSequenceExpression_whenSequenceTemplateUsed(final @TempDir Path tempDir)
+        throws IOException {
+      // Given
+      createYamlFile(
+          tempDir,
+          "users.yaml",
+          """
+          - ID: "${sequence}"
+            NAME: Alice
+          - ID: "${sequence}"
+            NAME: Bob
+          """);
+
+      // When
+      final var result = provider.parse(tempDir);
+
+      // Then
+      final var table = result.getTables().getFirst();
+      final var rows = table.getRows();
+
+      assertAll(
+          "sequence expressions should be resolved incrementally",
+          () ->
+              assertEquals(
+                  "1",
+                  rows.getFirst().getValue(new ColumnName("ID")).value(),
+                  "first row should have sequence value 1"),
+          () ->
+              assertEquals(
+                  "2",
+                  rows.get(1).getValue(new ColumnName("ID")).value(),
+                  "second row should have sequence value 2"));
+    }
+
+    /**
+     * Verifies that parse passes through numeric values without modification.
+     *
+     * @param tempDir temporary directory for test files
+     * @throws IOException if file operations fail
+     */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should pass through numeric values when no template expression present")
+    void shouldPassThroughNumericValues_whenNoTemplateExpression(final @TempDir Path tempDir)
+        throws IOException {
+      // Given
+      createYamlFile(
+          tempDir,
+          "products.yaml",
+          """
+          - ID: 42
+            PRICE: 99.99
+            NAME: "${uuid}"
+          """);
+
+      // When
+      final var result = provider.parse(tempDir);
+
+      // Then
+      final var table = result.getTables().getFirst();
+      final var row = table.getRows().getFirst();
+      final var nameString = (String) row.getValue(new ColumnName("NAME")).value();
+
+      assertAll(
+          "numeric values should be passed through unchanged",
+          () ->
+              assertEquals(
+                  "42",
+                  row.getValue(new ColumnName("ID")).value(),
+                  "integer should be converted to string"),
+          () ->
+              assertEquals(
+                  "99.99",
+                  row.getValue(new ColumnName("PRICE")).value(),
+                  "decimal should be converted to string"),
+          () ->
+              assertFalse(
+                  nameString != null && nameString.contains("${uuid}"),
+                  "UUID template should be resolved"));
     }
   }
 


### PR DESCRIPTION
## Summary
- `StructuredFormatParser` (JSON/YAML) did not process template expressions (`${uuid}`, `${sequence}`, `${now}`, `${faker.*}`), causing them to be inserted as literal strings
- Integrated `TemplateProcessor` into `StructuredFormatParser.parseFile()`, `createRow()`, and `toCellValue()` methods, aligning behavior with `DelimitedParser` (CSV/TSV)
- Added template expression tests to both `JsonFormatProviderTest` and `YamlFormatProviderTest`

## Test plan
- [x] UUID template expression resolution in JSON
- [x] Sequence template expression resolution in JSON
- [x] Numeric value passthrough in JSON
- [x] UUID template expression resolution in YAML
- [x] Sequence template expression resolution in YAML
- [x] Numeric value passthrough in YAML
- [x] All existing tests pass

Closes #146