### PR TITLE
docs(api): categorize API packages into User, Extension, and Domain layers

### DIFF
--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/context/package-info.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/context/package-info.java
@@ -1,6 +1,10 @@
 /**
  * Test context abstraction for framework-agnostic test execution.
  *
+ * <p><strong>API Category: Extension API</strong> — This package is intended for framework
+ * integrators building custom testing extensions. Test authors typically do not interact with this
+ * package directly.
+ *
  * <p>This package provides the {@link io.github.seijikohara.dbtester.api.context.TestContext}
  * record which captures the essential context of a running test, independent of any specific
  * testing framework.

--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/dataset/package-info.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/dataset/package-info.java
@@ -1,6 +1,9 @@
 /**
  * Dataset abstraction for representing database tables and rows.
  *
+ * <p><strong>API Category: Domain Types</strong> — Shared value objects used across both User API
+ * and Extension API. These types appear in method signatures throughout the framework.
+ *
  * <p>This package contains the core interfaces for representing database data in a format-agnostic
  * way. The main interfaces are:
  *

--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/domain/package-info.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/domain/package-info.java
@@ -1,6 +1,9 @@
 /**
  * Type-safe domain value objects for database identifiers, metadata, and values.
  *
+ * <p><strong>API Category: Domain Types</strong> — Shared value objects used across both User API
+ * and Extension API. These types appear in method signatures throughout the framework.
+ *
  * <p>This package contains immutable value objects that provide compile-time type safety and rich
  * domain modeling for database testing.
  *

--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/loader/package-info.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/loader/package-info.java
@@ -1,4 +1,10 @@
-/** Public SPI for components that load datasets prior to execution or validation. */
+/**
+ * Dataset loading SPI for components that load datasets prior to execution or validation.
+ *
+ * <p><strong>API Category: Extension API</strong> — This package is intended for framework
+ * integrators building custom testing extensions. Test authors typically do not interact with this
+ * package directly.
+ */
 @NullMarked
 package io.github.seijikohara.dbtester.api.loader;
 

--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/scenario/package-info.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/scenario/package-info.java
@@ -1,6 +1,10 @@
 /**
  * Scenario name resolution API for test framework integration.
  *
+ * <p><strong>API Category: Extension API</strong> — This package is intended for framework
+ * integrators building custom testing extensions. Test authors typically do not interact with this
+ * package directly.
+ *
  * <p>This package provides the SPI for resolving test scenario names from test methods. Different
  * test frameworks (JUnit, Spock, Kotest) have different conventions for naming tests, and this SPI
  * allows each framework to provide its own implementation.

--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/spi/package-info.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/spi/package-info.java
@@ -1,6 +1,10 @@
 /**
  * Service Provider Interfaces (SPI) for framework extensibility.
  *
+ * <p><strong>API Category: Extension API</strong> — This package is intended for framework
+ * integrators building custom testing extensions. Test authors typically do not interact with this
+ * package directly.
+ *
  * <p>This package contains SPI interfaces that allow the API module to remain independent of
  * specific implementations. Implementations are provided by the core module and loaded via {@link
  * java.util.ServiceLoader}.

--- a/db-tester-api/src/main/java/module-info.java
+++ b/db-tester-api/src/main/java/module-info.java
@@ -1,9 +1,47 @@
 /**
  * DB Tester API module providing public interfaces for database testing.
  *
- * <p>This module contains the public API that users interact with when using the db-tester library.
- * It defines annotations, configuration types, domain objects, and SPI interfaces that are
- * implemented by the core module.
+ * <p>This module exports packages in three categories:
+ *
+ * <h2>User API</h2>
+ *
+ * <p>Packages intended for test authors writing database tests. These packages form the stable,
+ * primary API surface and follow semantic versioning for backward compatibility.
+ *
+ * <ul>
+ *   <li>{@code annotation} — Declarative test annotations ({@code @DataSet},
+ *       {@code @ExpectedDataSet}, {@code @DataSetSource})
+ *   <li>{@code assertion} — Programmatic database assertion utilities
+ *   <li>{@code config} — Configuration types ({@code Configuration}, {@code DataSourceRegistry})
+ *   <li>{@code exception} — Framework exception hierarchy
+ *   <li>{@code export} — Data export API for writing database content to files
+ *   <li>{@code operation} — Database operation enumerations ({@code Operation}, {@code
+ *       TableOrderingStrategy})
+ *   <li>{@code preparation} — Programmatic test data preparation facade
+ * </ul>
+ *
+ * <h2>Extension API</h2>
+ *
+ * <p>Packages intended for framework integrators building custom testing extensions (JUnit, Spock,
+ * Kotest, or custom frameworks). These packages are stable but target advanced users.
+ *
+ * <ul>
+ *   <li>{@code context} — Test context abstraction for framework-agnostic test execution
+ *   <li>{@code loader} — Dataset loading SPI
+ *   <li>{@code scenario} — Scenario name resolution for test framework integration
+ *   <li>{@code spi} — Service Provider Interfaces for core extensibility
+ * </ul>
+ *
+ * <h2>Domain Types</h2>
+ *
+ * <p>Shared value objects and data structures used across both User API and Extension API. These
+ * types appear in method signatures throughout the framework.
+ *
+ * <ul>
+ *   <li>{@code dataset} — Format-agnostic dataset abstractions ({@code TableSet}, {@code Table},
+ *       {@code Row})
+ *   <li>{@code domain} — Type-safe value objects for database identifiers and metadata
+ * </ul>
  */
 module io.github.seijikohara.dbtester.api {
   // Required modules (transitive because DataSource and @Nullable are part of our public API)
@@ -11,20 +49,24 @@ module io.github.seijikohara.dbtester.api {
   requires transitive org.jspecify;
   requires static org.slf4j;
 
-  // Export public API packages
+  // --- User API: packages for test authors ---
   exports io.github.seijikohara.dbtester.api.annotation;
   exports io.github.seijikohara.dbtester.api.assertion;
   exports io.github.seijikohara.dbtester.api.config;
-  exports io.github.seijikohara.dbtester.api.context;
-  exports io.github.seijikohara.dbtester.api.dataset;
-  exports io.github.seijikohara.dbtester.api.domain;
   exports io.github.seijikohara.dbtester.api.exception;
   exports io.github.seijikohara.dbtester.api.export;
-  exports io.github.seijikohara.dbtester.api.loader;
   exports io.github.seijikohara.dbtester.api.operation;
   exports io.github.seijikohara.dbtester.api.preparation;
+
+  // --- Extension API: packages for framework integrators ---
+  exports io.github.seijikohara.dbtester.api.context;
+  exports io.github.seijikohara.dbtester.api.loader;
   exports io.github.seijikohara.dbtester.api.scenario;
   exports io.github.seijikohara.dbtester.api.spi;
+
+  // --- Domain types: shared value objects ---
+  exports io.github.seijikohara.dbtester.api.dataset;
+  exports io.github.seijikohara.dbtester.api.domain;
 
   // SPI for implementations
   uses io.github.seijikohara.dbtester.api.spi.AssertionProvider;

--- a/docs/specs/public-api.md
+++ b/docs/specs/public-api.md
@@ -5,6 +5,44 @@ description: "Comprehensive API reference for DB Tester annotations, configurati
 
 # DB Tester Specification - Public API
 
+## API Categories
+
+The `db-tester-api` module exports packages in three categories:
+
+### User API
+
+Packages intended for test authors writing database tests. These packages form the stable, primary API surface.
+
+| Package | Description |
+|---------|-------------|
+| `annotation` | Declarative test annotations (`@DataSet`, `@ExpectedDataSet`, `@DataSetSource`) |
+| `assertion` | Programmatic database assertion utilities (`DatabaseAssertion`) |
+| `config` | Configuration types (`Configuration`, `DataSourceRegistry`, `ConventionSettings`) |
+| `exception` | Framework exception hierarchy |
+| `export` | Data export API (`DataSetExporter`) |
+| `operation` | Database operation enumerations (`Operation`, `TableOrderingStrategy`) |
+| `preparation` | Programmatic test data preparation facade (`DatabasePreparation`) |
+
+### Extension API
+
+Packages intended for framework integrators building custom testing extensions (JUnit, Spock, Kotest, or custom frameworks). These packages are stable but target advanced users.
+
+| Package | Description |
+|---------|-------------|
+| `context` | Test context abstraction (`TestContext`) |
+| `loader` | Dataset loading SPI (`DataSetLoader`, `ExpectedTableSet`) |
+| `scenario` | Scenario name resolution (`ScenarioNameResolver`, `ScenarioName`) |
+| `spi` | Service Provider Interfaces for core extensibility |
+
+### Domain Types
+
+Shared value objects and data structures used across both User API and Extension API. These types appear in method signatures throughout the framework.
+
+| Package | Description |
+|---------|-------------|
+| `dataset` | Format-agnostic dataset abstractions (`TableSet`, `Table`, `Row`) |
+| `domain` | Type-safe value objects for database identifiers and metadata |
+
 ## Annotations
 
 ### @DataSet


### PR DESCRIPTION
## Summary
- Categorize 13 exported packages in `module-info.java` into three layers: User API (7), Extension API (4), Domain Types (2)
- Add `API Category` labels to `package-info.java` for Extension API and Domain packages
- Add API Categories section to `docs/specs/public-api.md` with tables documenting each layer

## Test plan
- [x] `db-tester-api` build passes
- [x] Javadoc generates without errors
- [x] No behavioral changes (documentation only)
- [ ] CI `test (21)` passes
- [ ] CI `test (25)` passes

Closes #170