### PR TITLE
feat(api): add UNSET constants and validate sentinel values in annotations

### DIFF
--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/annotation/DataSet.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/annotation/DataSet.java
@@ -28,6 +28,9 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface DataSet {
 
+  /** Sentinel value indicating that the global setting should be used. */
+  int UNSET = -1;
+
   /**
    * Lists the dataset sources that must be executed before the test.
    *
@@ -60,14 +63,16 @@ public @interface DataSet {
   /**
    * Specifies the number of rows per batch for INSERT operations.
    *
-   * <p>When set to a positive value, the executor flushes the JDBC batch every N rows instead of
-   * accumulating all rows before execution. This reduces memory usage for large datasets.
+   * <p>Supported values:
    *
-   * <p>A value of {@code -1} means the global setting from {@link
-   * io.github.seijikohara.dbtester.api.config.OperationDefaults#batchSize()} is used. A value of
-   * {@code 0} means all rows are added to a single batch (default behavior).
+   * <ul>
+   *   <li>{@link #UNSET} ({@code -1}) — use the global setting from {@link
+   *       io.github.seijikohara.dbtester.api.config.OperationDefaults#batchSize()}
+   *   <li>{@code 0} — execute all rows in a single batch
+   *   <li>Positive integer — flush the JDBC batch every N rows
+   * </ul>
    *
-   * @return the batch size, or {@code -1} to use the global setting
+   * @return the batch size, or {@link #UNSET} to use the global setting
    */
-  int batchSize() default -1;
+  int batchSize() default UNSET;
 }

--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/annotation/ExpectedDataSet.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/annotation/ExpectedDataSet.java
@@ -27,6 +27,9 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ExpectedDataSet {
 
+  /** Sentinel value indicating that the global setting should be used. */
+  int UNSET = -1;
+
   /**
    * Lists the dataset sources that should be considered the canonical post-test state.
    *
@@ -69,22 +72,34 @@ public @interface ExpectedDataSet {
    * times, waiting {@link #retryDelayMillis()} between attempts. This is useful for eventual
    * consistency scenarios.
    *
-   * <p>A value of {@code -1} means the global setting from {@link
-   * io.github.seijikohara.dbtester.api.config.ConventionSettings#retryCount()} is used.
+   * <p>Supported values:
    *
-   * @return the number of retry attempts, or -1 to use the global setting
+   * <ul>
+   *   <li>{@link #UNSET} ({@code -1}) — use the global setting from {@link
+   *       io.github.seijikohara.dbtester.api.config.ConventionSettings#retryCount()}
+   *   <li>{@code 0} — no retries (fail immediately on mismatch)
+   *   <li>Positive integer — retry up to N times
+   * </ul>
+   *
+   * @return the number of retry attempts, or {@link #UNSET} to use the global setting
    */
-  int retryCount() default -1;
+  int retryCount() default UNSET;
 
   /**
    * Specifies the delay between retry attempts in milliseconds.
    *
    * <p>This delay allows transient inconsistencies to resolve before the next verification attempt.
    *
-   * <p>A value of {@code -1} means the global setting from {@link
-   * io.github.seijikohara.dbtester.api.config.ConventionSettings#retryDelay()} is used.
+   * <p>Supported values:
    *
-   * @return the delay in milliseconds, or -1 to use the global setting
+   * <ul>
+   *   <li>{@link #UNSET} ({@code -1}) — use the global setting from {@link
+   *       io.github.seijikohara.dbtester.api.config.ConventionSettings#retryDelay()}
+   *   <li>{@code 0} — no delay between retries
+   *   <li>Positive integer — wait N milliseconds before retrying
+   * </ul>
+   *
+   * @return the delay in milliseconds, or {@link #UNSET} to use the global setting
    */
-  long retryDelayMillis() default -1;
+  long retryDelayMillis() default UNSET;
 }

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/lifecycle/DefaultExpectationSupport.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/lifecycle/DefaultExpectationSupport.java
@@ -80,12 +80,23 @@ public final class DefaultExpectationSupport implements ExpectationSupport {
   /**
    * Resolves the retry count from annotation or global settings.
    *
+   * <p>If the annotation specifies a non-negative value, that value is used directly. If the
+   * annotation value is {@link ExpectedDataSet#UNSET} (the default), the global setting from {@link
+   * io.github.seijikohara.dbtester.api.config.ConventionSettings#retryCount()} is used.
+   *
    * @param expectedDataSet the annotation
    * @param context the test context
    * @return the resolved retry count
+   * @throws IllegalArgumentException if retryCount is less than {@link ExpectedDataSet#UNSET}
    */
   private int resolveRetryCount(final ExpectedDataSet expectedDataSet, final TestContext context) {
     final var annotationValue = expectedDataSet.retryCount();
+    if (annotationValue < ExpectedDataSet.UNSET) {
+      throw new IllegalArgumentException(
+          String.format(
+              "retryCount must be %d (use global), 0, or positive. Got: %d",
+              ExpectedDataSet.UNSET, annotationValue));
+    }
     return annotationValue >= 0
         ? annotationValue
         : context.configuration().conventions().retryCount();
@@ -94,13 +105,24 @@ public final class DefaultExpectationSupport implements ExpectationSupport {
   /**
    * Resolves the retry delay from annotation or global settings.
    *
+   * <p>If the annotation specifies a non-negative value, that value is used directly. If the
+   * annotation value is {@link ExpectedDataSet#UNSET} (the default), the global setting from {@link
+   * io.github.seijikohara.dbtester.api.config.ConventionSettings#retryDelay()} is used.
+   *
    * @param expectedDataSet the annotation
    * @param context the test context
    * @return the resolved retry delay
+   * @throws IllegalArgumentException if retryDelayMillis is less than {@link ExpectedDataSet#UNSET}
    */
   private Duration resolveRetryDelay(
       final ExpectedDataSet expectedDataSet, final TestContext context) {
     final var annotationValue = expectedDataSet.retryDelayMillis();
+    if (annotationValue < ExpectedDataSet.UNSET) {
+      throw new IllegalArgumentException(
+          String.format(
+              "retryDelayMillis must be %d (use global), 0, or positive. Got: %d",
+              ExpectedDataSet.UNSET, annotationValue));
+    }
     return annotationValue >= 0
         ? Duration.ofMillis(annotationValue)
         : context.configuration().conventions().retryDelay();

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/lifecycle/DefaultPreparationSupport.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/lifecycle/DefaultPreparationSupport.java
@@ -126,15 +126,22 @@ public final class DefaultPreparationSupport implements PreparationSupport {
    * Resolves the effective batch size from the annotation and global defaults.
    *
    * <p>If the annotation specifies a non-negative value, that value is used directly. If the
-   * annotation value is {@code -1} (the default), the global setting from {@link
+   * annotation value is {@link DataSet#UNSET} (the default), the global setting from {@link
    * io.github.seijikohara.dbtester.api.config.OperationDefaults#batchSize()} is used.
    *
    * @param dataSet the DataSet annotation
    * @param context the test context
    * @return the effective batch size (zero or positive)
+   * @throws IllegalArgumentException if batchSize is less than {@link DataSet#UNSET}
    */
   private int resolveBatchSize(final DataSet dataSet, final TestContext context) {
     final var annotationBatchSize = dataSet.batchSize();
+    if (annotationBatchSize < DataSet.UNSET) {
+      throw new IllegalArgumentException(
+          String.format(
+              "batchSize must be %d (use global), 0 (single batch), or positive. Got: %d",
+              DataSet.UNSET, annotationBatchSize));
+    }
     if (annotationBatchSize >= 0) {
       return annotationBatchSize;
     }


### PR DESCRIPTION
## Summary

- Add named `UNSET` constants to `@DataSet` and `@ExpectedDataSet` annotations, replacing raw `-1` literals
- Improve Javadoc with structured value tables for `batchSize`, `retryCount`, and `retryDelayMillis`
- Add validation in core module to reject invalid negative values (less than `-1`)

## Changes

### API Module

**`DataSet.java`**:
- Add `int UNSET = -1` constant
- Update `batchSize()` default to use `UNSET` instead of `-1`
- Add structured Javadoc with supported values list

**`ExpectedDataSet.java`**:
- Add `int UNSET = -1` constant
- Update `retryCount()` and `retryDelayMillis()` defaults to use `UNSET`
- Add structured Javadoc with supported values list

### Core Module

**`DefaultPreparationSupport.java`**:
- Add validation: `batchSize < UNSET` throws `IllegalArgumentException`
- Update Javadoc references to use `DataSet.UNSET`

**`DefaultExpectationSupport.java`**:
- Add validation: `retryCount < UNSET` and `retryDelayMillis < UNSET` throw `IllegalArgumentException`
- Update Javadoc references to use `ExpectedDataSet.UNSET`

## Backward Compatibility

Fully backward compatible. Existing code using `batchSize = -1` continues to work identically. The `UNSET` constant provides a named alternative for better readability.

## Test plan

- [x] `./gradlew spotlessApply` passes
- [x] `./gradlew :db-tester-api:build :db-tester-core:build` passes (all existing tests pass)
- [ ] CI checks `test (21)` and `test (25)` pass

Closes #181