### PR TITLE
docs(specs): add JSON/YAML examples for empty scenario value behavior

### DIFF
--- a/docs/specs/data-formats.md
+++ b/docs/specs/data-formats.md
@@ -196,6 +196,10 @@ For test method `testCreate`, the framework filters to rows with `id` 1 and 2.
 
 Rows with empty, blank, or null scenario values are always included regardless of the active scenario filter. This applies to all formats (CSV, TSV, JSON, YAML).
 
+This behavior is useful for common reference data that every scenario requires.
+
+#### CSV
+
 ```csv
 [Scenario],id,name
 testCreate,1,Alice
@@ -203,12 +207,34 @@ testCreate,1,Alice
 testCreate,3,Charlie
 ```
 
-For test method `testCreate`, rows 1, 2, and 3 are all included:
+#### JSON
+
+```json
+[
+  {"[Scenario]": "testCreate", "id": 1, "name": "Alice"},
+  {"[Scenario]": "", "id": 2, "name": "Bob"},
+  {"[Scenario]": "testCreate", "id": 3, "name": "Charlie"}
+]
+```
+
+#### YAML
+
+```yaml
+- "[Scenario]": testCreate
+  id: 1
+  name: Alice
+- "[Scenario]": ""
+  id: 2
+  name: Bob
+- "[Scenario]": testCreate
+  id: 3
+  name: Charlie
+```
+
+For test method `testCreate`, rows 1, 2, and 3 are all included in every format:
 
 - Row 1 and 3: match the scenario name `testCreate`
 - Row 2: included because the scenario value is empty (shared data)
-
-This behavior is useful for common reference data that every scenario requires.
 
 ## Special Values
 

--- a/docs/specs/ja/data-formats.md
+++ b/docs/specs/ja/data-formats.md
@@ -198,6 +198,10 @@ void testMultipleScenarios() { }
 
 シナリオ値が空、空白、またはnullの行は、アクティブなシナリオフィルターに関係なく常に含まれます。これはすべてのフォーマット（CSV、TSV、JSON、YAML）に適用されます。
 
+この動作は、すべてのシナリオで必要な共通参照データに有用です。
+
+#### CSV
+
 ```csv
 [Scenario],id,name
 testCreate,1,Alice
@@ -205,12 +209,34 @@ testCreate,1,Alice
 testCreate,3,Charlie
 ```
 
-テストメソッド`testCreate`の場合、行1、2、3がすべて含まれます:
+#### JSON
+
+```json
+[
+  {"[Scenario]": "testCreate", "id": 1, "name": "Alice"},
+  {"[Scenario]": "", "id": 2, "name": "Bob"},
+  {"[Scenario]": "testCreate", "id": 3, "name": "Charlie"}
+]
+```
+
+#### YAML
+
+```yaml
+- "[Scenario]": testCreate
+  id: 1
+  name: Alice
+- "[Scenario]": ""
+  id: 2
+  name: Bob
+- "[Scenario]": testCreate
+  id: 3
+  name: Charlie
+```
+
+テストメソッド`testCreate`の場合、すべてのフォーマットで行1、2、3がすべて含まれます:
 
 - 行1と3: シナリオ名`testCreate`に一致
 - 行2: シナリオ値が空のため含まれる（共有データ）
-
-この動作は、すべてのシナリオで必要な共通参照データに有用です。
 
 ## 特殊値
 


### PR DESCRIPTION
## Summary
- Add concrete JSON and YAML examples to the "Empty Scenario Values" section in data format specifications
- Previously only a CSV example was provided, making the behavior unclear for JSON/YAML users
- Updated both English (`docs/specs/data-formats.md`) and Japanese (`docs/specs/ja/data-formats.md`) versions

## Test plan
- [ ] Verify examples render correctly in VitePress
- [ ] Confirm JSON/YAML examples match the documented ScenarioFilter behavior