### PR TITLE
test(spring): add Spring Boot starter test coverage

### DIFF
--- a/db-tester-junit-spring-boot-starter/build.gradle.kts
+++ b/db-tester-junit-spring-boot-starter/build.gradle.kts
@@ -36,6 +36,7 @@ testing {
                 implementation(platform(libs.mockito.bom))
                 implementation(libs.mockito.core)
                 implementation(libs.mockito.junit.jupiter)
+                implementation(libs.assertj.core)
                 implementation(libs.spring.test)
                 implementation(libs.spring.boot.test)
                 runtimeOnly(platform(libs.slf4j.bom))

--- a/db-tester-junit-spring-boot-starter/src/test/java/io/github/seijikohara/dbtester/junit/spring/boot/autoconfigure/DbTesterJUnitAutoConfigurationContextTest.java
+++ b/db-tester-junit-spring-boot-starter/src/test/java/io/github/seijikohara/dbtester/junit/spring/boot/autoconfigure/DbTesterJUnitAutoConfigurationContextTest.java
@@ -1,0 +1,256 @@
+package io.github.seijikohara.dbtester.junit.spring.boot.autoconfigure;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.seijikohara.dbtester.api.config.Configuration;
+import io.github.seijikohara.dbtester.api.config.DataSourceRegistry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+/**
+ * Auto-configuration context tests for {@link DbTesterJUnitAutoConfiguration}.
+ *
+ * <p>These tests use {@link ApplicationContextRunner} to verify conditional auto-configuration
+ * behavior, including property-based activation, bean registration, and custom bean overrides.
+ */
+@DisplayName("DbTesterJUnitAutoConfiguration (context)")
+class DbTesterJUnitAutoConfigurationContextTest {
+
+  /** Tests for the auto-configuration context behavior. */
+  DbTesterJUnitAutoConfigurationContextTest() {}
+
+  /** Base context runner with the auto-configuration registered. */
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner()
+          .withConfiguration(AutoConfigurations.of(DbTesterJUnitAutoConfiguration.class));
+
+  /** Tests for bean registration when auto-configuration is enabled. */
+  @Nested
+  @DisplayName("bean registration")
+  class BeanRegistration {
+
+    /** Tests for the bean registration behavior. */
+    BeanRegistration() {}
+
+    /** Verifies that all beans are registered with default properties. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should register all beans with default properties")
+    void shouldRegisterAllBeans_whenDefaultProperties() {
+      contextRunner.run(
+          context ->
+              assertAll(
+                  "should register all expected beans",
+                  () ->
+                      assertTrue(
+                          context.containsBean("dbTesterConfiguration"),
+                          "should have dbTesterConfiguration bean"),
+                  () ->
+                      assertTrue(
+                          context.containsBean("dbTesterDataSourceRegistry"),
+                          "should have dbTesterDataSourceRegistry bean"),
+                  () ->
+                      assertTrue(
+                          context.containsBean("dataSourceRegistrar"),
+                          "should have dataSourceRegistrar bean")));
+    }
+
+    /** Verifies that Configuration bean has correct type. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should register Configuration bean with correct type")
+    void shouldRegisterConfigurationBean_withCorrectType() {
+      contextRunner.run(
+          context ->
+              assertTrue(
+                  context.getBean("dbTesterConfiguration") instanceof Configuration,
+                  "dbTesterConfiguration should be Configuration instance"));
+    }
+
+    /** Verifies that DataSourceRegistry bean has correct type. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should register DataSourceRegistry bean with correct type")
+    void shouldRegisterDataSourceRegistryBean_withCorrectType() {
+      contextRunner.run(
+          context ->
+              assertTrue(
+                  context.getBean("dbTesterDataSourceRegistry") instanceof DataSourceRegistry,
+                  "dbTesterDataSourceRegistry should be DataSourceRegistry instance"));
+    }
+
+    /** Verifies that DataSourceRegistrar bean has correct type. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should register DataSourceRegistrar bean with correct type")
+    void shouldRegisterDataSourceRegistrarBean_withCorrectType() {
+      contextRunner.run(
+          context ->
+              assertTrue(
+                  context.getBean("dataSourceRegistrar") instanceof DataSourceRegistrar,
+                  "dataSourceRegistrar should be DataSourceRegistrar instance"));
+    }
+  }
+
+  /** Tests for the db-tester.enabled property. */
+  @Nested
+  @DisplayName("db-tester.enabled property")
+  class EnabledProperty {
+
+    /** Tests for the enabled property behavior. */
+    EnabledProperty() {}
+
+    /** Verifies that auto-configuration is disabled when enabled is false. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should not register beans when disabled")
+    void shouldNotRegisterBeans_whenDisabled() {
+      contextRunner
+          .withPropertyValues("db-tester.enabled=false")
+          .run(
+              context ->
+                  assertAll(
+                      "should not register any beans",
+                      () ->
+                          assertFalse(
+                              context.containsBean("dbTesterConfiguration"),
+                              "should not have dbTesterConfiguration bean"),
+                      () ->
+                          assertFalse(
+                              context.containsBean("dbTesterDataSourceRegistry"),
+                              "should not have dbTesterDataSourceRegistry bean"),
+                      () ->
+                          assertFalse(
+                              context.containsBean("dataSourceRegistrar"),
+                              "should not have dataSourceRegistrar bean")));
+    }
+
+    /** Verifies that auto-configuration is enabled when enabled is true. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should register beans when explicitly enabled")
+    void shouldRegisterBeans_whenExplicitlyEnabled() {
+      contextRunner
+          .withPropertyValues("db-tester.enabled=true")
+          .run(
+              context ->
+                  assertTrue(
+                      context.containsBean("dbTesterConfiguration"),
+                      "should have dbTesterConfiguration bean"));
+    }
+
+    /** Verifies that auto-configuration is enabled by default (matchIfMissing=true). */
+    @Test
+    @Tag("normal")
+    @DisplayName("should register beans when property is not set (default enabled)")
+    void shouldRegisterBeans_whenPropertyNotSet() {
+      contextRunner.run(
+          context ->
+              assertTrue(
+                  context.containsBean("dbTesterConfiguration"),
+                  "should have dbTesterConfiguration bean by default"));
+    }
+  }
+
+  /** Tests for the @ConditionalOnMissingBean behavior. */
+  @Nested
+  @DisplayName("@ConditionalOnMissingBean behavior")
+  class ConditionalOnMissingBean {
+
+    /** Tests for the conditional bean registration behavior. */
+    ConditionalOnMissingBean() {}
+
+    /** Verifies that custom Configuration bean takes precedence. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should use custom Configuration when provided")
+    void shouldUseCustomConfiguration_whenProvided() {
+      final var customConfig = Configuration.defaults();
+      contextRunner
+          .withBean("dbTesterConfiguration", Configuration.class, () -> customConfig)
+          .run(
+              context ->
+                  assertAll(
+                      "should use custom Configuration",
+                      () ->
+                          assertTrue(
+                              context.containsBean("dbTesterConfiguration"),
+                              "should have dbTesterConfiguration bean"),
+                      () ->
+                          assertTrue(
+                              context.getBean("dbTesterConfiguration") == customConfig,
+                              "should be the custom Configuration instance")));
+    }
+
+    /** Verifies that custom DataSourceRegistry bean takes precedence. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should use custom DataSourceRegistry when provided")
+    void shouldUseCustomDataSourceRegistry_whenProvided() {
+      final var customRegistry = new DataSourceRegistry();
+      contextRunner
+          .withBean("dbTesterDataSourceRegistry", DataSourceRegistry.class, () -> customRegistry)
+          .run(
+              context ->
+                  assertTrue(
+                      context.getBean("dbTesterDataSourceRegistry") == customRegistry,
+                      "should be the custom DataSourceRegistry instance"));
+    }
+  }
+
+  /** Tests for property binding. */
+  @Nested
+  @DisplayName("property binding")
+  class PropertyBinding {
+
+    /** Tests for property binding behavior. */
+    PropertyBinding() {}
+
+    /** Verifies that convention properties are bound correctly. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should bind convention properties")
+    void shouldBindConventionProperties() {
+      contextRunner
+          .withPropertyValues(
+              "db-tester.convention.expectation-suffix=/verify",
+              "db-tester.convention.scenario-marker=[Test]")
+          .run(
+              context -> {
+                final var config = context.getBean("dbTesterConfiguration", Configuration.class);
+                assertAll(
+                    "convention properties should be bound",
+                    () ->
+                        assertTrue(
+                            config.conventions().expectationSuffix().equals("/verify"),
+                            "expectation suffix should be /verify"),
+                    () ->
+                        assertTrue(
+                            config.conventions().scenarioMarker().equals("[Test]"),
+                            "scenario marker should be [Test]"));
+              });
+    }
+
+    /** Verifies that auto-register-data-sources property is bound correctly. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should bind auto-register-data-sources property")
+    void shouldBindAutoRegisterProperty() {
+      contextRunner
+          .withPropertyValues("db-tester.auto-register-data-sources=false")
+          .run(
+              context -> {
+                final var properties = context.getBean(DbTesterProperties.class);
+                assertFalse(
+                    properties.isAutoRegisterDataSources(),
+                    "auto-register-data-sources should be false");
+              });
+    }
+  }
+}

--- a/db-tester-junit-spring-boot-starter/src/test/java/io/github/seijikohara/dbtester/junit/spring/boot/autoconfigure/SpringBootDatabaseTestExtensionTest.java
+++ b/db-tester-junit-spring-boot-starter/src/test/java/io/github/seijikohara/dbtester/junit/spring/boot/autoconfigure/SpringBootDatabaseTestExtensionTest.java
@@ -1,0 +1,228 @@
+package io.github.seijikohara.dbtester.junit.spring.boot.autoconfigure;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.github.seijikohara.dbtester.api.config.Configuration;
+import io.github.seijikohara.dbtester.api.config.DataSourceRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/** Unit tests for {@link SpringBootDatabaseTestExtension}. */
+@DisplayName("SpringBootDatabaseTestExtension")
+class SpringBootDatabaseTestExtensionTest {
+
+  /** Tests for the SpringBootDatabaseTestExtension class. */
+  SpringBootDatabaseTestExtensionTest() {}
+
+  /** The extension under test. */
+  private SpringBootDatabaseTestExtension extension;
+
+  /** Sets up test fixtures. */
+  @BeforeEach
+  void setUp() {
+    extension = new SpringBootDatabaseTestExtension();
+  }
+
+  /** Tests for the constructor. */
+  @Nested
+  @DisplayName("constructor")
+  class Constructor {
+
+    /** Tests for the constructor. */
+    Constructor() {}
+
+    /** Verifies that constructor creates instance. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should create instance")
+    void shouldCreateInstance_whenCalled() {
+      // When
+      final var instance = new SpringBootDatabaseTestExtension();
+
+      // Then
+      assertNotNull(instance, "instance should not be null");
+    }
+  }
+
+  /** Tests for the beforeAll(ExtensionContext) method. */
+  @Nested
+  @DisplayName("beforeAll(ExtensionContext) method")
+  class BeforeAllMethod {
+
+    /** Tests for the beforeAll method. */
+    BeforeAllMethod() {}
+
+    /** Verifies that beforeAll registers Configuration and DataSources when both beans exist. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should register Configuration and DataSources when Spring context has both beans")
+    void shouldRegisterBoth_whenSpringContextHasBothBeans() {
+      // Given
+      final var extensionContext = createMockExtensionContext();
+      final var applicationContext = mock(ApplicationContext.class);
+      final var configuration = Configuration.defaults();
+      final var registrar = mock(DataSourceRegistrar.class);
+
+      when(applicationContext.containsBean("dbTesterConfiguration")).thenReturn(true);
+      when(applicationContext.getBean("dbTesterConfiguration", Configuration.class))
+          .thenReturn(configuration);
+      when(applicationContext.containsBean("dataSourceRegistrar")).thenReturn(true);
+      when(applicationContext.getBean(DataSourceRegistrar.class)).thenReturn(registrar);
+
+      try (final var springExtensionMock = mockStatic(SpringExtension.class)) {
+        springExtensionMock
+            .when(() -> SpringExtension.getApplicationContext(extensionContext))
+            .thenReturn(applicationContext);
+
+        // When
+        extension.beforeAll(extensionContext);
+
+        // Then
+        verify(registrar).registerAll(any(DataSourceRegistry.class));
+      }
+    }
+
+    /** Verifies that beforeAll skips Configuration when bean does not exist. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should skip Configuration when bean does not exist")
+    void shouldSkipConfiguration_whenBeanDoesNotExist() {
+      // Given
+      final var extensionContext = createMockExtensionContext();
+      final var applicationContext = mock(ApplicationContext.class);
+      final var registrar = mock(DataSourceRegistrar.class);
+
+      when(applicationContext.containsBean("dbTesterConfiguration")).thenReturn(false);
+      when(applicationContext.containsBean("dataSourceRegistrar")).thenReturn(true);
+      when(applicationContext.getBean(DataSourceRegistrar.class)).thenReturn(registrar);
+
+      try (final var springExtensionMock = mockStatic(SpringExtension.class)) {
+        springExtensionMock
+            .when(() -> SpringExtension.getApplicationContext(extensionContext))
+            .thenReturn(applicationContext);
+
+        // When
+        extension.beforeAll(extensionContext);
+
+        // Then
+        assertAll(
+            "should skip Configuration but register DataSources",
+            () ->
+                verify(applicationContext, never())
+                    .getBean(eq("dbTesterConfiguration"), eq(Configuration.class)),
+            () -> verify(registrar).registerAll(any(DataSourceRegistry.class)));
+      }
+    }
+
+    /** Verifies that beforeAll skips DataSource registration when registrar does not exist. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should skip DataSource registration when registrar does not exist")
+    void shouldSkipDataSourceRegistration_whenRegistrarDoesNotExist() {
+      // Given
+      final var extensionContext = createMockExtensionContext();
+      final var applicationContext = mock(ApplicationContext.class);
+      final var configuration = Configuration.defaults();
+
+      when(applicationContext.containsBean("dbTesterConfiguration")).thenReturn(true);
+      when(applicationContext.getBean("dbTesterConfiguration", Configuration.class))
+          .thenReturn(configuration);
+      when(applicationContext.containsBean("dataSourceRegistrar")).thenReturn(false);
+
+      try (final var springExtensionMock = mockStatic(SpringExtension.class)) {
+        springExtensionMock
+            .when(() -> SpringExtension.getApplicationContext(extensionContext))
+            .thenReturn(applicationContext);
+
+        // When
+        extension.beforeAll(extensionContext);
+
+        // Then
+        verify(applicationContext, never()).getBean(DataSourceRegistrar.class);
+      }
+    }
+
+    /** Verifies that beforeAll handles missing Spring context gracefully. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should handle missing Spring context gracefully")
+    void shouldHandleGracefully_whenSpringContextNotAvailable() {
+      // Given
+      final var extensionContext = createMockExtensionContext();
+
+      try (final var springExtensionMock = mockStatic(SpringExtension.class)) {
+        springExtensionMock
+            .when(() -> SpringExtension.getApplicationContext(extensionContext))
+            .thenThrow(new IllegalStateException("No Spring context available"));
+
+        // When & Then
+        assertDoesNotThrow(
+            () -> extension.beforeAll(extensionContext),
+            "should not throw when Spring context is not available");
+      }
+    }
+
+    /** Verifies that beforeAll handles context with no beans at all. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should handle context with no beans")
+    void shouldHandleGracefully_whenNoBeans() {
+      // Given
+      final var extensionContext = createMockExtensionContext();
+      final var applicationContext = mock(ApplicationContext.class);
+
+      when(applicationContext.containsBean("dbTesterConfiguration")).thenReturn(false);
+      when(applicationContext.containsBean("dataSourceRegistrar")).thenReturn(false);
+
+      try (final var springExtensionMock = mockStatic(SpringExtension.class)) {
+        springExtensionMock
+            .when(() -> SpringExtension.getApplicationContext(extensionContext))
+            .thenReturn(applicationContext);
+
+        // When & Then
+        assertDoesNotThrow(
+            () -> extension.beforeAll(extensionContext),
+            "should not throw when no beans are present");
+      }
+    }
+  }
+
+  /**
+   * Creates a mock ExtensionContext with proper store chain for DatabaseTestExtension.
+   *
+   * <p>The mock configures the context hierarchy required by {@link
+   * io.github.seijikohara.dbtester.junit.jupiter.extension.DatabaseTestExtension#getRegistry} which
+   * uses {@code extensionContext.getRoot().getStore(namespace)}.
+   *
+   * @return the mock ExtensionContext
+   */
+  private static ExtensionContext createMockExtensionContext() {
+    final var store = mock(Store.class);
+    final var rootContext = mock(ExtensionContext.class);
+    final var extensionContext = mock(ExtensionContext.class);
+
+    when(extensionContext.getRoot()).thenReturn(rootContext);
+    when(rootContext.getStore(any(Namespace.class))).thenReturn(store);
+    when(extensionContext.getRequiredTestClass())
+        .thenAnswer(invocation -> SpringBootDatabaseTestExtensionTest.class);
+
+    return extensionContext;
+  }
+}

--- a/db-tester-kotest-spring-boot-starter/build.gradle.kts
+++ b/db-tester-kotest-spring-boot-starter/build.gradle.kts
@@ -36,6 +36,7 @@ testing {
                 implementation(platform(libs.kotest.bom))
                 implementation(libs.kotest.runner.junit5)
                 implementation(libs.kotest.assertions.core)
+                implementation(libs.assertj.core)
                 implementation(libs.mockk)
                 implementation(libs.spring.test)
                 implementation(libs.spring.boot.test)

--- a/db-tester-kotest-spring-boot-starter/src/test/kotlin/io/github/seijikohara/dbtester/kotest/spring/boot/autoconfigure/DbTesterKotestAutoConfigurationContextSpec.kt
+++ b/db-tester-kotest-spring-boot-starter/src/test/kotlin/io/github/seijikohara/dbtester/kotest/spring/boot/autoconfigure/DbTesterKotestAutoConfigurationContextSpec.kt
@@ -1,0 +1,122 @@
+package io.github.seijikohara.dbtester.kotest.spring.boot.autoconfigure
+
+import io.github.seijikohara.dbtester.api.config.Configuration
+import io.github.seijikohara.dbtester.api.config.DataSourceRegistry
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+
+/**
+ * Auto-configuration context tests for [DbTesterKotestAutoConfiguration].
+ *
+ * These tests use [ApplicationContextRunner] to verify conditional auto-configuration
+ * behavior, including property-based activation, bean registration, and custom bean overrides.
+ */
+class DbTesterKotestAutoConfigurationContextSpec : AnnotationSpec() {
+    /** Base context runner with the auto-configuration registered. */
+    private val contextRunner =
+        ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(DbTesterKotestAutoConfiguration::class.java))
+
+    @Test
+    fun `should register all beans with default properties`() {
+        contextRunner.run { context ->
+            context.containsBean("dbTesterConfiguration") shouldBe true
+            context.containsBean("dbTesterDataSourceRegistry") shouldBe true
+            context.containsBean("dataSourceRegistrar") shouldBe true
+        }
+    }
+
+    @Test
+    fun `should register Configuration bean with correct type`() {
+        contextRunner.run { context ->
+            context.getBean("dbTesterConfiguration").shouldBeInstanceOf<Configuration>()
+        }
+    }
+
+    @Test
+    fun `should register DataSourceRegistry bean with correct type`() {
+        contextRunner.run { context ->
+            context.getBean("dbTesterDataSourceRegistry").shouldBeInstanceOf<DataSourceRegistry>()
+        }
+    }
+
+    @Test
+    fun `should register DataSourceRegistrar bean with correct type`() {
+        contextRunner.run { context ->
+            context.getBean("dataSourceRegistrar").shouldBeInstanceOf<DataSourceRegistrar>()
+        }
+    }
+
+    @Test
+    fun `should not register beans when disabled`() {
+        contextRunner
+            .withPropertyValues("db-tester.enabled=false")
+            .run { context ->
+                context.containsBean("dbTesterConfiguration") shouldBe false
+                context.containsBean("dbTesterDataSourceRegistry") shouldBe false
+                context.containsBean("dataSourceRegistrar") shouldBe false
+            }
+    }
+
+    @Test
+    fun `should register beans when explicitly enabled`() {
+        contextRunner
+            .withPropertyValues("db-tester.enabled=true")
+            .run { context ->
+                context.containsBean("dbTesterConfiguration") shouldBe true
+            }
+    }
+
+    @Test
+    fun `should register beans when property is not set`() {
+        contextRunner.run { context ->
+            context.containsBean("dbTesterConfiguration") shouldBe true
+        }
+    }
+
+    @Test
+    fun `should use custom Configuration when provided`() {
+        val customConfig = Configuration.defaults()
+        contextRunner
+            .withBean("dbTesterConfiguration", Configuration::class.java, { customConfig })
+            .run { context ->
+                context.containsBean("dbTesterConfiguration") shouldBe true
+                (context.getBean("dbTesterConfiguration") === customConfig) shouldBe true
+            }
+    }
+
+    @Test
+    fun `should use custom DataSourceRegistry when provided`() {
+        val customRegistry = DataSourceRegistry()
+        contextRunner
+            .withBean("dbTesterDataSourceRegistry", DataSourceRegistry::class.java, { customRegistry })
+            .run { context ->
+                (context.getBean("dbTesterDataSourceRegistry") === customRegistry) shouldBe true
+            }
+    }
+
+    @Test
+    fun `should bind convention properties`() {
+        contextRunner
+            .withPropertyValues(
+                "db-tester.convention.expectation-suffix=/verify",
+                "db-tester.convention.scenario-marker=[Test]",
+            ).run { context ->
+                val config = context.getBean("dbTesterConfiguration", Configuration::class.java)
+                config.conventions().expectationSuffix() shouldBe "/verify"
+                config.conventions().scenarioMarker() shouldBe "[Test]"
+            }
+    }
+
+    @Test
+    fun `should bind auto-register-data-sources property`() {
+        contextRunner
+            .withPropertyValues("db-tester.auto-register-data-sources=false")
+            .run { context ->
+                context.getBean(DbTesterProperties::class.java).isAutoRegisterDataSources shouldBe false
+            }
+    }
+}

--- a/db-tester-spock-spring-boot-starter/build.gradle.kts
+++ b/db-tester-spock-spring-boot-starter/build.gradle.kts
@@ -42,6 +42,7 @@ testing {
             dependencies {
                 implementation(platform(libs.mockito.bom))
                 implementation(libs.mockito.core)
+                implementation(libs.assertj.core)
                 implementation(libs.spring.test)
                 implementation(libs.spring.boot.test)
                 runtimeOnly(platform(libs.slf4j.bom))

--- a/db-tester-spock-spring-boot-starter/src/test/groovy/io/github/seijikohara/dbtester/spock/spring/boot/autoconfigure/DbTesterSpockAutoConfigurationContextSpec.groovy
+++ b/db-tester-spock-spring-boot-starter/src/test/groovy/io/github/seijikohara/dbtester/spock/spring/boot/autoconfigure/DbTesterSpockAutoConfigurationContextSpec.groovy
@@ -1,0 +1,126 @@
+package io.github.seijikohara.dbtester.spock.spring.boot.autoconfigure
+
+import io.github.seijikohara.dbtester.api.config.Configuration
+import io.github.seijikohara.dbtester.api.config.DataSourceRegistry
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import spock.lang.Specification
+
+/**
+ * Auto-configuration context tests for {@link DbTesterSpockAutoConfiguration}.
+ *
+ * <p>These tests use {@link ApplicationContextRunner} to verify conditional
+ * auto-configuration behavior, including property-based activation, bean
+ * registration, and custom bean overrides.
+ */
+class DbTesterSpockAutoConfigurationContextSpec extends Specification {
+
+	/** Base context runner with the auto-configuration registered. */
+	ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+	.withConfiguration(AutoConfigurations.of(DbTesterSpockAutoConfiguration))
+
+	def 'should register all beans with default properties'() {
+		expect: 'all beans are registered with default properties'
+		contextRunner.run { context ->
+			assert context.containsBean('dbTesterConfiguration')
+			assert context.containsBean('dbTesterDataSourceRegistry')
+			assert context.containsBean('dataSourceRegistrar')
+		}
+	}
+
+	def 'should register Configuration bean with correct type'() {
+		expect: 'Configuration bean is correct type'
+		contextRunner.run { context ->
+			assert context.getBean('dbTesterConfiguration') instanceof Configuration
+		}
+	}
+
+	def 'should register DataSourceRegistry bean with correct type'() {
+		expect: 'DataSourceRegistry bean is correct type'
+		contextRunner.run { context ->
+			assert context.getBean('dbTesterDataSourceRegistry') instanceof DataSourceRegistry
+		}
+	}
+
+	def 'should register DataSourceRegistrar bean with correct type'() {
+		expect: 'DataSourceRegistrar bean is correct type'
+		contextRunner.run { context ->
+			assert context.getBean('dataSourceRegistrar') instanceof DataSourceRegistrar
+		}
+	}
+
+	def 'should not register beans when disabled'() {
+		expect: 'no beans are registered when disabled'
+		contextRunner
+				.withPropertyValues('db-tester.enabled=false')
+				.run { context ->
+					assert !context.containsBean('dbTesterConfiguration')
+					assert !context.containsBean('dbTesterDataSourceRegistry')
+					assert !context.containsBean('dataSourceRegistrar')
+				}
+	}
+
+	def 'should register beans when explicitly enabled'() {
+		expect: 'beans are registered when explicitly enabled'
+		contextRunner
+				.withPropertyValues('db-tester.enabled=true')
+				.run { context ->
+					assert context.containsBean('dbTesterConfiguration')
+				}
+	}
+
+	def 'should register beans when property is not set'() {
+		expect: 'beans are registered by default'
+		contextRunner.run { context ->
+			assert context.containsBean('dbTesterConfiguration')
+		}
+	}
+
+	def 'should use custom Configuration when provided'() {
+		given: 'a custom Configuration bean'
+		def customConfig = Configuration.defaults()
+
+		expect: 'custom Configuration is used'
+		contextRunner
+				.withBean('dbTesterConfiguration', Configuration) { -> customConfig }
+				.run { context ->
+					assert context.containsBean('dbTesterConfiguration')
+					assert context.getBean('dbTesterConfiguration').is(customConfig)
+				}
+	}
+
+	def 'should use custom DataSourceRegistry when provided'() {
+		given: 'a custom DataSourceRegistry bean'
+		def customRegistry = new DataSourceRegistry()
+
+		expect: 'custom DataSourceRegistry is used'
+		contextRunner
+				.withBean('dbTesterDataSourceRegistry', DataSourceRegistry) { -> customRegistry }
+				.run { context ->
+					assert context.getBean('dbTesterDataSourceRegistry').is(customRegistry)
+				}
+	}
+
+	def 'should bind convention properties'() {
+		expect: 'convention properties are bound'
+		contextRunner
+				.withPropertyValues(
+				'db-tester.convention.expectation-suffix=/verify',
+				'db-tester.convention.scenario-marker=[Test]')
+				.run { context ->
+					def config = context.getBean('dbTesterConfiguration', Configuration)
+					assert config.conventions().expectationSuffix() == '/verify'
+					assert config.conventions().scenarioMarker() == '[Test]'
+				}
+	}
+
+	def 'should bind auto-register-data-sources property'() {
+		expect: 'property is bound correctly'
+		contextRunner
+				.withPropertyValues('db-tester.auto-register-data-sources=false')
+				.run { context ->
+					def properties = context.getBean(DbTesterProperties)
+					assert !properties.autoRegisterDataSources
+				}
+	}
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+assertj = "3.27.6"
 axion-release = "1.21.1"
 checker-qual = "3.53.1"
 datafaker = "2.4.2"
@@ -33,6 +34,7 @@ testcontainers = "2.0.3"
 version-catalog-update = "1.0.1"
 
 [libraries]
+assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 checker-qual = { module = "org.checkerframework:checker-qual", version.ref = "checker-qual" }
 datafaker = { module = "net.datafaker:datafaker", version.ref = "datafaker" }
 derby-client = { module = "org.apache.derby:derbyclient", version.ref = "derby" }


### PR DESCRIPTION
## Summary
- Add `SpringBootDatabaseTestExtensionTest` (JUnit) with `mockStatic` for `beforeAll()` branch coverage
- Add `DbTesterJUnitAutoConfigurationContextTest`, `DbTesterSpockAutoConfigurationContextSpec`, and `DbTesterKotestAutoConfigurationContextSpec` using `ApplicationContextRunner` for conditional auto-configuration testing
- Add `assertj-core` test dependency to all three starters (required by `ApplicationContextRunner`)

## Test plan
- [x] JUnit starter build passes with all new tests
- [x] Spock starter build passes with all new tests
- [x] Kotest starter build passes with all new tests
- [ ] CI `test (21)` passes
- [ ] CI `test (25)` passes

Closes #180