### PR TITLE
refactor(core): move comparison logic from ComparisonStrategy to ComparisonEngine

### DIFF
--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/domain/Cell.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/domain/Cell.java
@@ -145,7 +145,11 @@ public final class Cell {
    * @param other the value to compare with
    * @return {@code true} if the values match according to the column's strategy, {@code false}
    *     otherwise
+   * @deprecated Use {@code ComparisonEngine.matches(strategy, expected, actual)} in the core module
+   *     instead. Removed in 2.0.
    */
+  @Deprecated(since = "1.1", forRemoval = true)
+  @SuppressWarnings("removal")
   public boolean matches(final CellValue other) {
     return column.getComparisonStrategy().matches(value.value(), other.value());
   }
@@ -158,7 +162,10 @@ public final class Cell {
    * @param other the cell to compare with
    * @return {@code true} if the values match according to this column's strategy, {@code false}
    *     otherwise
+   * @deprecated Use {@code ComparisonEngine.matches(strategy, expected, actual)} in the core module
+   *     instead. Removed in 2.0.
    */
+  @Deprecated(since = "1.1", forRemoval = true)
   public boolean matches(final Cell other) {
     return matches(other.value);
   }

--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/domain/ComparisonStrategy.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/domain/ComparisonStrategy.java
@@ -257,7 +257,10 @@ public final class ComparisonStrategy {
    * @param expected the expected value
    * @param actual the actual value
    * @return {@code true} if the values match according to this strategy, {@code false} otherwise
+   * @deprecated Use {@code ComparisonEngine.matches(strategy, expected, actual)} in the core module
+   *     instead. Comparison logic is moving from API descriptors to core execution. Removed in 2.0.
    */
+  @Deprecated(since = "1.1", forRemoval = true)
   public boolean matches(final @Nullable Object expected, final @Nullable Object actual) {
     return switch (type) {
       case STRICT -> Objects.equals(expected, actual);

--- a/db-tester-api/src/test/java/io/github/seijikohara/dbtester/api/domain/CellTest.java
+++ b/db-tester-api/src/test/java/io/github/seijikohara/dbtester/api/domain/CellTest.java
@@ -273,6 +273,7 @@ class CellTest {
   /** Tests for matches method. */
   @Nested
   @DisplayName("matches")
+  @SuppressWarnings("removal")
   class Matches {
 
     /** Tests for matches method. */

--- a/db-tester-api/src/test/java/io/github/seijikohara/dbtester/api/domain/ComparisonStrategyTest.java
+++ b/db-tester-api/src/test/java/io/github/seijikohara/dbtester/api/domain/ComparisonStrategyTest.java
@@ -23,6 +23,7 @@ class ComparisonStrategyTest {
   /** Tests for STRICT strategy. */
   @Nested
   @DisplayName("STRICT strategy")
+  @SuppressWarnings("removal")
   class StrictStrategyTests {
 
     /** Tests for STRICT strategy. */
@@ -70,6 +71,7 @@ class ComparisonStrategyTest {
   /** Tests for IGNORE strategy. */
   @Nested
   @DisplayName("IGNORE strategy")
+  @SuppressWarnings("removal")
   class IgnoreStrategyTests {
 
     /** Tests for IGNORE strategy. */
@@ -102,6 +104,7 @@ class ComparisonStrategyTest {
   /** Tests for NUMERIC strategy. */
   @Nested
   @DisplayName("NUMERIC strategy")
+  @SuppressWarnings("removal")
   class NumericStrategyTests {
 
     /** Tests for NUMERIC strategy. */
@@ -165,6 +168,7 @@ class ComparisonStrategyTest {
   /** Tests for CASE_INSENSITIVE strategy. */
   @Nested
   @DisplayName("CASE_INSENSITIVE strategy")
+  @SuppressWarnings("removal")
   class CaseInsensitiveStrategyTests {
 
     /** Tests for CASE_INSENSITIVE strategy. */
@@ -218,6 +222,7 @@ class ComparisonStrategyTest {
   /** Tests for TIMESTAMP_FLEXIBLE strategy. */
   @Nested
   @DisplayName("TIMESTAMP_FLEXIBLE strategy")
+  @SuppressWarnings("removal")
   class TimestampFlexibleStrategyTests {
 
     /** Tests for TIMESTAMP_FLEXIBLE strategy. */
@@ -407,6 +412,7 @@ class ComparisonStrategyTest {
   /** Tests for NOT_NULL strategy. */
   @Nested
   @DisplayName("NOT_NULL strategy")
+  @SuppressWarnings("removal")
   class NotNullStrategyTests {
 
     /** Tests for NOT_NULL strategy. */
@@ -445,6 +451,7 @@ class ComparisonStrategyTest {
   /** Tests for REGEX strategy. */
   @Nested
   @DisplayName("REGEX strategy")
+  @SuppressWarnings("removal")
   class RegexStrategyTests {
 
     /** Tests for REGEX strategy. */
@@ -561,6 +568,7 @@ class ComparisonStrategyTest {
   /** Tests for DATE_FLEXIBLE strategy. */
   @Nested
   @DisplayName("DATE_FLEXIBLE strategy")
+  @SuppressWarnings("removal")
   class DateFlexibleStrategyTests {
 
     /** Tests for DATE_FLEXIBLE strategy. */
@@ -645,6 +653,7 @@ class ComparisonStrategyTest {
   /** Tests for JSON_EQUIVALENT strategy. */
   @Nested
   @DisplayName("JSON_EQUIVALENT strategy")
+  @SuppressWarnings("removal")
   class JsonEquivalentStrategyTests {
 
     /** Tests for JSON_EQUIVALENT strategy. */
@@ -758,6 +767,7 @@ class ComparisonStrategyTest {
   /** Tests for CONTAINS strategy. */
   @Nested
   @DisplayName("CONTAINS strategy")
+  @SuppressWarnings("removal")
   class ContainsStrategyTests {
 
     /** Tests for CONTAINS strategy. */
@@ -835,6 +845,7 @@ class ComparisonStrategyTest {
   /** Tests for RANGE strategy. */
   @Nested
   @DisplayName("RANGE strategy")
+  @SuppressWarnings("removal")
   class RangeStrategyTests {
 
     /** Tests for RANGE strategy. */

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/assertion/ComparisonEngine.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/assertion/ComparisonEngine.java
@@ -1,0 +1,495 @@
+package io.github.seijikohara.dbtester.internal.assertion;
+
+import io.github.seijikohara.dbtester.api.domain.ComparisonStrategy;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Executes comparison logic for {@link ComparisonStrategy} descriptors.
+ *
+ * <p>This class contains all comparison implementations that were previously embedded in {@code
+ * ComparisonStrategy}. The API module defines descriptors (what to compare), while this class
+ * handles execution (how to compare).
+ *
+ * @see ComparisonStrategy
+ */
+public final class ComparisonEngine {
+
+  /** Pattern for parsing RANGE options in format "min=N,max=M". */
+  private static final Pattern RANGE_OPTIONS_PATTERN =
+      Pattern.compile("min\\s*=\\s*([\\d.eE+\\-]+)\\s*,\\s*max\\s*=\\s*([\\d.eE+\\-]+)");
+
+  /** Formatter for timestamps with timezone offset. */
+  private static final DateTimeFormatter FLEXIBLE_OFFSET_FORMATTER =
+      new DateTimeFormatterBuilder()
+          .append(DateTimeFormatter.ISO_LOCAL_DATE)
+          .appendLiteral('T')
+          .appendValue(ChronoField.HOUR_OF_DAY, 2)
+          .appendLiteral(':')
+          .appendValue(ChronoField.MINUTE_OF_HOUR, 2)
+          .optionalStart()
+          .appendLiteral(':')
+          .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
+          .optionalEnd()
+          .optionalStart()
+          .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
+          .optionalEnd()
+          .appendOffset("+HH:MM", "Z")
+          .toFormatter();
+
+  /** Formatter for timestamps without timezone (treated as UTC). */
+  private static final DateTimeFormatter FLEXIBLE_LOCAL_FORMATTER =
+      new DateTimeFormatterBuilder()
+          .append(DateTimeFormatter.ISO_LOCAL_DATE)
+          .appendLiteral('T')
+          .appendValue(ChronoField.HOUR_OF_DAY, 2)
+          .appendLiteral(':')
+          .appendValue(ChronoField.MINUTE_OF_HOUR, 2)
+          .optionalStart()
+          .appendLiteral(':')
+          .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
+          .optionalEnd()
+          .optionalStart()
+          .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
+          .optionalEnd()
+          .toFormatter();
+
+  /** Pattern for slash-separated date format (yyyy/MM/dd). */
+  private static final DateTimeFormatter SLASH_DATE_FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy/MM/dd");
+
+  /** Pattern for dot-separated date format (yyyy.MM.dd). */
+  private static final DateTimeFormatter DOT_DATE_FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+  /** Prevents instantiation. */
+  private ComparisonEngine() {}
+
+  /**
+   * Compares two values according to the specified strategy.
+   *
+   * @param strategy the comparison strategy descriptor
+   * @param expected the expected value
+   * @param actual the actual value
+   * @return {@code true} if the values match according to the strategy, {@code false} otherwise
+   */
+  @SuppressWarnings("removal")
+  public static boolean matches(
+      final ComparisonStrategy strategy,
+      final @Nullable Object expected,
+      final @Nullable Object actual) {
+    return switch (strategy.getType()) {
+      case STRICT -> Objects.equals(expected, actual);
+      case IGNORE -> true;
+      case NUMERIC -> compareNumeric(expected, actual);
+      case CASE_INSENSITIVE -> compareCaseInsensitive(expected, actual);
+      case TIMESTAMP_FLEXIBLE -> compareTimestamp(expected, actual);
+      case DATE_FLEXIBLE -> compareDateFlexible(expected, actual);
+      case JSON_EQUIVALENT -> compareJsonEquivalent(expected, actual);
+      case NOT_NULL -> actual != null;
+      case REGEX -> matchesRegex(strategy, actual);
+      case CONTAINS -> matchesContains(strategy, expected, actual);
+      case RANGE -> matchesRange(strategy, actual);
+    };
+  }
+
+  // ========== Numeric comparison ==========
+
+  /**
+   * Compares two values numerically.
+   *
+   * @param expected the expected value
+   * @param actual the actual value
+   * @return {@code true} if numerically equal, {@code false} otherwise
+   */
+  private static boolean compareNumeric(
+      final @Nullable Object expected, final @Nullable Object actual) {
+    return compareNullable(expected, actual, ComparisonEngine::compareNumericValues);
+  }
+
+  /**
+   * Compares two non-null values numerically.
+   *
+   * @param expected the expected value (non-null)
+   * @param actual the actual value (non-null)
+   * @return {@code true} if numerically equal, {@code false} otherwise
+   */
+  private static boolean compareNumericValues(final Object expected, final Object actual) {
+    try {
+      return toNumber(expected)
+          .flatMap(
+              expNum ->
+                  toNumber(actual)
+                      .map(
+                          actNum -> {
+                            final var expectedDecimal = new BigDecimal(expNum.toString());
+                            final var actualDecimal = new BigDecimal(actNum.toString());
+                            return expectedDecimal.compareTo(actualDecimal) == 0;
+                          }))
+          .orElseGet(() -> Objects.equals(expected, actual));
+    } catch (final NumberFormatException e) {
+      return Objects.equals(expected, actual);
+    }
+  }
+
+  /**
+   * Converts an object to a Number if possible.
+   *
+   * @param value the value to convert
+   * @return the number, or empty if not convertible
+   */
+  private static Optional<Number> toNumber(final Object value) {
+    if (value instanceof Number num) {
+      return Optional.of(num);
+    }
+    if (value instanceof String str) {
+      try {
+        return Optional.of(new BigDecimal(str.trim()));
+      } catch (final NumberFormatException e) {
+        return Optional.empty();
+      }
+    }
+    return Optional.empty();
+  }
+
+  // ========== Case-insensitive comparison ==========
+
+  /**
+   * Compares two values case-insensitively.
+   *
+   * @param expected the expected value
+   * @param actual the actual value
+   * @return {@code true} if case-insensitively equal, {@code false} otherwise
+   */
+  private static boolean compareCaseInsensitive(
+      final @Nullable Object expected, final @Nullable Object actual) {
+    return compareNullable(
+        expected, actual, (exp, act) -> exp.toString().equalsIgnoreCase(act.toString()));
+  }
+
+  // ========== Timestamp comparison ==========
+
+  /**
+   * Compares two timestamp values with flexible precision.
+   *
+   * <p>Converts both timestamps to UTC epoch seconds for comparison, properly handling timezone
+   * differences. If timezone information is not present, the timestamp is treated as UTC.
+   *
+   * @param expected the expected value
+   * @param actual the actual value
+   * @return {@code true} if timestamps represent the same instant (ignoring sub-second precision),
+   *     {@code false} otherwise
+   */
+  private static boolean compareTimestamp(
+      final @Nullable Object expected, final @Nullable Object actual) {
+    return compareNullable(
+        expected,
+        actual,
+        (exp, act) -> {
+          final var expectedEpoch = parseToEpochSecond(exp.toString());
+          final var actualEpoch = parseToEpochSecond(act.toString());
+          return expectedEpoch.equals(actualEpoch);
+        });
+  }
+
+  /**
+   * Parses a timestamp string to epoch seconds (UTC).
+   *
+   * <p>Supports various timestamp formats:
+   *
+   * <ul>
+   *   <li>ISO-8601 with offset: "2024-01-15T10:30:00+09:00"
+   *   <li>ISO-8601 with Z: "2024-01-15T10:30:00Z"
+   *   <li>SQL timestamp with offset: "2024-01-15 10:30:00+09:00"
+   *   <li>SQL timestamp without offset: "2024-01-15 10:30:00" (treated as UTC)
+   *   <li>With fractional seconds: "2024-01-15T10:30:00.123456+09:00"
+   * </ul>
+   *
+   * @param timestamp the timestamp string
+   * @return epoch seconds in UTC, or the original string if parsing fails
+   */
+  private static Object parseToEpochSecond(final String timestamp) {
+    final var normalized = timestamp.trim().replace(' ', 'T');
+
+    // Try parsing as OffsetDateTime (with timezone)
+    try {
+      final var odt = OffsetDateTime.parse(normalized, FLEXIBLE_OFFSET_FORMATTER);
+      return odt.toEpochSecond();
+    } catch (final DateTimeParseException ignored) {
+      // Continue to next format
+    }
+
+    // Try parsing as LocalDateTime (without timezone, treat as UTC)
+    try {
+      final var ldt = LocalDateTime.parse(normalized, FLEXIBLE_LOCAL_FORMATTER);
+      return ldt.toEpochSecond(ZoneOffset.UTC);
+    } catch (final DateTimeParseException ignored) {
+      // Continue to next format
+    }
+
+    // Try parsing as Instant
+    try {
+      return Instant.parse(normalized).getEpochSecond();
+    } catch (final DateTimeParseException ignored) {
+      // Parsing failed, return original string for equals comparison
+    }
+
+    return timestamp;
+  }
+
+  // ========== Date flexible comparison ==========
+
+  /**
+   * Compares two date values with format flexibility.
+   *
+   * <p>Supports ISO-8601 (yyyy-MM-dd), slashed (yyyy/MM/dd), and SQL date formats. Both values are
+   * parsed to {@link LocalDate} and compared.
+   *
+   * @param expected the expected value
+   * @param actual the actual value
+   * @return {@code true} if both values represent the same date, {@code false} otherwise
+   */
+  private static boolean compareDateFlexible(
+      final @Nullable Object expected, final @Nullable Object actual) {
+    return compareNullable(
+        expected,
+        actual,
+        (exp, act) -> {
+          final var expectedDate = parseToLocalDate(exp.toString());
+          final var actualDate = parseToLocalDate(act.toString());
+          return expectedDate.equals(actualDate);
+        });
+  }
+
+  /**
+   * Parses a date string to a LocalDate using multiple format attempts.
+   *
+   * <p>Tries the following formats in order: ISO-8601 (yyyy-MM-dd), slashed (yyyy/MM/dd), dot
+   * (yyyy.MM.dd). If a timestamp format is detected (contains 'T' or space followed by time), the
+   * date portion is extracted first.
+   *
+   * @param dateStr the date string to parse
+   * @return the parsed LocalDate, or the original string if parsing fails
+   */
+  private static Object parseToLocalDate(final String dateStr) {
+    final var trimmed = dateStr.trim();
+
+    // Extract date portion from timestamp if needed
+    final var datePart = extractDatePortion(trimmed);
+
+    // Try ISO-8601 format (yyyy-MM-dd)
+    try {
+      return LocalDate.parse(datePart, DateTimeFormatter.ISO_LOCAL_DATE);
+    } catch (final DateTimeParseException ignored) {
+      // Continue to next format
+    }
+
+    // Try slashed format (yyyy/MM/dd)
+    try {
+      return LocalDate.parse(datePart, SLASH_DATE_FORMATTER);
+    } catch (final DateTimeParseException ignored) {
+      // Continue to next format
+    }
+
+    // Try dot format (yyyy.MM.dd)
+    try {
+      return LocalDate.parse(datePart, DOT_DATE_FORMATTER);
+    } catch (final DateTimeParseException ignored) {
+      // Parsing failed
+    }
+
+    return dateStr;
+  }
+
+  /**
+   * Extracts the date portion from a timestamp string.
+   *
+   * @param value the timestamp or date string
+   * @return the date portion only
+   */
+  private static String extractDatePortion(final String value) {
+    // Handle ISO format with T separator
+    final var tIndex = value.indexOf('T');
+    if (tIndex > 0) {
+      return value.substring(0, tIndex);
+    }
+    // Handle SQL format with space separator (only if time-like pattern follows)
+    final var spaceIndex = value.indexOf(' ');
+    if (spaceIndex > 0 && spaceIndex < value.length() - 1) {
+      final var afterSpace = value.charAt(spaceIndex + 1);
+      if (afterSpace >= '0' && afterSpace <= '9') {
+        return value.substring(0, spaceIndex);
+      }
+    }
+    return value;
+  }
+
+  // ========== JSON equivalent comparison ==========
+
+  /**
+   * Compares two JSON values by structural equivalence.
+   *
+   * <p>Object key order and insignificant whitespace are ignored. Values are normalized before
+   * comparison by parsing and re-serializing with sorted keys.
+   *
+   * @param expected the expected value
+   * @param actual the actual value
+   * @return {@code true} if the JSON structures are equivalent, {@code false} otherwise
+   */
+  private static boolean compareJsonEquivalent(
+      final @Nullable Object expected, final @Nullable Object actual) {
+    return compareNullable(
+        expected,
+        actual,
+        (exp, act) -> {
+          final var expStr = exp.toString();
+          final var actStr = act.toString();
+          if (JsonNormalizer.looksLikeJson(expStr) && JsonNormalizer.looksLikeJson(actStr)) {
+            return JsonNormalizer.normalize(expStr).equals(JsonNormalizer.normalize(actStr));
+          }
+          return Objects.equals(expStr, actStr);
+        });
+  }
+
+  // ========== Contains comparison ==========
+
+  /**
+   * Checks if the actual value contains the expected value (or the configured substring).
+   *
+   * <p>If an options string is configured, the actual value is checked for that substring.
+   * Otherwise, the expected value is used as the substring to find in the actual value.
+   *
+   * @param strategy the comparison strategy with options
+   * @param expected the expected value
+   * @param actual the actual value
+   * @return {@code true} if the actual value contains the substring, {@code false} otherwise
+   */
+  private static boolean matchesContains(
+      final ComparisonStrategy strategy,
+      final @Nullable Object expected,
+      final @Nullable Object actual) {
+    if (actual == null) {
+      return false;
+    }
+    final var actualStr = actual.toString();
+    final var options = strategy.getOptions().orElse(null);
+    if (options != null && !options.isEmpty()) {
+      return actualStr.contains(options);
+    }
+    if (expected == null) {
+      return false;
+    }
+    return actualStr.contains(expected.toString());
+  }
+
+  // ========== Range comparison ==========
+
+  /**
+   * Checks if the actual value falls within the configured numeric range.
+   *
+   * @param strategy the comparison strategy with range options
+   * @param actual the actual value
+   * @return {@code true} if the value is within range (inclusive), {@code false} otherwise
+   */
+  private static boolean matchesRange(
+      final ComparisonStrategy strategy, final @Nullable Object actual) {
+    if (actual == null) {
+      return false;
+    }
+    final var options = strategy.getOptions().orElse(null);
+    if (options == null) {
+      return false;
+    }
+    final Matcher matcher = RANGE_OPTIONS_PATTERN.matcher(options);
+    if (!matcher.matches()) {
+      return false;
+    }
+    try {
+      final var min = new BigDecimal(matcher.group(1));
+      final var max = new BigDecimal(matcher.group(2));
+      final var actualValue = toBigDecimalFromObject(actual);
+      return actualValue.map(v -> v.compareTo(min) >= 0 && v.compareTo(max) <= 0).orElse(false);
+    } catch (final NumberFormatException e) {
+      return false;
+    }
+  }
+
+  /**
+   * Converts an object to BigDecimal if possible.
+   *
+   * @param value the value to convert
+   * @return the BigDecimal, or empty if not convertible
+   */
+  private static Optional<BigDecimal> toBigDecimalFromObject(final Object value) {
+    if (value instanceof Number num) {
+      try {
+        return Optional.of(new BigDecimal(num.toString()));
+      } catch (final NumberFormatException e) {
+        return Optional.empty();
+      }
+    }
+    if (value instanceof String str) {
+      try {
+        return Optional.of(new BigDecimal(str.trim()));
+      } catch (final NumberFormatException e) {
+        return Optional.empty();
+      }
+    }
+    return Optional.empty();
+  }
+
+  // ========== Regex comparison ==========
+
+  /**
+   * Matches the actual value against the strategy's regex pattern.
+   *
+   * @param strategy the comparison strategy with regex pattern
+   * @param actual the actual value
+   * @return {@code true} if the value matches the pattern, {@code false} otherwise
+   */
+  private static boolean matchesRegex(
+      final ComparisonStrategy strategy, final @Nullable Object actual) {
+    return strategy
+        .getPattern()
+        .flatMap(p -> Optional.ofNullable(actual).map(a -> p.matcher(a.toString()).matches()))
+        .orElse(false);
+  }
+
+  // ========== Null-safe comparison utility ==========
+
+  /**
+   * Compares two nullable values using the provided comparator function.
+   *
+   * <p>Returns {@code true} if both values are null (both absent means equal). Returns {@code
+   * false} if exactly one value is null (one absent means not equal). Otherwise, applies the
+   * comparator function to the non-null values.
+   *
+   * @param expected the expected value (nullable)
+   * @param actual the actual value (nullable)
+   * @param comparator the function to compare non-null values
+   * @return {@code true} if the values are considered equal, {@code false} otherwise
+   */
+  private static boolean compareNullable(
+      final @Nullable Object expected,
+      final @Nullable Object actual,
+      final BiFunction<Object, Object, Boolean> comparator) {
+    return Optional.ofNullable(expected)
+        .map(
+            exp -> Optional.ofNullable(actual).map(act -> comparator.apply(exp, act)).orElse(false))
+        .orElseGet(() -> actual == null);
+  }
+}

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/assertion/DataSetComparator.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/assertion/DataSetComparator.java
@@ -751,8 +751,8 @@ public class DataSetComparator {
     final var expectedObj = Optional.ofNullable(expected).map(CellValue::value).orElse(null);
     final var actualObj = Optional.ofNullable(actual).map(CellValue::value).orElse(null);
 
-    // Use the strategy's matches method
-    return strategy.matches(expectedObj, actualObj);
+    // Use ComparisonEngine for comparison execution
+    return ComparisonEngine.matches(strategy, expectedObj, actualObj);
   }
 
   /**

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/assertion/JsonNormalizer.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/assertion/JsonNormalizer.java
@@ -1,0 +1,488 @@
+package io.github.seijikohara.dbtester.internal.assertion;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Normalizes JSON strings for structural comparison.
+ *
+ * <p>This class parses JSON strings and re-serializes them with sorted object keys and consistent
+ * formatting, enabling structural equivalence comparison that ignores key order and whitespace
+ * differences.
+ *
+ * <p>This implementation uses a minimal recursive descent parser without external JSON library
+ * dependencies. It handles standard JSON types: objects, arrays, strings, numbers, booleans, and
+ * null.
+ *
+ * <p>Limitations:
+ *
+ * <ul>
+ *   <li>Maximum nesting depth of {@value #MAX_NESTING_DEPTH} levels
+ *   <li>Maximum input length of {@value #MAX_INPUT_LENGTH} characters
+ *   <li>Unicode surrogate pairs in JSON unicode escapes are handled correctly
+ * </ul>
+ */
+final class JsonNormalizer {
+
+  /** Maximum allowed nesting depth for JSON structures. */
+  static final int MAX_NESTING_DEPTH = 128;
+
+  /** Maximum allowed input length in characters (1 MB of UTF-16). */
+  static final int MAX_INPUT_LENGTH = 1_048_576;
+
+  /** The JSON input string. */
+  private final String input;
+
+  /** Current position in the input string. */
+  private int pos;
+
+  /** Current nesting depth for recursion protection. */
+  private int depth;
+
+  /**
+   * Creates a new JSON normalizer for the specified input.
+   *
+   * @param input the JSON string to normalize
+   */
+  private JsonNormalizer(final String input) {
+    this.input = input;
+    this.pos = 0;
+    this.depth = 0;
+  }
+
+  /**
+   * Normalizes a JSON string by sorting object keys and removing insignificant whitespace.
+   *
+   * <p>Returns the original string unchanged if the input exceeds {@value #MAX_INPUT_LENGTH}
+   * characters or if parsing fails.
+   *
+   * @param json the JSON string to normalize
+   * @return the normalized JSON string, or the original string if parsing fails
+   */
+  static String normalize(final String json) {
+    final var trimmed = json.trim();
+    if (trimmed.length() > MAX_INPUT_LENGTH) {
+      return json;
+    }
+    try {
+      final var normalizer = new JsonNormalizer(trimmed);
+      final var value = normalizer.parseValue();
+      normalizer.skipWhitespace();
+      if (normalizer.pos != normalizer.input.length()) {
+        return json;
+      }
+      return serialize(value);
+    } catch (final JsonParseException e) {
+      return json;
+    }
+  }
+
+  /**
+   * Checks if a string looks like JSON (starts with '{' or '[').
+   *
+   * @param value the string to check
+   * @return true if the string appears to be JSON
+   */
+  static boolean looksLikeJson(final String value) {
+    final var trimmed = value.trim();
+    return (trimmed.startsWith("{") && trimmed.endsWith("}"))
+        || (trimmed.startsWith("[") && trimmed.endsWith("]"));
+  }
+
+  /**
+   * Parses a JSON value.
+   *
+   * <p>JSON string values are wrapped in {@link JsonString} to distinguish them from literal values
+   * (numbers, booleans, null) during serialization.
+   *
+   * @return the parsed value (Map, List, JsonString, or String for literals)
+   * @throws JsonParseException if nesting depth exceeds {@value #MAX_NESTING_DEPTH}
+   */
+  private Object parseValue() {
+    skipWhitespace();
+    if (pos >= input.length()) {
+      throw new JsonParseException("Unexpected end of input");
+    }
+    final var ch = input.charAt(pos);
+    return switch (ch) {
+      case '{' -> {
+        checkDepth();
+        yield parseObject();
+      }
+      case '[' -> {
+        checkDepth();
+        yield parseArray();
+      }
+      case '"' -> new JsonString(parseString());
+      case 't', 'f' -> parseBoolean();
+      case 'n' -> parseNull();
+      default -> {
+        if (ch == '-' || (ch >= '0' && ch <= '9')) {
+          yield parseNumber();
+        }
+        throw new JsonParseException(
+            String.format("Unexpected character: %c at position %d", ch, pos));
+      }
+    };
+  }
+
+  /**
+   * Checks and increments the nesting depth.
+   *
+   * @throws JsonParseException if the maximum nesting depth is exceeded
+   */
+  private void checkDepth() {
+    depth++;
+    if (depth > MAX_NESTING_DEPTH) {
+      throw new JsonParseException(
+          String.format("Maximum nesting depth of %d exceeded", MAX_NESTING_DEPTH));
+    }
+  }
+
+  /**
+   * Parses a JSON object.
+   *
+   * @return a TreeMap with sorted keys
+   */
+  private Map<String, Object> parseObject() {
+    final var map = new TreeMap<String, Object>();
+    pos++; // skip '{'
+    skipWhitespace();
+    if (pos < input.length() && input.charAt(pos) == '}') {
+      pos++;
+      depth--;
+      return map;
+    }
+    while (pos < input.length()) {
+      skipWhitespace();
+      final var key = parseString();
+      skipWhitespace();
+      expect(':');
+      final var value = parseValue();
+      map.put(key, value);
+      skipWhitespace();
+      if (pos < input.length() && input.charAt(pos) == ',') {
+        pos++;
+      } else {
+        break;
+      }
+    }
+    expect('}');
+    depth--;
+    return map;
+  }
+
+  /**
+   * Parses a JSON array.
+   *
+   * @return a List of parsed values
+   */
+  private List<Object> parseArray() {
+    final var list = new ArrayList<Object>();
+    pos++; // skip '['
+    skipWhitespace();
+    if (pos < input.length() && input.charAt(pos) == ']') {
+      pos++;
+      depth--;
+      return list;
+    }
+    while (pos < input.length()) {
+      list.add(parseValue());
+      skipWhitespace();
+      if (pos < input.length() && input.charAt(pos) == ',') {
+        pos++;
+      } else {
+        break;
+      }
+    }
+    expect(']');
+    depth--;
+    return list;
+  }
+
+  /**
+   * Parses a JSON string.
+   *
+   * <p>Handles all JSON escape sequences including Unicode escapes with surrogate pairs.
+   *
+   * @return the parsed string value
+   */
+  private String parseString() {
+    expect('"');
+    final var sb = new StringBuilder();
+    while (pos < input.length()) {
+      final var ch = input.charAt(pos);
+      if (ch == '"') {
+        pos++;
+        return sb.toString();
+      }
+      if (ch == '\\') {
+        pos++;
+        if (pos >= input.length()) {
+          throw new JsonParseException("Unexpected end of input in string escape");
+        }
+        final var escaped = input.charAt(pos);
+        switch (escaped) {
+          case '"', '\\', '/' -> sb.append(escaped);
+          case 'b' -> sb.append('\b');
+          case 'f' -> sb.append('\f');
+          case 'n' -> sb.append('\n');
+          case 'r' -> sb.append('\r');
+          case 't' -> sb.append('\t');
+          case 'u' -> {
+            final var codeUnit = parseUnicodeEscape();
+            if (Character.isHighSurrogate(codeUnit)) {
+              // Expect low surrogate pair
+              if (pos + 1 < input.length()
+                  && input.charAt(pos + 1) == '\\'
+                  && pos + 2 < input.length()
+                  && input.charAt(pos + 2) == 'u') {
+                pos += 2; // skip backslash-u prefix
+                final var lowSurrogate = parseUnicodeEscape();
+                if (Character.isLowSurrogate(lowSurrogate)) {
+                  sb.appendCodePoint(Character.toCodePoint(codeUnit, lowSurrogate));
+                } else {
+                  sb.append(codeUnit);
+                  sb.append(lowSurrogate);
+                }
+              } else {
+                sb.append(codeUnit);
+              }
+            } else {
+              sb.append(codeUnit);
+            }
+          }
+          default ->
+              throw new JsonParseException(String.format("Invalid escape character: %c", escaped));
+        }
+      } else {
+        sb.append(ch);
+      }
+      pos++;
+    }
+    throw new JsonParseException("Unterminated string");
+  }
+
+  /**
+   * Parses a four-digit Unicode escape sequence.
+   *
+   * <p>Assumes the parser is positioned after the 'u' character. Advances the position by 4
+   * characters.
+   *
+   * @return the parsed Unicode code unit
+   * @throws JsonParseException if the escape sequence is invalid
+   */
+  private char parseUnicodeEscape() {
+    if (pos + 4 >= input.length()) {
+      throw new JsonParseException("Invalid unicode escape");
+    }
+    final var hex = input.substring(pos + 1, pos + 5);
+    pos += 4;
+    try {
+      return (char) Integer.parseInt(hex, 16);
+    } catch (final NumberFormatException e) {
+      throw new JsonParseException(String.format("Invalid unicode escape: \\u%s", hex));
+    }
+  }
+
+  /**
+   * Parses a JSON number.
+   *
+   * @return the number as a string (preserving exact representation)
+   */
+  private String parseNumber() {
+    final var start = pos;
+    if (pos < input.length() && input.charAt(pos) == '-') {
+      pos++;
+    }
+    while (pos < input.length() && input.charAt(pos) >= '0' && input.charAt(pos) <= '9') {
+      pos++;
+    }
+    if (pos < input.length() && input.charAt(pos) == '.') {
+      pos++;
+      while (pos < input.length() && input.charAt(pos) >= '0' && input.charAt(pos) <= '9') {
+        pos++;
+      }
+    }
+    if (pos < input.length() && (input.charAt(pos) == 'e' || input.charAt(pos) == 'E')) {
+      pos++;
+      if (pos < input.length() && (input.charAt(pos) == '+' || input.charAt(pos) == '-')) {
+        pos++;
+      }
+      while (pos < input.length() && input.charAt(pos) >= '0' && input.charAt(pos) <= '9') {
+        pos++;
+      }
+    }
+    return input.substring(start, pos);
+  }
+
+  /**
+   * Parses a JSON boolean value.
+   *
+   * @return "true" or "false" as a string
+   */
+  private String parseBoolean() {
+    if (input.startsWith("true", pos)) {
+      pos += 4;
+      return "true";
+    }
+    if (input.startsWith("false", pos)) {
+      pos += 5;
+      return "false";
+    }
+    throw new JsonParseException(String.format("Unexpected token at position %d", pos));
+  }
+
+  /**
+   * Parses a JSON null value.
+   *
+   * @return the string "null"
+   */
+  private String parseNull() {
+    if (input.startsWith("null", pos)) {
+      pos += 4;
+      return "null";
+    }
+    throw new JsonParseException(String.format("Unexpected token at position %d", pos));
+  }
+
+  /** Skips whitespace characters in the input. */
+  private void skipWhitespace() {
+    while (pos < input.length() && Character.isWhitespace(input.charAt(pos))) {
+      pos++;
+    }
+  }
+
+  /**
+   * Expects and consumes the specified character.
+   *
+   * @param expected the expected character
+   */
+  private void expect(final char expected) {
+    if (pos >= input.length() || input.charAt(pos) != expected) {
+      throw new JsonParseException(String.format("Expected '%c' at position %d", expected, pos));
+    }
+    pos++;
+  }
+
+  /**
+   * Serializes a parsed JSON value to a normalized string with sorted object keys.
+   *
+   * <p>{@link JsonString} instances are serialized as quoted strings. Plain {@link String} values
+   * represent JSON literals (numbers, booleans, null) and are serialized without quotes.
+   *
+   * @param value the parsed value
+   * @return the serialized JSON string
+   */
+  @SuppressWarnings("unchecked")
+  private static String serialize(final Object value) {
+    return switch (value) {
+      case Map<?, ?> map -> serializeObject((Map<String, Object>) map);
+      case List<?> list -> serializeArray(list);
+      case JsonString jsonStr -> escapeString(jsonStr.value());
+      case String str -> str;
+      default -> value.toString();
+    };
+  }
+
+  /**
+   * Serializes a JSON object with sorted keys.
+   *
+   * @param map the object to serialize
+   * @return the serialized JSON object string
+   */
+  private static String serializeObject(final Map<String, Object> map) {
+    final var sb = new StringBuilder("{");
+    var first = true;
+    for (final var entry : map.entrySet()) {
+      if (!first) {
+        sb.append(",");
+      }
+      first = false;
+      sb.append(escapeString(entry.getKey()));
+      sb.append(":");
+      sb.append(serialize(entry.getValue()));
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Serializes a JSON array.
+   *
+   * @param list the array to serialize
+   * @return the serialized JSON array string
+   */
+  private static String serializeArray(final List<?> list) {
+    final var sb = new StringBuilder("[");
+    var first = true;
+    for (final var item : list) {
+      if (!first) {
+        sb.append(",");
+      }
+      first = false;
+      sb.append(serialize(item));
+    }
+    sb.append("]");
+    return sb.toString();
+  }
+
+  /**
+   * Escapes a string value for JSON output.
+   *
+   * @param str the string to escape
+   * @return the escaped JSON string with surrounding quotes
+   */
+  private static String escapeString(final String str) {
+    final var sb = new StringBuilder("\"");
+    for (var i = 0; i < str.length(); i++) {
+      final var ch = str.charAt(i);
+      switch (ch) {
+        case '"' -> sb.append("\\\"");
+        case '\\' -> sb.append("\\\\");
+        case '\b' -> sb.append("\\b");
+        case '\f' -> sb.append("\\f");
+        case '\n' -> sb.append("\\n");
+        case '\r' -> sb.append("\\r");
+        case '\t' -> sb.append("\\t");
+        default -> {
+          if (ch < 0x20) {
+            sb.append(String.format("\\u%04x", (int) ch));
+          } else {
+            sb.append(ch);
+          }
+        }
+      }
+    }
+    sb.append("\"");
+    return sb.toString();
+  }
+
+  /**
+   * Wrapper for JSON string values to distinguish them from JSON literals during serialization.
+   *
+   * <p>JSON string values (parsed from quoted strings) are wrapped in this record, while literal
+   * values (numbers, booleans, null) remain as plain {@link String} instances.
+   *
+   * @param value the string value
+   */
+  private record JsonString(String value) {}
+
+  /** Exception thrown when JSON parsing fails. */
+  private static final class JsonParseException extends RuntimeException {
+
+    /** Serial version UID for serialization compatibility. */
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Creates a new JSON parse exception.
+     *
+     * @param message the error message
+     */
+    JsonParseException(final String message) {
+      super(message);
+    }
+  }
+}

--- a/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/assertion/ComparisonEngineTest.java
+++ b/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/assertion/ComparisonEngineTest.java
@@ -1,0 +1,501 @@
+package io.github.seijikohara.dbtester.internal.assertion;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.seijikohara.dbtester.api.domain.ComparisonStrategy;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link ComparisonEngine}. */
+@DisplayName("ComparisonEngine")
+class ComparisonEngineTest {
+
+  /** Tests for the ComparisonEngine class. */
+  ComparisonEngineTest() {}
+
+  /** Tests for STRICT strategy via ComparisonEngine. */
+  @Nested
+  @DisplayName("STRICT strategy")
+  class StrictStrategyTests {
+
+    /** Tests for STRICT strategy. */
+    StrictStrategyTests() {}
+
+    /** Verifies that STRICT matches equal objects. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should match when objects are equal")
+    void shouldMatch_whenObjectsAreEqual() {
+      // When & Then
+      assertTrue(
+          ComparisonEngine.matches(ComparisonStrategy.STRICT, "hello", "hello"),
+          "should match equal strings");
+      assertTrue(
+          ComparisonEngine.matches(ComparisonStrategy.STRICT, 123, 123),
+          "should match equal integers");
+      assertTrue(
+          ComparisonEngine.matches(ComparisonStrategy.STRICT, null, null),
+          "should match null values");
+    }
+
+    /** Verifies that STRICT does not match different objects. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should not match when objects are different")
+    void shouldNotMatch_whenObjectsAreDifferent() {
+      // When & Then
+      assertFalse(
+          ComparisonEngine.matches(ComparisonStrategy.STRICT, "hello", "world"),
+          "should not match different strings");
+      assertFalse(
+          ComparisonEngine.matches(ComparisonStrategy.STRICT, "123", 123),
+          "should not match string and integer");
+      assertFalse(
+          ComparisonEngine.matches(ComparisonStrategy.STRICT, null, "hello"),
+          "should not match null and string");
+    }
+  }
+
+  /** Tests for IGNORE strategy via ComparisonEngine. */
+  @Nested
+  @DisplayName("IGNORE strategy")
+  class IgnoreStrategyTests {
+
+    /** Tests for IGNORE strategy. */
+    IgnoreStrategyTests() {}
+
+    /** Verifies that IGNORE always matches. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should always match regardless of values")
+    void shouldAlwaysMatch_whenCalled() {
+      // When & Then
+      assertTrue(
+          ComparisonEngine.matches(ComparisonStrategy.IGNORE, "hello", "world"),
+          "should match different strings");
+      assertTrue(
+          ComparisonEngine.matches(ComparisonStrategy.IGNORE, null, 123),
+          "should match null and integer");
+    }
+  }
+
+  /** Tests for NUMERIC strategy via ComparisonEngine. */
+  @Nested
+  @DisplayName("NUMERIC strategy")
+  class NumericStrategyTests {
+
+    /** Tests for NUMERIC strategy. */
+    NumericStrategyTests() {}
+
+    /** Verifies that NUMERIC matches equal numbers across types. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should match when numbers are equal across types")
+    void shouldMatch_whenNumbersAreEqual() {
+      // When & Then
+      assertTrue(
+          ComparisonEngine.matches(ComparisonStrategy.NUMERIC, 123L, 123),
+          "should match Long and Integer");
+      assertTrue(
+          ComparisonEngine.matches(ComparisonStrategy.NUMERIC, "123", 123),
+          "should match string and integer");
+      assertTrue(
+          ComparisonEngine.matches(
+              ComparisonStrategy.NUMERIC, new BigDecimal("99.99"), new BigDecimal("99.99")),
+          "should match equal BigDecimals");
+    }
+
+    /** Verifies that NUMERIC handles null values. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should handle null values correctly")
+    void shouldHandle_whenNullValuesProvided() {
+      // When & Then
+      assertTrue(
+          ComparisonEngine.matches(ComparisonStrategy.NUMERIC, null, null),
+          "should match null with null");
+      assertFalse(
+          ComparisonEngine.matches(ComparisonStrategy.NUMERIC, null, 123),
+          "should not match null with number");
+    }
+  }
+
+  /** Tests for CASE_INSENSITIVE strategy via ComparisonEngine. */
+  @Nested
+  @DisplayName("CASE_INSENSITIVE strategy")
+  class CaseInsensitiveStrategyTests {
+
+    /** Tests for CASE_INSENSITIVE strategy. */
+    CaseInsensitiveStrategyTests() {}
+
+    /** Verifies that CASE_INSENSITIVE matches strings ignoring case. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should match when strings differ only in case")
+    void shouldMatch_whenStringsIgnoringCase() {
+      // When & Then
+      assertTrue(
+          ComparisonEngine.matches(ComparisonStrategy.CASE_INSENSITIVE, "Hello", "HELLO"),
+          "should match 'Hello' and 'HELLO'");
+    }
+
+    /** Verifies that CASE_INSENSITIVE handles null values. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should handle null values correctly")
+    void shouldHandle_whenNullValuesProvided() {
+      // When & Then
+      assertTrue(
+          ComparisonEngine.matches(ComparisonStrategy.CASE_INSENSITIVE, null, null),
+          "should match null with null");
+      assertFalse(
+          ComparisonEngine.matches(ComparisonStrategy.CASE_INSENSITIVE, null, "hello"),
+          "should not match null with string");
+    }
+  }
+
+  /** Tests for TIMESTAMP_FLEXIBLE strategy via ComparisonEngine. */
+  @Nested
+  @DisplayName("TIMESTAMP_FLEXIBLE strategy")
+  class TimestampFlexibleStrategyTests {
+
+    /** Tests for TIMESTAMP_FLEXIBLE strategy. */
+    TimestampFlexibleStrategyTests() {}
+
+    /** Verifies that TIMESTAMP_FLEXIBLE matches timestamps with timezone conversion. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should match when timestamps represent same instant in different timezones")
+    void shouldMatch_whenTimestampsRepresentSameInstant() {
+      // When & Then
+      assertTrue(
+          ComparisonEngine.matches(
+              ComparisonStrategy.TIMESTAMP_FLEXIBLE,
+              "2024-01-15T10:30:00+09:00",
+              "2024-01-15T01:30:00Z"),
+          "should match JST and UTC representing same instant");
+    }
+
+    /** Verifies that TIMESTAMP_FLEXIBLE ignores fractional seconds. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should match when timestamps differ only in fractional seconds")
+    void shouldMatch_whenTimestampsIgnoringFractionalSeconds() {
+      // When & Then
+      assertTrue(
+          ComparisonEngine.matches(
+              ComparisonStrategy.TIMESTAMP_FLEXIBLE,
+              "2024-01-15 10:30:00",
+              "2024-01-15 10:30:00.123"),
+          "should match timestamp without and with fractional seconds");
+    }
+
+    /** Verifies that timestamps without timezone are treated as UTC. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should treat timestamps without timezone as UTC")
+    void shouldTreatAsUtc_whenTimezoneNotSpecified() {
+      // When & Then
+      assertTrue(
+          ComparisonEngine.matches(
+              ComparisonStrategy.TIMESTAMP_FLEXIBLE, "2024-01-15 10:30:00", "2024-01-15T10:30:00Z"),
+          "should match local timestamp with UTC");
+    }
+
+    /** Verifies that TIMESTAMP_FLEXIBLE does not match different timestamps. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should not match when timestamps are different")
+    void shouldNotMatch_whenTimestampsAreDifferent() {
+      // When & Then
+      assertFalse(
+          ComparisonEngine.matches(
+              ComparisonStrategy.TIMESTAMP_FLEXIBLE, "2024-01-15 10:30:00", "2024-01-15 10:31:00"),
+          "should not match timestamps with different minutes");
+    }
+  }
+
+  /** Tests for DATE_FLEXIBLE strategy via ComparisonEngine. */
+  @Nested
+  @DisplayName("DATE_FLEXIBLE strategy")
+  class DateFlexibleStrategyTests {
+
+    /** Tests for DATE_FLEXIBLE strategy. */
+    DateFlexibleStrategyTests() {}
+
+    /** Verifies that DATE_FLEXIBLE matches dates in different formats. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should match when dates are in different formats")
+    void shouldMatch_whenDatesInDifferentFormats() {
+      // When & Then
+      assertTrue(
+          ComparisonEngine.matches(ComparisonStrategy.DATE_FLEXIBLE, "2024-01-15", "2024/01/15"),
+          "should match ISO and slashed formats");
+      assertTrue(
+          ComparisonEngine.matches(ComparisonStrategy.DATE_FLEXIBLE, "2024/01/15", "2024.01.15"),
+          "should match slashed and dot formats");
+    }
+
+    /** Verifies that DATE_FLEXIBLE extracts dates from timestamps. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should match when dates are extracted from timestamps")
+    void shouldMatch_whenDatesExtractedFromTimestamps() {
+      // When & Then
+      assertTrue(
+          ComparisonEngine.matches(
+              ComparisonStrategy.DATE_FLEXIBLE, "2024-01-15", "2024-01-15T10:30:00"),
+          "should match date with timestamp");
+    }
+
+    /** Verifies that DATE_FLEXIBLE does not match different dates. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should not match when dates are different")
+    void shouldNotMatch_whenDatesAreDifferent() {
+      // When & Then
+      assertFalse(
+          ComparisonEngine.matches(ComparisonStrategy.DATE_FLEXIBLE, "2024-01-15", "2024-01-16"),
+          "should not match different dates");
+    }
+  }
+
+  /** Tests for JSON_EQUIVALENT strategy via ComparisonEngine. */
+  @Nested
+  @DisplayName("JSON_EQUIVALENT strategy")
+  class JsonEquivalentStrategyTests {
+
+    /** Tests for JSON_EQUIVALENT strategy. */
+    JsonEquivalentStrategyTests() {}
+
+    /** Verifies that JSON_EQUIVALENT matches JSON with different key order. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should match when JSON objects have different key order")
+    void shouldMatch_whenJsonHasDifferentKeyOrder() {
+      // When & Then
+      assertTrue(
+          ComparisonEngine.matches(
+              ComparisonStrategy.JSON_EQUIVALENT, "{\"b\":2,\"a\":1}", "{\"a\":1,\"b\":2}"),
+          "should match objects with different key order");
+    }
+
+    /** Verifies that JSON_EQUIVALENT distinguishes string values from literals. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should distinguish string values from boolean and number literals")
+    void shouldDistinguishStringFromLiteral_whenValueTypeDiffers() {
+      // When & Then
+      assertFalse(
+          ComparisonEngine.matches(
+              ComparisonStrategy.JSON_EQUIVALENT, "{\"value\":\"true\"}", "{\"value\":true}"),
+          "should not match string \"true\" with boolean true");
+    }
+
+    /** Verifies that JSON_EQUIVALENT falls back to string comparison for non-JSON. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should fall back to string comparison for non-JSON values")
+    void shouldFallBackToStringComparison_whenValuesAreNotJson() {
+      // When & Then
+      assertTrue(
+          ComparisonEngine.matches(ComparisonStrategy.JSON_EQUIVALENT, "hello", "hello"),
+          "should match identical non-JSON strings");
+      assertFalse(
+          ComparisonEngine.matches(ComparisonStrategy.JSON_EQUIVALENT, "hello", "world"),
+          "should not match different non-JSON strings");
+    }
+  }
+
+  /** Tests for NOT_NULL strategy via ComparisonEngine. */
+  @Nested
+  @DisplayName("NOT_NULL strategy")
+  class NotNullStrategyTests {
+
+    /** Tests for NOT_NULL strategy. */
+    NotNullStrategyTests() {}
+
+    /** Verifies that NOT_NULL matches when actual is not null. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should match when actual value is not null")
+    void shouldMatch_whenActualIsNotNull() {
+      // When & Then
+      assertTrue(
+          ComparisonEngine.matches(ComparisonStrategy.NOT_NULL, "anything", "hello"),
+          "should match when actual is string");
+      assertTrue(
+          ComparisonEngine.matches(ComparisonStrategy.NOT_NULL, null, 123),
+          "should match when actual is number");
+    }
+
+    /** Verifies that NOT_NULL does not match when actual is null. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should not match when actual value is null")
+    void shouldNotMatch_whenActualIsNull() {
+      // When & Then
+      assertFalse(
+          ComparisonEngine.matches(ComparisonStrategy.NOT_NULL, "hello", null),
+          "should not match when actual is null");
+      assertFalse(
+          ComparisonEngine.matches(ComparisonStrategy.NOT_NULL, null, null),
+          "should not match when both are null");
+    }
+  }
+
+  /** Tests for REGEX strategy via ComparisonEngine. */
+  @Nested
+  @DisplayName("REGEX strategy")
+  class RegexStrategyTests {
+
+    /** Tests for REGEX strategy. */
+    RegexStrategyTests() {}
+
+    /** Verifies that REGEX matches values against pattern. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should match when value matches pattern")
+    void shouldMatch_whenValueMatchesPattern() {
+      // Given
+      final var strategy = ComparisonStrategy.regex("[a-f0-9-]{36}");
+
+      // When & Then
+      assertTrue(
+          ComparisonEngine.matches(strategy, null, "a1b2c3d4-e5f6-7890-abcd-ef1234567890"),
+          "should match UUID pattern");
+    }
+
+    /** Verifies that REGEX does not match non-matching values. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should not match when value does not match pattern")
+    void shouldNotMatch_whenValueDoesNotMatchPattern() {
+      // Given
+      final var strategy = ComparisonStrategy.regex("\\d+");
+
+      // When & Then
+      assertFalse(
+          ComparisonEngine.matches(strategy, null, "abc"), "should not match non-numeric string");
+    }
+
+    /** Verifies that REGEX does not match null actual value. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should not match when actual value is null")
+    void shouldNotMatch_whenActualValueIsNull() {
+      // Given
+      final var strategy = ComparisonStrategy.regex(".*");
+
+      // When & Then
+      assertFalse(
+          ComparisonEngine.matches(strategy, "expected", null), "should not match null actual");
+    }
+  }
+
+  /** Tests for CONTAINS strategy via ComparisonEngine. */
+  @Nested
+  @DisplayName("CONTAINS strategy")
+  @SuppressWarnings("removal")
+  class ContainsStrategyTests {
+
+    /** Tests for CONTAINS strategy. */
+    ContainsStrategyTests() {}
+
+    /** Verifies that CONTAINS matches when actual contains expected. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should match when actual contains expected value")
+    void shouldMatch_whenActualContainsExpected() {
+      // Given
+      final var strategy = ComparisonStrategy.contains();
+
+      // When & Then
+      assertTrue(
+          ComparisonEngine.matches(strategy, "world", "hello world"),
+          "should match when actual contains expected");
+    }
+
+    /** Verifies that CONTAINS with explicit substring matches. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should match when actual contains configured substring")
+    void shouldMatch_whenActualContainsConfiguredSubstring() {
+      // Given
+      final var strategy = ComparisonStrategy.contains("admin");
+
+      // When & Then
+      assertTrue(
+          ComparisonEngine.matches(strategy, "ignored", "user_admin_role"),
+          "should match configured substring regardless of expected");
+    }
+
+    /** Verifies that CONTAINS handles null values. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should handle null values correctly")
+    void shouldHandle_whenNullValuesProvided() {
+      // Given
+      final var strategy = ComparisonStrategy.contains();
+
+      // When & Then
+      assertFalse(
+          ComparisonEngine.matches(strategy, "test", null), "should not match when actual is null");
+    }
+  }
+
+  /** Tests for RANGE strategy via ComparisonEngine. */
+  @Nested
+  @DisplayName("RANGE strategy")
+  @SuppressWarnings("removal")
+  class RangeStrategyTests {
+
+    /** Tests for RANGE strategy. */
+    RangeStrategyTests() {}
+
+    /** Verifies that RANGE matches values within range. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should match when value is within range")
+    void shouldMatch_whenValueIsWithinRange() {
+      // Given
+      final var strategy = ComparisonStrategy.range(100.0, 200.0);
+
+      // When & Then
+      assertTrue(
+          ComparisonEngine.matches(strategy, null, 150), "should match integer within range");
+      assertTrue(ComparisonEngine.matches(strategy, null, 100), "should match min boundary");
+      assertTrue(ComparisonEngine.matches(strategy, null, 200), "should match max boundary");
+    }
+
+    /** Verifies that RANGE does not match values outside range. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should not match when value is outside range")
+    void shouldNotMatch_whenValueIsOutsideRange() {
+      // Given
+      final var strategy = ComparisonStrategy.range(100.0, 200.0);
+
+      // When & Then
+      assertFalse(ComparisonEngine.matches(strategy, null, 99), "should not match below min");
+      assertFalse(ComparisonEngine.matches(strategy, null, 201), "should not match above max");
+    }
+
+    /** Verifies that RANGE handles null actual value. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should not match when actual is null")
+    void shouldNotMatch_whenActualIsNull() {
+      // Given
+      final var strategy = ComparisonStrategy.range(0.0, 100.0);
+
+      // When & Then
+      assertFalse(ComparisonEngine.matches(strategy, null, null), "should not match null actual");
+    }
+  }
+}

--- a/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/assertion/JsonNormalizerTest.java
+++ b/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/assertion/JsonNormalizerTest.java
@@ -1,0 +1,238 @@
+package io.github.seijikohara.dbtester.internal.assertion;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link JsonNormalizer}. */
+@DisplayName("JsonNormalizer")
+class JsonNormalizerTest {
+
+  /** Tests for the JsonNormalizer class. */
+  JsonNormalizerTest() {}
+
+  /** Tests for the normalize() method. */
+  @Nested
+  @DisplayName("normalize(String) method")
+  class NormalizeMethod {
+
+    /** Tests for the normalize method. */
+    NormalizeMethod() {}
+
+    /** Verifies that normalize sorts object keys. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should sort object keys alphabetically")
+    void shouldSortObjectKeys_whenObjectHasMultipleKeys() {
+      // Given
+      final var input = "{\"b\":2,\"a\":1,\"c\":3}";
+
+      // When
+      final var result = JsonNormalizer.normalize(input);
+
+      // Then
+      assertEquals("{\"a\":1,\"b\":2,\"c\":3}", result, "should sort keys alphabetically");
+    }
+
+    /** Verifies that normalize removes insignificant whitespace. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should remove insignificant whitespace")
+    void shouldRemoveWhitespace_whenInputHasExtraSpaces() {
+      // Given
+      final var input = "{ \"a\" : 1 , \"b\" : 2 }";
+
+      // When
+      final var result = JsonNormalizer.normalize(input);
+
+      // Then
+      assertEquals("{\"a\":1,\"b\":2}", result, "should remove whitespace");
+    }
+
+    /** Verifies that normalize handles nested objects. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should sort keys in nested objects")
+    void shouldSortNestedKeys_whenObjectsAreNested() {
+      // Given
+      final var input = "{\"b\":{\"d\":4,\"c\":3},\"a\":1}";
+
+      // When
+      final var result = JsonNormalizer.normalize(input);
+
+      // Then
+      assertEquals("{\"a\":1,\"b\":{\"c\":3,\"d\":4}}", result, "should sort nested keys");
+    }
+
+    /** Verifies that normalize handles arrays. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should preserve array order")
+    void shouldPreserveArrayOrder_whenArrayProvided() {
+      // Given
+      final var input = "[3,1,2]";
+
+      // When
+      final var result = JsonNormalizer.normalize(input);
+
+      // Then
+      assertEquals("[3,1,2]", result, "should preserve array element order");
+    }
+
+    /** Verifies that normalize handles empty objects. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should handle empty object")
+    void shouldHandleEmptyObject_whenEmptyObjectProvided() {
+      // When
+      final var result = JsonNormalizer.normalize("{}");
+
+      // Then
+      assertEquals("{}", result, "should normalize empty object");
+    }
+
+    /** Verifies that normalize handles empty arrays. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should handle empty array")
+    void shouldHandleEmptyArray_whenEmptyArrayProvided() {
+      // When
+      final var result = JsonNormalizer.normalize("[]");
+
+      // Then
+      assertEquals("[]", result, "should normalize empty array");
+    }
+
+    /** Verifies that normalize returns original string for invalid JSON. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should return original string when JSON is invalid")
+    void shouldReturnOriginal_whenJsonIsInvalid() {
+      // Given
+      final var invalid = "not valid json";
+
+      // When
+      final var result = JsonNormalizer.normalize(invalid);
+
+      // Then
+      assertEquals(invalid, result, "should return original for invalid JSON");
+    }
+
+    /** Verifies that normalize returns original for oversized input. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should return original string when input exceeds size limit")
+    void shouldReturnOriginal_whenInputExceedsSizeLimit() {
+      // Given
+      final var large = "{\"a\":\"" + "x".repeat(JsonNormalizer.MAX_INPUT_LENGTH) + "\"}";
+
+      // When
+      final var result = JsonNormalizer.normalize(large);
+
+      // Then
+      assertEquals(large, result, "should return original for oversized input");
+    }
+
+    /** Verifies that normalize returns original for excessively deep nesting. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should return original string when nesting exceeds depth limit")
+    void shouldReturnOriginal_whenNestingExceedsDepthLimit() {
+      // Given - create nesting exceeding MAX_NESTING_DEPTH
+      final var sb = new StringBuilder();
+      for (var i = 0; i < JsonNormalizer.MAX_NESTING_DEPTH + 1; i++) {
+        sb.append("[");
+      }
+      sb.append("1");
+      for (var i = 0; i < JsonNormalizer.MAX_NESTING_DEPTH + 1; i++) {
+        sb.append("]");
+      }
+      final var input = sb.toString();
+
+      // When
+      final var result = JsonNormalizer.normalize(input);
+
+      // Then
+      assertEquals(input, result, "should return original for excessive nesting");
+    }
+
+    /** Verifies that normalize distinguishes string values from literals. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should distinguish string values from boolean literals")
+    void shouldDistinguishStringFromBoolean_whenBothPresent() {
+      // Given
+      final var withStringTrue = "{\"value\":\"true\"}";
+      final var withBoolTrue = "{\"value\":true}";
+
+      // When
+      final var normalizedString = JsonNormalizer.normalize(withStringTrue);
+      final var normalizedBool = JsonNormalizer.normalize(withBoolTrue);
+
+      // Then
+      assertEquals("{\"value\":\"true\"}", normalizedString, "should keep string true quoted");
+      assertEquals("{\"value\":true}", normalizedBool, "should keep boolean true unquoted");
+      assertFalse(
+          normalizedString.equals(normalizedBool),
+          "string and boolean should normalize differently");
+    }
+  }
+
+  /** Tests for the looksLikeJson() method. */
+  @Nested
+  @DisplayName("looksLikeJson(String) method")
+  class LooksLikeJsonMethod {
+
+    /** Tests for the looksLikeJson method. */
+    LooksLikeJsonMethod() {}
+
+    /** Verifies that looksLikeJson returns true for object syntax. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return true for JSON object syntax")
+    void shouldReturnTrue_whenValueLooksLikeJsonObject() {
+      // When & Then
+      assertTrue(JsonNormalizer.looksLikeJson("{\"a\":1}"), "should detect JSON object");
+      assertTrue(JsonNormalizer.looksLikeJson("{}"), "should detect empty JSON object");
+    }
+
+    /** Verifies that looksLikeJson returns true for array syntax. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return true for JSON array syntax")
+    void shouldReturnTrue_whenValueLooksLikeJsonArray() {
+      // When & Then
+      assertTrue(JsonNormalizer.looksLikeJson("[1,2,3]"), "should detect JSON array");
+      assertTrue(JsonNormalizer.looksLikeJson("[]"), "should detect empty JSON array");
+    }
+
+    /** Verifies that looksLikeJson returns false for non-JSON. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return false for non-JSON strings")
+    void shouldReturnFalse_whenValueIsNotJson() {
+      // When & Then
+      assertFalse(JsonNormalizer.looksLikeJson("hello"), "should reject plain string");
+      assertFalse(JsonNormalizer.looksLikeJson("123"), "should reject number string");
+    }
+
+    /** Verifies that looksLikeJson returns false for mismatched brackets. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should return false for mismatched brackets")
+    void shouldReturnFalse_whenBracketsAreMismatched() {
+      // When & Then
+      assertFalse(
+          JsonNormalizer.looksLikeJson("{\"a\":1]"),
+          "should reject mismatched curly-square brackets");
+      assertFalse(
+          JsonNormalizer.looksLikeJson("[1,2,3}"),
+          "should reject mismatched square-curly brackets");
+    }
+  }
+}

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -113,7 +113,7 @@ Source: [db-tester-api/src/main/java](https://github.com/seijikohara/db-tester/t
 
 | Package | Responsibility |
 |---------|----------------|
-| `assertion` | Dataset comparison and verification |
+| `assertion` | Dataset comparison, verification, and `ComparisonEngine` execution |
 | `dataset` | Dataset, Table, Row implementations |
 | `domain` | Internal value objects |
 | `format` | CSV, TSV, JSON, and YAML parsing and format providers |

--- a/docs/specs/ja/architecture.md
+++ b/docs/specs/ja/architecture.md
@@ -114,7 +114,7 @@ graph TD
 
 | パッケージ | 責務 |
 |-----------|------|
-| `assertion` | データセット比較と検証 |
+| `assertion` | データセット比較、検証、および `ComparisonEngine` 実行 |
 | `dataset` | TableSet, Table, Row実装 |
 | `domain` | 内部値オブジェクト |
 | `format` | CSV、TSV、JSON、およびYAML解析とフォーマットプロバイダー |

--- a/docs/specs/ja/public-api.md
+++ b/docs/specs/ja/public-api.md
@@ -547,6 +547,7 @@ DatabaseAssertion.assertEqualsWithStrategies(expectedTable, actualTable, strateg
 | `CONTAINS` | false | false | false | String.contains() |
 | `RANGE` | false | false | false | min <= value <= max |
 
+**アーキテクチャに関する注記**: `ComparisonStrategy` はディスクリプタ（何を比較するか）として機能します。比較の実行（どのように比較するか）はcoreモジュールの `ComparisonEngine` が担当します。`ComparisonStrategy` の `matches()` メソッドは1.1で非推奨となり、2.0で削除予定です。
 
 ## アサーションAPI
 

--- a/docs/specs/public-api.md
+++ b/docs/specs/public-api.md
@@ -568,6 +568,8 @@ Defines value comparison behavior during assertion.
 | `CONTAINS` | false | false | false | String.contains() |
 | `RANGE` | false | false | false | min <= value <= max |
 
+**Architecture Note**: `ComparisonStrategy` serves as a descriptor (what to compare). Comparison execution (how to compare) is handled by `ComparisonEngine` in the core module. The `matches()` method on `ComparisonStrategy` is deprecated since 1.1 and will be removed in 2.0.
+
 ## Assertion API
 
 ### DatabaseAssertion


### PR DESCRIPTION
## Summary
- Extract comparison execution logic into `ComparisonEngine` static utility class in the core module
- `ComparisonStrategy` remains as a pure descriptor (what to compare) in the API module; `ComparisonEngine` handles execution (how to compare)
- Deprecate `ComparisonStrategy.matches()` and `Cell.matches()` with `@Deprecated(since = "1.1", forRemoval = true)` for removal in 2.0
- Copy `JsonNormalizer` to core module for `ComparisonEngine` JSON comparison support
- Internal `DataSetComparator` now delegates to `ComparisonEngine.matches()` instead of `ComparisonStrategy.matches()`
- Update architecture and public API documentation (EN/JA)

## Test plan
- [x] `ComparisonEngineTest` covers all 11 comparison strategies (STRICT, IGNORE, NUMERIC, CASE_INSENSITIVE, TIMESTAMP_FLEXIBLE, DATE_FLEXIBLE, JSON_EQUIVALENT, NOT_NULL, REGEX, CONTAINS, RANGE)
- [x] `JsonNormalizerTest` covers JSON normalization in core module
- [x] Existing `ComparisonStrategyTest` and `CellTest` pass with `@SuppressWarnings("removal")`
- [x] `:db-tester-api:build`, `:db-tester-core:build`, `:db-tester-junit:build` all pass

Closes #163