### PR TITLE
docs: fix documentation inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ class UserRepositoryTest {
 
 ```groovy
 @DatabaseTest
-class UserRepositorySpec extends Specification {
+class UserRepositorySpec extends Specification implements DatabaseTestSupport {
 
     @Shared
     DataSourceRegistry dbTesterRegistry

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -84,7 +84,7 @@ For comprehensive understanding, read the specifications in this order:
 | Base directory | null (classpath-relative) |
 | Expectation suffix | `/expected` |
 | Scenario marker | `[Scenario]` |
-| Data format | CSV |
+| Data format | AUTO |
 | Table merge strategy | UNION_ALL |
 | DataSet operation | CLEAN_INSERT |
 

--- a/docs/specs/comparison.md
+++ b/docs/specs/comparison.md
@@ -165,7 +165,7 @@ USER:
 |------------|--------|------------|
 | **No XML support** | Cannot migrate from existing DBUnit XML datasets | Convert XML to CSV manually or via script |
 | **No Excel support** | Business users cannot maintain test data in spreadsheets | Export Excel to CSV |
-| **No programmatic dataset builder** | Cannot generate dynamic test data in code | Implement custom DataLoader via SPI |
+| **No fluent builder API for datasets** | Cannot construct datasets using a fluent builder in code | Use `TableSet`/`Table` factory methods or implement custom `DataLoader` via SPI |
 
 ### Feature Limitations
 

--- a/docs/specs/configuration.md
+++ b/docs/specs/configuration.md
@@ -182,7 +182,7 @@ When `baseDirectory` is specified:
 
 ### ExpectedDataSet Suffix
 
-The `expectedDataSetSuffix` is appended to the data set path:
+The `expectationSuffix` is appended to the data set path:
 
 | DataSet Path | Suffix | ExpectedDataSet Path |
 |-----------------|--------|------------------|

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -153,7 +153,7 @@ package com.example
 @DatabaseTest
 @DataSet  // Loads test data from CSV
 @ExpectedDataSet  // Verifies database state
-class UserRepositorySpec extends Specification {
+class UserRepositorySpec extends Specification implements DatabaseTestSupport {
 
     def "should create user"() {
         when:

--- a/docs/specs/ja/spi.md
+++ b/docs/specs/ja/spi.md
@@ -74,6 +74,16 @@ public interface OperationProvider {
         TableOrderingStrategy tableOrderingStrategy,
         TransactionMode transactionMode,
         @Nullable Duration queryTimeout);
+
+    // バッチサイズ制御付き（デフォルトではベースのexecuteに委譲）
+    default void execute(
+        Operation operation,
+        TableSet tableSet,
+        DataSource dataSource,
+        TableOrderingStrategy tableOrderingStrategy,
+        TransactionMode transactionMode,
+        @Nullable Duration queryTimeout,
+        int batchSize);
 }
 ```
 
@@ -89,6 +99,7 @@ public interface OperationProvider {
 | `tableOrderingStrategy` | `TableOrderingStrategy` | テーブル処理順序の戦略 |
 | `transactionMode` | `TransactionMode` | トランザクション動作モード |
 | `queryTimeout` | `@Nullable Duration` | クエリタイムアウト、またはタイムアウトなしの場合はnull |
+| `batchSize` | `int` | INSERTバッチあたりの行数（0 = 単一バッチ）、バッチオーバーロードで使用 |
 
 **操作**:
 - `NONE` - 操作なし
@@ -185,6 +196,13 @@ public interface ExpectationProvider {
                                    Collection<String> excludeColumns,
                                    Map<String, ColumnStrategyMapping> columnStrategies,
                                    RowOrdering rowOrdering);
+
+    // 操作デフォルト付き（例: 浮動小数点イプシロン）
+    default void verifyExpectation(TableSet expectedTableSet, DataSource dataSource,
+                                   Collection<String> excludeColumns,
+                                   Map<String, ColumnStrategyMapping> columnStrategies,
+                                   RowOrdering rowOrdering,
+                                   OperationDefaults operationDefaults);
 }
 ```
 
@@ -198,6 +216,7 @@ public interface ExpectationProvider {
 | `verifyExpectation(..., excludeColumns)` | 指定カラムを除外して検証 |
 | `verifyExpectation(..., columnStrategies)` | カラム比較戦略付きで検証 |
 | `verifyExpectation(..., rowOrdering)` | 行順序制御付きで検証 |
+| `verifyExpectation(..., operationDefaults)` | 操作デフォルト付きで検証（例: 浮動小数点イプシロン） |
 
 **パラメータ**:
 
@@ -208,6 +227,7 @@ public interface ExpectationProvider {
 | `excludeColumns` | `Collection<String>` | 比較から除外するカラム名（大文字小文字区別なし） |
 | `columnStrategies` | `Map<String, ColumnStrategyMapping>` | カラム名でキーイングされたカラム比較戦略 |
 | `rowOrdering` | `RowOrdering` | 行比較戦略（ORDEREDまたはUNORDERED） |
+| `operationDefaults` | `OperationDefaults` | 比較設定を含む操作デフォルト（例: 浮動小数点イプシロン） |
 
 **プロセス**:
 1. 期待テーブルセット内の各テーブルに対して、データベースから実際のデータを取得

--- a/docs/specs/spi.md
+++ b/docs/specs/spi.md
@@ -75,6 +75,16 @@ public interface OperationProvider {
         TableOrderingStrategy tableOrderingStrategy,
         TransactionMode transactionMode,
         @Nullable Duration queryTimeout);
+
+    // With batch size control (default delegates to base execute)
+    default void execute(
+        Operation operation,
+        TableSet tableSet,
+        DataSource dataSource,
+        TableOrderingStrategy tableOrderingStrategy,
+        TransactionMode transactionMode,
+        @Nullable Duration queryTimeout,
+        int batchSize);
 }
 ```
 
@@ -90,6 +100,7 @@ public interface OperationProvider {
 | `tableOrderingStrategy` | `TableOrderingStrategy` | Strategy for table processing order |
 | `transactionMode` | `TransactionMode` | Transaction behavior mode |
 | `queryTimeout` | `@Nullable Duration` | Query timeout, or null for no timeout |
+| `batchSize` | `int` | Rows per INSERT batch (0 = single batch), used by the batch overload |
 
 **Operations**:
 
@@ -189,6 +200,13 @@ public interface ExpectationProvider {
                                    Collection<String> excludeColumns,
                                    Map<String, ColumnStrategyMapping> columnStrategies,
                                    RowOrdering rowOrdering);
+
+    // With operation defaults (e.g., floating-point epsilon)
+    default void verifyExpectation(TableSet expectedTableSet, DataSource dataSource,
+                                   Collection<String> excludeColumns,
+                                   Map<String, ColumnStrategyMapping> columnStrategies,
+                                   RowOrdering rowOrdering,
+                                   OperationDefaults operationDefaults);
 }
 ```
 
@@ -202,6 +220,7 @@ public interface ExpectationProvider {
 | `verifyExpectation(..., excludeColumns)` | Verify excluding specified columns |
 | `verifyExpectation(..., columnStrategies)` | Verify with column comparison strategies |
 | `verifyExpectation(..., rowOrdering)` | Verify with row ordering control |
+| `verifyExpectation(..., operationDefaults)` | Verify with operation defaults (e.g., floating-point epsilon) |
 
 **Parameters**:
 
@@ -212,6 +231,7 @@ public interface ExpectationProvider {
 | `excludeColumns` | `Collection<String>` | Column names to exclude from comparison (case-insensitive) |
 | `columnStrategies` | `Map<String, ColumnStrategyMapping>` | Column comparison strategies keyed by column name |
 | `rowOrdering` | `RowOrdering` | Row comparison strategy (ORDERED or UNORDERED) |
+| `operationDefaults` | `OperationDefaults` | Operation defaults containing comparison settings (e.g., floating-point epsilon) |
 
 **Process**:
 1. The provider iterates each table in the expected dataset and fetches actual data from the database.


### PR DESCRIPTION
## Summary

- Add missing `implements DatabaseTestSupport` to Spock Quick Start examples in README.md and docs/specs/index.md
- Fix default data format from "CSV" to "AUTO" in docs/specs/README.md (updated by #157)
- Fix property name from `expectedDataSetSuffix` to `expectationSuffix` in docs/specs/configuration.md
- Add missing `OperationProvider.execute()` batch overload and `ExpectationProvider.verifyExpectation()` with `OperationDefaults` to docs/specs/spi.md (EN and JA)
- Fix "No programmatic dataset builder" to "No fluent builder API" with factory method note in docs/specs/comparison.md

## Test plan

- [x] Verify all changes match actual source code
- [ ] CI passes (`test (21)` + `test (25)`)

Closes #164