### PR TITLE
feat(core): support glob patterns in excludeColumns for column exclusion

### DIFF
--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/annotation/DataSetSource.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/annotation/DataSetSource.java
@@ -73,7 +73,7 @@ public @interface DataSetSource {
   String[] scenarioNames() default {};
 
   /**
-   * Lists the column names to exclude from assertion verification.
+   * Lists the column names or patterns to exclude from assertion verification.
    *
    * <p>Columns listed here are ignored during database state comparison. This is useful for
    * excluding auto-generated columns (timestamps, version numbers, auto-increment IDs) that cannot
@@ -81,6 +81,15 @@ public @interface DataSetSource {
    *
    * <p>Column name matching is case-insensitive. For example, specifying {@code "CREATED_AT"} will
    * exclude columns named {@code "created_at"}, {@code "CREATED_AT"}, or {@code "Created_At"}.
+   *
+   * <p>Glob patterns are supported for matching multiple columns:
+   *
+   * <ul>
+   *   <li>{@code *} matches any sequence of characters (e.g., {@code "*_AT"} matches {@code
+   *       CREATED_AT}, {@code UPDATED_AT})
+   *   <li>{@code ?} matches any single character (e.g., {@code "COL?"} matches {@code COL1}, {@code
+   *       COLA})
+   * </ul>
    *
    * <p>This attribute only applies to expectation verification (when used within {@link
    * ExpectedDataSet#sources()}). It has no effect when used within {@link DataSet#sources()} for
@@ -90,12 +99,13 @@ public @interface DataSetSource {
    *
    * <pre>{@code
    * @ExpectedDataSet(sources = @DataSetSource(
-   *     excludeColumns = {"CREATED_AT", "UPDATED_AT", "VERSION"}
+   *     excludeColumns = {"*_AT", "*_BY", "VERSION"}
    * ))
    * void testUserCreation() { }
    * }</pre>
    *
-   * @return column names to exclude from verification, or an empty array for no exclusions
+   * @return column names or patterns to exclude from verification, or an empty array for no
+   *     exclusions
    * @see io.github.seijikohara.dbtester.api.assertion.DatabaseAssertion#assertEqualsIgnoreColumns
    */
   String[] excludeColumns() default {};

--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/config/ConventionSettings.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/config/ConventionSettings.java
@@ -73,7 +73,7 @@ public final class ConventionSettings {
   /** The file name used to specify table loading order. */
   private final String loadOrderFileName;
 
-  /** The column names to exclude from all expectation verifications globally. */
+  /** The column names or glob patterns to exclude from all expectation verifications globally. */
   private final Set<String> globalExcludeColumns;
 
   /** The column comparison strategies applied globally. */
@@ -192,9 +192,14 @@ public final class ConventionSettings {
   }
 
   /**
-   * Returns the column names to exclude from all expectation verifications globally.
+   * Returns the column names or glob patterns to exclude from all expectation verifications
+   * globally.
    *
-   * @return an unmodifiable set of column names
+   * <p>Entries containing {@code *} or {@code ?} are treated as glob patterns and matched against
+   * actual column names during verification. Entries without wildcards are treated as exact column
+   * names.
+   *
+   * @return an unmodifiable set of column names or patterns
    */
   public Set<String> globalExcludeColumns() {
     return globalExcludeColumns;
@@ -502,7 +507,7 @@ public final class ConventionSettings {
     /** The file name used to specify table loading order. */
     private String loadOrderFileName = DEFAULT_LOAD_ORDER_FILE_NAME;
 
-    /** The column names to exclude from all expectation verifications globally. */
+    /** The column names or glob patterns to exclude from all expectation verifications globally. */
     private Set<String> globalExcludeColumns = Set.of();
 
     /** The column comparison strategies applied globally. */
@@ -593,9 +598,14 @@ public final class ConventionSettings {
     }
 
     /**
-     * Sets the column names to exclude from all expectation verifications globally.
+     * Sets the column names or glob patterns to exclude from all expectation verifications
+     * globally.
      *
-     * @param globalExcludeColumns the column names to exclude
+     * <p>Entries containing {@code *} or {@code ?} are treated as glob patterns. Example: {@code
+     * Set.of("*_AT", "*_BY", "VERSION")} excludes all columns ending with {@code _AT} or {@code
+     * _BY}, and the exact column {@code VERSION}.
+     *
+     * @param globalExcludeColumns the column names or patterns to exclude
      * @return this builder
      */
     public Builder globalExcludeColumns(final Set<String> globalExcludeColumns) {

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/assertion/ColumnPatternMatcher.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/assertion/ColumnPatternMatcher.java
@@ -1,0 +1,121 @@
+package io.github.seijikohara.dbtester.internal.assertion;
+
+import java.util.Collection;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Matches column names against glob patterns for column exclusion.
+ *
+ * <p>This utility supports glob-style patterns in column exclusion lists. Entries containing {@code
+ * *} or {@code ?} wildcards are treated as patterns and matched against actual column names.
+ * Entries without wildcards are treated as exact column names.
+ *
+ * <p>Pattern syntax:
+ *
+ * <ul>
+ *   <li>{@code *} matches any sequence of characters (including empty)
+ *   <li>{@code ?} matches any single character
+ * </ul>
+ *
+ * <p>All matching is case-insensitive, consistent with existing column exclusion behavior.
+ *
+ * <p>Example patterns:
+ *
+ * <ul>
+ *   <li>{@code *_AT} matches {@code CREATED_AT}, {@code UPDATED_AT}, {@code DELETED_AT}
+ *   <li>{@code *_BY} matches {@code CREATED_BY}, {@code MODIFIED_BY}
+ *   <li>{@code VERSION?} matches {@code VERSION1}, {@code VERSIONS}
+ * </ul>
+ *
+ * @see io.github.seijikohara.dbtester.api.annotation.DataSetSource#excludeColumns()
+ */
+public final class ColumnPatternMatcher {
+
+  /** Private constructor to prevent instantiation. */
+  private ColumnPatternMatcher() {}
+
+  /**
+   * Checks whether the given string contains glob wildcard characters.
+   *
+   * @param value the string to check
+   * @return true if the string contains {@code *} or {@code ?}, false otherwise
+   */
+  public static boolean isPattern(final String value) {
+    return value.contains("*") || value.contains("?");
+  }
+
+  /**
+   * Resolves glob patterns in a set of exclude column entries against actual column names.
+   *
+   * <p>Entries without wildcards are returned unchanged. Entries containing {@code *} or {@code ?}
+   * are matched against the provided column names, and matching column names replace the pattern
+   * entry.
+   *
+   * @param excludeEntries the exclude column entries (may contain both exact names and patterns)
+   * @param columnNames the actual column names to match patterns against
+   * @return set of resolved column names (uppercase, no patterns remaining)
+   */
+  public static Set<String> resolvePatterns(
+      final Collection<String> excludeEntries, final Collection<String> columnNames) {
+    if (excludeEntries.isEmpty()) {
+      return Set.of();
+    }
+
+    final var upperColumnNames =
+        columnNames.stream()
+            .map(name -> name.toUpperCase(Locale.ROOT))
+            .collect(Collectors.toUnmodifiableSet());
+
+    return excludeEntries.stream()
+        .flatMap(
+            entry -> {
+              if (isPattern(entry)) {
+                final var pattern = globToRegex(entry.toUpperCase(Locale.ROOT));
+                return upperColumnNames.stream().filter(name -> pattern.matcher(name).matches());
+              } else {
+                return java.util.stream.Stream.of(entry.toUpperCase(Locale.ROOT));
+              }
+            })
+        .collect(Collectors.toUnmodifiableSet());
+  }
+
+  /**
+   * Converts a glob pattern to a compiled regex Pattern.
+   *
+   * <p>The conversion escapes all regex special characters except {@code *} and {@code ?}, which
+   * are converted to {@code .*} and {@code .} respectively.
+   *
+   * @param glob the glob pattern
+   * @return compiled regex Pattern for case-insensitive matching
+   */
+  private static Pattern globToRegex(final String glob) {
+    final var regex = new StringBuilder();
+    for (int i = 0; i < glob.length(); i++) {
+      final var c = glob.charAt(i);
+      switch (c) {
+        case '*' -> regex.append(".*");
+        case '?' -> regex.append('.');
+        default -> {
+          if (isRegexSpecialChar(c)) {
+            regex.append('\\');
+          }
+          regex.append(c);
+        }
+      }
+    }
+    return Pattern.compile(regex.toString(), Pattern.CASE_INSENSITIVE);
+  }
+
+  /**
+   * Checks whether a character is a regex special character that needs escaping.
+   *
+   * @param c the character to check
+   * @return true if the character is a regex special character
+   */
+  private static boolean isRegexSpecialChar(final char c) {
+    return ".+^${}[]|()\\\t".indexOf(c) >= 0;
+  }
+}

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/lifecycle/DefaultExpectationSupport.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/lifecycle/DefaultExpectationSupport.java
@@ -3,14 +3,20 @@ package io.github.seijikohara.dbtester.internal.lifecycle;
 import io.github.seijikohara.dbtester.api.annotation.ExpectedDataSet;
 import io.github.seijikohara.dbtester.api.config.RowOrdering;
 import io.github.seijikohara.dbtester.api.context.TestContext;
+import io.github.seijikohara.dbtester.api.dataset.Table;
+import io.github.seijikohara.dbtester.api.domain.ColumnName;
 import io.github.seijikohara.dbtester.api.exception.ValidationException;
 import io.github.seijikohara.dbtester.api.loader.ExpectedTableSet;
 import io.github.seijikohara.dbtester.api.spi.ExpectationProvider;
 import io.github.seijikohara.dbtester.api.spi.ExpectationSupport;
+import io.github.seijikohara.dbtester.internal.assertion.ColumnPatternMatcher;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -189,7 +195,8 @@ public final class DefaultExpectationSupport implements ExpectationSupport {
       final ExpectedTableSet expectedTableSet,
       final RowOrdering rowOrdering) {
     final var tableSet = expectedTableSet.tableSet();
-    final var excludeColumns = expectedTableSet.excludeColumns();
+    final var rawExcludeColumns = expectedTableSet.excludeColumns();
+    final var excludeColumns = resolveExcludeColumnPatterns(rawExcludeColumns, tableSet);
     final var columnStrategies = expectedTableSet.columnStrategies();
     final DataSource dataSource =
         tableSet.getDataSource().orElseGet(() -> context.registry().get(""));
@@ -225,5 +232,36 @@ public final class DefaultExpectationSupport implements ExpectationSupport {
               "Failed to verify expectation TableSet for %s", context.testMethod().getName()),
           e);
     }
+  }
+
+  /**
+   * Resolves glob patterns in exclude column entries against the expected table columns.
+   *
+   * <p>If any entry in {@code excludeColumns} contains glob wildcards ({@code *} or {@code ?}), the
+   * patterns are matched against the column names in the expected tables. Non-pattern entries are
+   * passed through unchanged.
+   *
+   * @param excludeColumns the exclude column entries (may contain both exact names and patterns)
+   * @param tableSet the expected table set providing column names for pattern resolution
+   * @return resolved set of column names (uppercase, no patterns remaining)
+   */
+  private Set<String> resolveExcludeColumnPatterns(
+      final Collection<String> excludeColumns,
+      final io.github.seijikohara.dbtester.api.dataset.TableSet tableSet) {
+    final var hasPatterns = excludeColumns.stream().anyMatch(ColumnPatternMatcher::isPattern);
+    if (!hasPatterns) {
+      return Set.copyOf(excludeColumns);
+    }
+
+    final var allColumnNames =
+        tableSet.getTables().stream()
+            .map(Table::getColumns)
+            .flatMap(Collection::stream)
+            .map(ColumnName::value)
+            .collect(Collectors.toUnmodifiableSet());
+
+    final var resolved = ColumnPatternMatcher.resolvePatterns(excludeColumns, allColumnNames);
+    logger.debug("Resolved exclude column patterns: {} -> {}", excludeColumns, resolved);
+    return resolved;
   }
 }

--- a/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/assertion/ColumnPatternMatcherTest.java
+++ b/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/assertion/ColumnPatternMatcherTest.java
@@ -1,0 +1,210 @@
+package io.github.seijikohara.dbtester.internal.assertion;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link ColumnPatternMatcher}. */
+@DisplayName("ColumnPatternMatcher")
+class ColumnPatternMatcherTest {
+
+  /** Tests for the ColumnPatternMatcher class. */
+  ColumnPatternMatcherTest() {}
+
+  /** Tests for the isPattern(String) method. */
+  @Nested
+  @DisplayName("isPattern(String) method")
+  class IsPatternMethod {
+
+    /** Tests for the isPattern method. */
+    IsPatternMethod() {}
+
+    /** Verifies that isPattern returns true when string contains asterisk. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return true when string contains asterisk")
+    void shouldReturnTrue_whenStringContainsAsterisk() {
+      // When & Then
+      assertTrue(ColumnPatternMatcher.isPattern("*_AT"), "should detect asterisk pattern");
+    }
+
+    /** Verifies that isPattern returns true when string contains question mark. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return true when string contains question mark")
+    void shouldReturnTrue_whenStringContainsQuestionMark() {
+      // When & Then
+      assertTrue(ColumnPatternMatcher.isPattern("VERSION?"), "should detect question mark pattern");
+    }
+
+    /** Verifies that isPattern returns false when string contains no wildcards. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return false when string contains no wildcards")
+    void shouldReturnFalse_whenStringContainsNoWildcards() {
+      // When & Then
+      assertFalse(
+          ColumnPatternMatcher.isPattern("CREATED_AT"), "should not detect pattern in plain name");
+    }
+
+    /** Verifies that isPattern returns false when string is empty. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should return false when string is empty")
+    void shouldReturnFalse_whenStringIsEmpty() {
+      // When & Then
+      assertFalse(ColumnPatternMatcher.isPattern(""), "should not detect pattern in empty string");
+    }
+  }
+
+  /** Tests for the resolvePatterns(Collection, Collection) method. */
+  @Nested
+  @DisplayName("resolvePatterns(Collection, Collection) method")
+  class ResolvePatternsMethod {
+
+    /** Tests for the resolvePatterns method. */
+    ResolvePatternsMethod() {}
+
+    /** Verifies that resolvePatterns returns exact names unchanged when no patterns present. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return exact names unchanged when no patterns present")
+    void shouldReturnExactNames_whenNoPatternsPresent() {
+      // Given
+      final var excludeEntries = List.of("CREATED_AT", "VERSION");
+      final var columnNames = List.of("ID", "NAME", "CREATED_AT", "VERSION");
+
+      // When
+      final var result = ColumnPatternMatcher.resolvePatterns(excludeEntries, columnNames);
+
+      // Then
+      assertAll(
+          "should contain exact names",
+          () -> assertEquals(2, result.size(), "should have 2 entries"),
+          () -> assertTrue(result.contains("CREATED_AT"), "should contain CREATED_AT"),
+          () -> assertTrue(result.contains("VERSION"), "should contain VERSION"));
+    }
+
+    /** Verifies that resolvePatterns matches asterisk pattern against column names. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should match asterisk pattern against column names")
+    void shouldMatchAsteriskPattern_whenPatternProvided() {
+      // Given
+      final var excludeEntries = List.of("*_AT");
+      final var columnNames = List.of("ID", "NAME", "CREATED_AT", "UPDATED_AT", "DELETED_AT");
+
+      // When
+      final var result = ColumnPatternMatcher.resolvePatterns(excludeEntries, columnNames);
+
+      // Then
+      assertAll(
+          "should match all columns ending with _AT",
+          () -> assertEquals(3, result.size(), "should have 3 matches"),
+          () -> assertTrue(result.contains("CREATED_AT"), "should match CREATED_AT"),
+          () -> assertTrue(result.contains("UPDATED_AT"), "should match UPDATED_AT"),
+          () -> assertTrue(result.contains("DELETED_AT"), "should match DELETED_AT"));
+    }
+
+    /** Verifies that resolvePatterns matches question mark pattern against column names. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should match question mark pattern against column names")
+    void shouldMatchQuestionMarkPattern_whenPatternProvided() {
+      // Given
+      final var excludeEntries = List.of("COL?");
+      final var columnNames = List.of("COL1", "COL2", "COLA", "COLUMN");
+
+      // When
+      final var result = ColumnPatternMatcher.resolvePatterns(excludeEntries, columnNames);
+
+      // Then
+      assertAll(
+          "should match columns matching COL?",
+          () -> assertEquals(3, result.size(), "should have 3 matches"),
+          () -> assertTrue(result.contains("COL1"), "should match COL1"),
+          () -> assertTrue(result.contains("COL2"), "should match COL2"),
+          () -> assertTrue(result.contains("COLA"), "should match COLA"));
+    }
+
+    /** Verifies that resolvePatterns mixes exact names and patterns. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should combine exact names and pattern matches")
+    void shouldCombineExactNamesAndPatternMatches() {
+      // Given
+      final var excludeEntries = List.of("VERSION", "*_BY");
+      final var columnNames = List.of("ID", "VERSION", "CREATED_BY", "MODIFIED_BY", "NAME");
+
+      // When
+      final var result = ColumnPatternMatcher.resolvePatterns(excludeEntries, columnNames);
+
+      // Then
+      assertAll(
+          "should combine exact and pattern matches",
+          () -> assertEquals(3, result.size(), "should have 3 entries"),
+          () -> assertTrue(result.contains("VERSION"), "should contain exact name VERSION"),
+          () -> assertTrue(result.contains("CREATED_BY"), "should match CREATED_BY"),
+          () -> assertTrue(result.contains("MODIFIED_BY"), "should match MODIFIED_BY"));
+    }
+
+    /** Verifies that resolvePatterns performs case-insensitive matching. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should perform case-insensitive matching")
+    void shouldPerformCaseInsensitiveMatching() {
+      // Given
+      final var excludeEntries = List.of("*_at");
+      final var columnNames = List.of("ID", "Created_At", "UPDATED_AT");
+
+      // When
+      final var result = ColumnPatternMatcher.resolvePatterns(excludeEntries, columnNames);
+
+      // Then
+      assertAll(
+          "should match case-insensitively",
+          () -> assertEquals(2, result.size(), "should have 2 matches"),
+          () -> assertTrue(result.contains("CREATED_AT"), "should match CREATED_AT (uppercase)"),
+          () -> assertTrue(result.contains("UPDATED_AT"), "should match UPDATED_AT (uppercase)"));
+    }
+
+    /** Verifies that resolvePatterns returns empty set when no entries provided. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should return empty set when no entries provided")
+    void shouldReturnEmptySet_whenNoEntriesProvided() {
+      // Given
+      final List<String> excludeEntries = List.of();
+      final var columnNames = List.of("ID", "NAME");
+
+      // When
+      final var result = ColumnPatternMatcher.resolvePatterns(excludeEntries, columnNames);
+
+      // Then
+      assertTrue(result.isEmpty(), "should return empty set");
+    }
+
+    /** Verifies that resolvePatterns returns empty set when pattern matches no columns. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should return pattern with no matches as non-matching when no columns match")
+    void shouldReturnNonMatchingEntries_whenPatternMatchesNoColumns() {
+      // Given
+      final var excludeEntries = List.of("*_XYZ");
+      final var columnNames = List.of("ID", "NAME", "CREATED_AT");
+
+      // When
+      final var result = ColumnPatternMatcher.resolvePatterns(excludeEntries, columnNames);
+
+      // Then
+      assertTrue(result.isEmpty(), "should return empty set when pattern matches nothing");
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `ColumnPatternMatcher` utility that resolves glob-style wildcards (`*` and `?`) in `excludeColumns` entries against actual column names
- Pattern resolution in `DefaultExpectationSupport` before verification, avoiding changes to public API records or SPI interfaces
- Update `DataSetSource` and `ConventionSettings` Javadoc to document pattern support

## Test plan
- [x] `ColumnPatternMatcherTest` covers: asterisk patterns, question mark patterns, mixed exact/pattern, case-insensitive matching, empty input, no-match patterns
- [x] `./gradlew :db-tester-core:build` passes (compile, test, checkstyle, Error Prone, JaCoCo)
- [ ] CI: `test (21)` and `test (25)` pass

Closes #175