### PR TITLE
feat: include db-tester-core as transitive runtime dependency

### DIFF
--- a/db-tester-junit/README.md
+++ b/db-tester-junit/README.md
@@ -15,10 +15,10 @@ db-tester-api (compile-time dependency)
         ↑
 db-tester-junit
         ↓
-db-tester-core (runtime dependency, loaded via ServiceLoader)
+db-tester-core (transitive runtime dependency, loaded via ServiceLoader)
 ```
 
-This module depends **only on `db-tester-api`** at compile time. The `db-tester-core` module is loaded at runtime via Java ServiceLoader mechanism.
+This module depends on `db-tester-api` at compile time and includes `db-tester-core` as a transitive runtime dependency. Users only need to add `db-tester-junit` to their project.
 
 ## Requirements
 

--- a/db-tester-junit/build.gradle.kts
+++ b/db-tester-junit/build.gradle.kts
@@ -14,6 +14,9 @@ dependencies {
     implementation(platform(libs.junit.bom))
     implementation(libs.junit.jupiter)
 
+    // Runtime dependency for SPI implementation (ServiceLoader)
+    runtimeOnly(project(":db-tester-core"))
+
     // Compile-time dependency for logging
     compileOnly(platform(libs.slf4j.bom))
     compileOnly(libs.slf4j.api)
@@ -26,7 +29,6 @@ testing {
                 implementation(platform(libs.mockito.bom))
                 implementation(libs.mockito.core)
                 implementation(libs.mockito.junit.jupiter)
-                runtimeOnly(project(":db-tester-core"))
                 runtimeOnly(platform(libs.slf4j.bom))
                 runtimeOnly(libs.slf4j.simple)
             }

--- a/db-tester-kotest/README.md
+++ b/db-tester-kotest/README.md
@@ -15,10 +15,10 @@ db-tester-api (compile-time dependency)
         ↑
 db-tester-kotest
         ↓
-db-tester-core (runtime dependency, loaded via ServiceLoader)
+db-tester-core (transitive runtime dependency, loaded via ServiceLoader)
 ```
 
-This module depends **only on `db-tester-api`** at compile time. The `db-tester-core` module is loaded at runtime via Java ServiceLoader mechanism.
+This module depends on `db-tester-api` at compile time and includes `db-tester-core` as a transitive runtime dependency. Users only need to add `db-tester-kotest` to their project.
 
 ## Requirements
 

--- a/db-tester-kotest/build.gradle.kts
+++ b/db-tester-kotest/build.gradle.kts
@@ -20,6 +20,9 @@ dependencies {
     implementation(libs.kotlin.stdlib)
     implementation(libs.kotlin.reflect)
 
+    // Runtime dependency for SPI implementation (ServiceLoader)
+    runtimeOnly(project(":db-tester-core"))
+
     // Compile-time dependency for logging
     compileOnly(libs.slf4j.api)
 }
@@ -32,7 +35,6 @@ testing {
                 implementation(libs.kotest.runner.junit5)
                 implementation(libs.kotest.assertions.core)
                 implementation(libs.mockk)
-                runtimeOnly(project(":db-tester-core"))
                 runtimeOnly(platform(libs.slf4j.bom))
                 runtimeOnly(libs.slf4j.simple)
             }

--- a/db-tester-spock/README.md
+++ b/db-tester-spock/README.md
@@ -15,10 +15,10 @@ db-tester-api (compile-time dependency)
         ↑
 db-tester-spock
         ↓
-db-tester-core (runtime dependency, loaded via ServiceLoader)
+db-tester-core (transitive runtime dependency, loaded via ServiceLoader)
 ```
 
-This module depends **only on `db-tester-api`** at compile time. The `db-tester-core` module is loaded at runtime via Java ServiceLoader mechanism.
+This module depends on `db-tester-api` at compile time and includes `db-tester-core` as a transitive runtime dependency. Users only need to add `db-tester-spock` to their project.
 
 ## Requirements
 

--- a/db-tester-spock/build.gradle.kts
+++ b/db-tester-spock/build.gradle.kts
@@ -16,6 +16,9 @@ dependencies {
     implementation(libs.groovy)
     implementation(platform(libs.spock.bom))
 
+    // Runtime dependency for SPI implementation (ServiceLoader)
+    runtimeOnly(project(":db-tester-core"))
+
     // Compile-time dependency for logging
     compileOnly(platform(libs.slf4j.bom))
     compileOnly(libs.slf4j.api)
@@ -25,7 +28,6 @@ testing {
     suites {
         val test by getting(JvmTestSuite::class) {
             dependencies {
-                runtimeOnly(project(":db-tester-core"))
                 runtimeOnly(platform(libs.slf4j.bom))
                 runtimeOnly(libs.slf4j.simple)
                 runtimeOnly(libs.junit.platform.launcher)


### PR DESCRIPTION
## Summary

- Move `db-tester-core` from test-only `runtimeOnly` to published `runtimeOnly` dependency in all framework extension modules
- Update module READMEs to reflect the simplified dependency model

## Details

Previously, `db-tester-core` was declared only within `testing.suites.test.dependencies` as `runtimeOnly`, making it available only during the module's own tests. End users who added `db-tester-junit` to their project would get `db-tester-api` transitively but NOT `db-tester-core`, causing `ServiceLoader` `IllegalStateException` at runtime.

Now `db-tester-core` is declared as a published `runtimeOnly` dependency in the main `dependencies` block, so it is included transitively when users add any framework extension module.

## Test plan

- [x] All JUnit, Spock, and Kotest module tests pass
- [x] `db-tester-core` appears in `runtimeClasspath` for all framework modules
- [x] Spotless formatting applied
- [ ] CI `test (21)` passes
- [ ] CI `test (25)` passes

Closes #166