### PR TITLE
refactor(api): replace ExpectationProvider telescoping overloads with ExpectationContext

### DIFF
--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/config/ExpectationContext.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/config/ExpectationContext.java
@@ -1,0 +1,138 @@
+package io.github.seijikohara.dbtester.api.config;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Encapsulates optional verification parameters for expectation verification.
+ *
+ * <p>This record replaces the telescoping method overloads in {@link
+ * io.github.seijikohara.dbtester.api.spi.ExpectationProvider} by bundling all optional parameters
+ * into a single immutable value object. Use {@link #defaults()} to obtain an instance with default
+ * values, and {@code with*()} methods to customize individual parameters.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * // Default context (no exclusions, no strategies, ordered comparison)
+ * var context = ExpectationContext.defaults();
+ *
+ * // Custom context with excluded columns and unordered comparison
+ * var context = ExpectationContext.defaults()
+ *     .withExcludeColumns(Set.of("CREATED_AT", "UPDATED_AT"))
+ *     .withRowOrdering(RowOrdering.UNORDERED);
+ *
+ * // Custom context with column strategies
+ * var context = ExpectationContext.defaults()
+ *     .withColumnStrategies(Map.of(
+ *         "EMAIL", ColumnStrategyMapping.caseInsensitive("EMAIL")));
+ * }</pre>
+ *
+ * @param excludeColumns column names to exclude from comparison (case-insensitive matching)
+ * @param columnStrategies column comparison strategies keyed by uppercase column name
+ * @param rowOrdering the row comparison strategy (ORDERED or UNORDERED)
+ * @param operationDefaults the operation defaults containing comparison settings
+ * @see io.github.seijikohara.dbtester.api.spi.ExpectationProvider
+ */
+public record ExpectationContext(
+    Set<String> excludeColumns,
+    Map<String, ColumnStrategyMapping> columnStrategies,
+    RowOrdering rowOrdering,
+    OperationDefaults operationDefaults) {
+
+  /**
+   * Creates an ExpectationContext with defensive copies of collections.
+   *
+   * @param excludeColumns column names to exclude from comparison
+   * @param columnStrategies column comparison strategies keyed by uppercase column name
+   * @param rowOrdering the row comparison strategy
+   * @param operationDefaults the operation defaults containing comparison settings
+   */
+  public ExpectationContext {
+    excludeColumns = Set.copyOf(excludeColumns);
+    columnStrategies = Map.copyOf(columnStrategies);
+  }
+
+  /**
+   * Returns an instance with default values.
+   *
+   * <p>The default context has no excluded columns, no column strategies, ordered row comparison,
+   * and standard operation defaults.
+   *
+   * @return a new ExpectationContext with default values
+   */
+  public static ExpectationContext defaults() {
+    return new ExpectationContext(
+        Set.of(), Map.of(), RowOrdering.ORDERED, OperationDefaults.standard());
+  }
+
+  /**
+   * Creates a new ExpectationContext from the provided parameters.
+   *
+   * <p>This factory method accepts {@link Collection} for exclude columns and converts it to an
+   * immutable {@link Set} internally.
+   *
+   * @param excludeColumns column names to exclude from comparison
+   * @param columnStrategies column comparison strategies keyed by uppercase column name
+   * @param rowOrdering the row comparison strategy
+   * @param operationDefaults the operation defaults containing comparison settings
+   * @return a new ExpectationContext
+   */
+  public static ExpectationContext of(
+      final Collection<String> excludeColumns,
+      final Map<String, ColumnStrategyMapping> columnStrategies,
+      final RowOrdering rowOrdering,
+      final OperationDefaults operationDefaults) {
+    return new ExpectationContext(
+        Set.copyOf(excludeColumns), columnStrategies, rowOrdering, operationDefaults);
+  }
+
+  /**
+   * Returns a new ExpectationContext with the specified exclude columns.
+   *
+   * @param excludeColumns column names to exclude from comparison
+   * @return a new ExpectationContext with the specified exclude columns
+   */
+  public ExpectationContext withExcludeColumns(final Collection<String> excludeColumns) {
+    return new ExpectationContext(
+        Set.copyOf(excludeColumns),
+        this.columnStrategies,
+        this.rowOrdering,
+        this.operationDefaults);
+  }
+
+  /**
+   * Returns a new ExpectationContext with the specified column strategies.
+   *
+   * @param columnStrategies column comparison strategies keyed by uppercase column name
+   * @return a new ExpectationContext with the specified column strategies
+   */
+  public ExpectationContext withColumnStrategies(
+      final Map<String, ColumnStrategyMapping> columnStrategies) {
+    return new ExpectationContext(
+        this.excludeColumns, columnStrategies, this.rowOrdering, this.operationDefaults);
+  }
+
+  /**
+   * Returns a new ExpectationContext with the specified row ordering.
+   *
+   * @param rowOrdering the row comparison strategy
+   * @return a new ExpectationContext with the specified row ordering
+   */
+  public ExpectationContext withRowOrdering(final RowOrdering rowOrdering) {
+    return new ExpectationContext(
+        this.excludeColumns, this.columnStrategies, rowOrdering, this.operationDefaults);
+  }
+
+  /**
+   * Returns a new ExpectationContext with the specified operation defaults.
+   *
+   * @param operationDefaults the operation defaults containing comparison settings
+   * @return a new ExpectationContext with the specified operation defaults
+   */
+  public ExpectationContext withOperationDefaults(final OperationDefaults operationDefaults) {
+    return new ExpectationContext(
+        this.excludeColumns, this.columnStrategies, this.rowOrdering, operationDefaults);
+  }
+}

--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/spi/ExpectationProvider.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/spi/ExpectationProvider.java
@@ -1,6 +1,7 @@
 package io.github.seijikohara.dbtester.api.spi;
 
 import io.github.seijikohara.dbtester.api.config.ColumnStrategyMapping;
+import io.github.seijikohara.dbtester.api.config.ExpectationContext;
 import io.github.seijikohara.dbtester.api.config.OperationDefaults;
 import io.github.seijikohara.dbtester.api.config.RowOrdering;
 import io.github.seijikohara.dbtester.api.dataset.TableSet;
@@ -31,6 +32,7 @@ import org.slf4j.LoggerFactory;
  * test extensions (JUnit Jupiter, Spock) which internally delegate to this provider.
  *
  * @see java.util.ServiceLoader
+ * @see ExpectationContext
  */
 public interface ExpectationProvider {
 
@@ -59,101 +61,107 @@ public interface ExpectationProvider {
   void verifyExpectation(TableSet expectedTableSet, DataSource dataSource);
 
   /**
+   * Verifies that the database state matches the expected dataset using the specified context.
+   *
+   * <p>This method accepts an {@link ExpectationContext} parameter object that encapsulates all
+   * optional verification parameters (column exclusions, column strategies, row ordering, and
+   * operation defaults). This replaces the telescoping overload pattern.
+   *
+   * <p>The default implementation logs warnings for non-default context values and delegates to
+   * {@link #verifyExpectation(TableSet, DataSource)}. Implementations should override this method
+   * to support the full set of verification parameters.
+   *
+   * @param expectedTableSet the expected dataset containing expected table data
+   * @param dataSource the database connection source for retrieving actual data
+   * @param context the verification context containing optional parameters
+   * @throws AssertionError if verification fails
+   * @see ExpectationContext
+   */
+  default void verifyExpectation(
+      final TableSet expectedTableSet,
+      final DataSource dataSource,
+      final ExpectationContext context) {
+    if (!context.excludeColumns().isEmpty()) {
+      logWarning(
+          "Column exclusions specified but current ExpectationProvider does not support them. "
+              + "Exclusions will be ignored: {}. Override verifyExpectation(TableSet, DataSource, "
+              + "ExpectationContext) to support column exclusion.",
+          context.excludeColumns());
+    }
+    if (!context.columnStrategies().isEmpty()) {
+      logWarning(
+          "Column strategies specified but current ExpectationProvider does not support them. "
+              + "Strategies will be ignored: {}. Override verifyExpectation(TableSet, DataSource, "
+              + "ExpectationContext) to support column strategies.",
+          context.columnStrategies().keySet());
+    }
+    if (context.rowOrdering() == RowOrdering.UNORDERED) {
+      logWarning(
+          "Unordered row comparison requested but current ExpectationProvider does not support it. "
+              + "Falling back to ordered comparison. Override verifyExpectation(TableSet, "
+              + "DataSource, ExpectationContext) to support unordered comparison.");
+    }
+    if (context.operationDefaults().floatingPointEpsilon()
+        != OperationDefaults.DEFAULT_FLOATING_POINT_EPSILON) {
+      logWarning(
+          "Custom floating-point epsilon specified but current ExpectationProvider does not "
+              + "support it. Using default epsilon. Override verifyExpectation(TableSet, "
+              + "DataSource, ExpectationContext) to support custom epsilon.");
+    }
+    verifyExpectation(expectedTableSet, dataSource);
+  }
+
+  /**
    * Verifies that the database state matches the expected dataset, excluding specified columns.
-   *
-   * <p>This method extends {@link #verifyExpectation(TableSet, DataSource)} with column exclusion
-   * support. Excluded columns are ignored during the comparison, which is useful for auto-generated
-   * columns (timestamps, version numbers, auto-increment IDs) that cannot be predicted in test
-   * data.
-   *
-   * <p>Column name matching is case-insensitive. For example, excluding {@code "CREATED_AT"} will
-   * ignore columns named {@code "created_at"}, {@code "CREATED_AT"}, or {@code "Created_At"}.
-   *
-   * <p>The default implementation delegates to {@link #verifyExpectation(TableSet, DataSource)}
-   * when no columns are excluded. Implementations should override this method to support column
-   * exclusion.
    *
    * @param expectedTableSet the expected dataset containing expected table data
    * @param dataSource the database connection source for retrieving actual data
    * @param excludeColumns column names to exclude from comparison (case-insensitive matching)
    * @throws AssertionError if verification fails (row count mismatch, column value mismatch, or
    *     table structure mismatch)
+   * @deprecated Use {@link #verifyExpectation(TableSet, DataSource, ExpectationContext)} instead.
+   *     Construct an {@link ExpectationContext} with {@link ExpectationContext#defaults()}{@code
+   *     .withExcludeColumns(excludeColumns)}. Removed in 2.0.
    */
+  @Deprecated(since = "1.1", forRemoval = true)
   default void verifyExpectation(
       final TableSet expectedTableSet,
       final DataSource dataSource,
       final Collection<String> excludeColumns) {
-    // Default implementation delegates to the basic verifyExpectation method.
-    // Implementations should override this method to support column exclusion.
-    if (excludeColumns != null && !excludeColumns.isEmpty()) {
-      logWarning(
-          "Column exclusions specified but current ExpectationProvider does not support them. "
-              + "Exclusions will be ignored: {}. Override verifyExpectation(TableSet, DataSource, "
-              + "Collection) to support column exclusion.",
-          excludeColumns);
-    }
-    verifyExpectation(expectedTableSet, dataSource);
+    verifyExpectation(
+        expectedTableSet,
+        dataSource,
+        ExpectationContext.defaults().withExcludeColumns(excludeColumns));
   }
 
   /**
    * Verifies that the database state matches the expected dataset with column comparison
    * strategies.
    *
-   * <p>This method extends {@link #verifyExpectation(TableSet, DataSource, Collection)} with
-   * column-specific comparison strategy support. Each column can have its own comparison strategy:
-   *
-   * <ul>
-   *   <li>{@code STRICT} - Exact match (default)
-   *   <li>{@code IGNORE} - Skip comparison entirely
-   *   <li>{@code NUMERIC} - Type-aware numeric comparison
-   *   <li>{@code CASE_INSENSITIVE} - Case-insensitive string comparison
-   *   <li>{@code TIMESTAMP_FLEXIBLE} - Ignores sub-second precision and handles timezone
-   *   <li>{@code NOT_NULL} - Only verify the value is not null
-   *   <li>{@code REGEX} - Match against a regular expression pattern
-   * </ul>
-   *
-   * <p>Column exclusion takes precedence: columns in {@code excludeColumns} are skipped entirely
-   * before column strategies are applied.
-   *
-   * <p>The default implementation delegates to {@link #verifyExpectation(TableSet, DataSource,
-   * Collection)} when no column strategies are provided. Implementations should override this
-   * method to support column strategies.
-   *
    * @param expectedTableSet the expected dataset containing expected table data
    * @param dataSource the database connection source for retrieving actual data
    * @param excludeColumns column names to exclude from comparison (case-insensitive matching)
    * @param columnStrategies column comparison strategies keyed by uppercase column name
    * @throws AssertionError if verification fails
-   * @see ColumnStrategyMapping
-   * @see io.github.seijikohara.dbtester.api.domain.ComparisonStrategy
+   * @deprecated Use {@link #verifyExpectation(TableSet, DataSource, ExpectationContext)} instead.
+   *     Construct an {@link ExpectationContext} with the desired parameters. Removed in 2.0.
    */
+  @Deprecated(since = "1.1", forRemoval = true)
   default void verifyExpectation(
       final TableSet expectedTableSet,
       final DataSource dataSource,
       final Collection<String> excludeColumns,
       final Map<String, ColumnStrategyMapping> columnStrategies) {
-    // Default implementation ignores column strategies for backward compatibility.
-    // Implementations should override this method to support column strategies.
-    if (columnStrategies != null && !columnStrategies.isEmpty()) {
-      logWarning(
-          "Column strategies specified but current ExpectationProvider does not support them. "
-              + "Strategies will be ignored: {}. Override verifyExpectation(TableSet, DataSource, "
-              + "Collection, Map) to support column strategies.",
-          columnStrategies.keySet());
-    }
-    verifyExpectation(expectedTableSet, dataSource, excludeColumns);
+    verifyExpectation(
+        expectedTableSet,
+        dataSource,
+        ExpectationContext.defaults()
+            .withExcludeColumns(excludeColumns)
+            .withColumnStrategies(columnStrategies));
   }
 
   /**
    * Verifies that the database state matches the expected dataset with row ordering control.
-   *
-   * <p>This method extends {@link #verifyExpectation(TableSet, DataSource, Collection, Map)} with
-   * row ordering support. When set to {@link RowOrdering#UNORDERED}, rows are compared without
-   * considering their position, using set-based matching.
-   *
-   * <p>The default implementation delegates to {@link #verifyExpectation(TableSet, DataSource,
-   * Collection, Map)} when row ordering is {@link RowOrdering#ORDERED}. Implementations should
-   * override this method to support unordered comparison.
    *
    * @param expectedTableSet the expected dataset containing expected table data
    * @param dataSource the database connection source for retrieving actual data
@@ -161,35 +169,25 @@ public interface ExpectationProvider {
    * @param columnStrategies column comparison strategies keyed by uppercase column name
    * @param rowOrdering the row comparison strategy (ORDERED or UNORDERED)
    * @throws AssertionError if verification fails
-   * @see RowOrdering
+   * @deprecated Use {@link #verifyExpectation(TableSet, DataSource, ExpectationContext)} instead.
+   *     Construct an {@link ExpectationContext} with the desired parameters. Removed in 2.0.
    */
+  @Deprecated(since = "1.1", forRemoval = true)
   default void verifyExpectation(
       final TableSet expectedTableSet,
       final DataSource dataSource,
       final Collection<String> excludeColumns,
       final Map<String, ColumnStrategyMapping> columnStrategies,
       final RowOrdering rowOrdering) {
-    // Default implementation ignores row ordering for backward compatibility.
-    // Implementations should override this method to support unordered comparison.
-    if (rowOrdering == RowOrdering.UNORDERED) {
-      logWarning(
-          "Unordered row comparison requested but current ExpectationProvider does not support it. "
-              + "Falling back to ordered comparison. Override verifyExpectation(TableSet, "
-              + "DataSource, Collection, Map, RowOrdering) to support unordered comparison.");
-    }
-    verifyExpectation(expectedTableSet, dataSource, excludeColumns, columnStrategies);
+    verifyExpectation(
+        expectedTableSet,
+        dataSource,
+        ExpectationContext.of(
+            excludeColumns, columnStrategies, rowOrdering, OperationDefaults.standard()));
   }
 
   /**
    * Verifies that the database state matches the expected dataset with operation defaults.
-   *
-   * <p>This method extends {@link #verifyExpectation(TableSet, DataSource, Collection, Map,
-   * RowOrdering)} with operation defaults support. The operation defaults contain comparison
-   * settings such as the floating-point epsilon for numeric comparisons.
-   *
-   * <p>The default implementation delegates to {@link #verifyExpectation(TableSet, DataSource,
-   * Collection, Map, RowOrdering)}. Implementations should override this method to support
-   * operation defaults.
    *
    * @param expectedTableSet the expected dataset containing expected table data
    * @param dataSource the database connection source for retrieving actual data
@@ -198,8 +196,10 @@ public interface ExpectationProvider {
    * @param rowOrdering the row comparison strategy (ORDERED or UNORDERED)
    * @param operationDefaults the operation defaults containing comparison settings
    * @throws AssertionError if verification fails
-   * @see OperationDefaults
+   * @deprecated Use {@link #verifyExpectation(TableSet, DataSource, ExpectationContext)} instead.
+   *     Construct an {@link ExpectationContext} with the desired parameters. Removed in 2.0.
    */
+  @Deprecated(since = "1.1", forRemoval = true)
   default void verifyExpectation(
       final TableSet expectedTableSet,
       final DataSource dataSource,
@@ -207,17 +207,9 @@ public interface ExpectationProvider {
       final Map<String, ColumnStrategyMapping> columnStrategies,
       final RowOrdering rowOrdering,
       final OperationDefaults operationDefaults) {
-    // Default implementation ignores operation defaults for backward compatibility.
-    // Implementations should override this method to support operation defaults.
-    if (operationDefaults != null
-        && operationDefaults.floatingPointEpsilon()
-            != OperationDefaults.DEFAULT_FLOATING_POINT_EPSILON) {
-      logWarning(
-          "Custom floating-point epsilon specified but current ExpectationProvider does not "
-              + "support it. Using default epsilon. Override verifyExpectation(TableSet, "
-              + "DataSource, Collection, Map, RowOrdering, OperationDefaults) to support "
-              + "custom epsilon.");
-    }
-    verifyExpectation(expectedTableSet, dataSource, excludeColumns, columnStrategies, rowOrdering);
+    verifyExpectation(
+        expectedTableSet,
+        dataSource,
+        ExpectationContext.of(excludeColumns, columnStrategies, rowOrdering, operationDefaults));
   }
 }

--- a/db-tester-api/src/test/java/io/github/seijikohara/dbtester/api/config/ExpectationContextTest.java
+++ b/db-tester-api/src/test/java/io/github/seijikohara/dbtester/api/config/ExpectationContextTest.java
@@ -1,0 +1,290 @@
+package io.github.seijikohara.dbtester.api.config;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link ExpectationContext}. */
+@DisplayName("ExpectationContext")
+class ExpectationContextTest {
+
+  /** Tests for the ExpectationContext class. */
+  ExpectationContextTest() {}
+
+  /** Tests for the defaults() factory method. */
+  @Nested
+  @DisplayName("defaults() method")
+  class DefaultsMethod {
+
+    /** Tests for the defaults method. */
+    DefaultsMethod() {}
+
+    /** Verifies that defaults creates instance with default values. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should create instance with default values")
+    void shouldCreateInstanceWithDefaultValues() {
+      // When
+      final var context = ExpectationContext.defaults();
+
+      // Then
+      assertAll(
+          "default context values",
+          () -> assertNotNull(context, "context should not be null"),
+          () -> assertTrue(context.excludeColumns().isEmpty(), "excludeColumns should be empty"),
+          () ->
+              assertTrue(context.columnStrategies().isEmpty(), "columnStrategies should be empty"),
+          () ->
+              assertEquals(
+                  RowOrdering.ORDERED, context.rowOrdering(), "rowOrdering should be ORDERED"),
+          () -> assertNotNull(context.operationDefaults(), "operationDefaults should not be null"));
+    }
+  }
+
+  /** Tests for the of() factory method. */
+  @Nested
+  @DisplayName("of(Collection, Map, RowOrdering, OperationDefaults) method")
+  class OfMethod {
+
+    /** Tests for the of method. */
+    OfMethod() {}
+
+    /** Verifies that of creates instance with provided values. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should create instance with provided values")
+    void shouldCreateInstanceWithProvidedValues() {
+      // Given
+      final var excludeColumns = List.of("CREATED_AT", "UPDATED_AT");
+      final var columnStrategies = Map.of("EMAIL", ColumnStrategyMapping.caseInsensitive("EMAIL"));
+      final var rowOrdering = RowOrdering.UNORDERED;
+      final var operationDefaults = OperationDefaults.standard();
+
+      // When
+      final var context =
+          ExpectationContext.of(excludeColumns, columnStrategies, rowOrdering, operationDefaults);
+
+      // Then
+      assertAll(
+          "context values",
+          () ->
+              assertEquals(
+                  Set.of("CREATED_AT", "UPDATED_AT"),
+                  context.excludeColumns(),
+                  "excludeColumns should match"),
+          () ->
+              assertEquals(1, context.columnStrategies().size(), "should have one column strategy"),
+          () ->
+              assertEquals(
+                  RowOrdering.UNORDERED, context.rowOrdering(), "rowOrdering should be UNORDERED"),
+          () ->
+              assertEquals(
+                  operationDefaults,
+                  context.operationDefaults(),
+                  "operationDefaults should match"));
+    }
+  }
+
+  /** Tests for defensive copy behavior. */
+  @Nested
+  @DisplayName("defensive copies")
+  class DefensiveCopies {
+
+    /** Tests for defensive copy behavior. */
+    DefensiveCopies() {}
+
+    /** Verifies that excludeColumns creates a defensive copy. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should create defensive copy of excludeColumns")
+    void shouldCreateDefensiveCopy_whenExcludeColumnsModified() {
+      // Given
+      final var mutableList = new ArrayList<>(List.of("COL1", "COL2"));
+      final var context =
+          ExpectationContext.of(
+              mutableList, Map.of(), RowOrdering.ORDERED, OperationDefaults.standard());
+
+      // When
+      mutableList.add("COL3");
+
+      // Then
+      assertEquals(2, context.excludeColumns().size(), "excludeColumns should not be affected");
+    }
+
+    /** Verifies that columnStrategies creates a defensive copy. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should create defensive copy of columnStrategies")
+    void shouldCreateDefensiveCopy_whenColumnStrategiesModified() {
+      // Given
+      final var mutableMap =
+          new HashMap<>(Map.of("EMAIL", ColumnStrategyMapping.caseInsensitive("EMAIL")));
+      final var context =
+          ExpectationContext.of(
+              List.of(), mutableMap, RowOrdering.ORDERED, OperationDefaults.standard());
+
+      // When
+      mutableMap.put("NAME", ColumnStrategyMapping.strict("NAME"));
+
+      // Then
+      assertEquals(1, context.columnStrategies().size(), "columnStrategies should not be affected");
+    }
+
+    /** Verifies that returned excludeColumns is immutable. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should return immutable excludeColumns")
+    void shouldReturnImmutableExcludeColumns() {
+      // Given
+      final var context =
+          ExpectationContext.of(
+              List.of("COL1"), Map.of(), RowOrdering.ORDERED, OperationDefaults.standard());
+
+      // When & Then
+      assertThrows(
+          UnsupportedOperationException.class,
+          () -> context.excludeColumns().add("COL2"),
+          "excludeColumns should be immutable");
+    }
+
+    /** Verifies that returned columnStrategies is immutable. */
+    @Test
+    @Tag("edge-case")
+    @DisplayName("should return immutable columnStrategies")
+    void shouldReturnImmutableColumnStrategies() {
+      // Given
+      final var context =
+          ExpectationContext.of(
+              List.of(),
+              Map.of("EMAIL", ColumnStrategyMapping.caseInsensitive("EMAIL")),
+              RowOrdering.ORDERED,
+              OperationDefaults.standard());
+
+      // When & Then
+      assertThrows(
+          UnsupportedOperationException.class,
+          () -> context.columnStrategies().put("NAME", ColumnStrategyMapping.strict("NAME")),
+          "columnStrategies should be immutable");
+    }
+  }
+
+  /** Tests for with*() copy methods. */
+  @Nested
+  @DisplayName("with*() copy methods")
+  class WithMethods {
+
+    /** Tests for with methods. */
+    WithMethods() {}
+
+    /** Verifies that withExcludeColumns returns new instance with updated columns. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return new instance with updated excludeColumns")
+    void shouldReturnNewInstance_whenWithExcludeColumnsCalled() {
+      // Given
+      final var original = ExpectationContext.defaults();
+
+      // When
+      final var updated = original.withExcludeColumns(List.of("CREATED_AT"));
+
+      // Then
+      assertAll(
+          "updated context",
+          () ->
+              assertEquals(
+                  Set.of("CREATED_AT"),
+                  updated.excludeColumns(),
+                  "excludeColumns should be updated"),
+          () ->
+              assertTrue(
+                  original.excludeColumns().isEmpty(),
+                  "original excludeColumns should remain empty"));
+    }
+
+    /** Verifies that withColumnStrategies returns new instance with updated strategies. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return new instance with updated columnStrategies")
+    void shouldReturnNewInstance_whenWithColumnStrategiesCalled() {
+      // Given
+      final var original = ExpectationContext.defaults();
+      final var strategies = Map.of("EMAIL", ColumnStrategyMapping.caseInsensitive("EMAIL"));
+
+      // When
+      final var updated = original.withColumnStrategies(strategies);
+
+      // Then
+      assertAll(
+          "updated context",
+          () ->
+              assertEquals(1, updated.columnStrategies().size(), "should have one column strategy"),
+          () ->
+              assertTrue(
+                  original.columnStrategies().isEmpty(),
+                  "original columnStrategies should remain empty"));
+    }
+
+    /** Verifies that withRowOrdering returns new instance with updated ordering. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return new instance with updated rowOrdering")
+    void shouldReturnNewInstance_whenWithRowOrderingCalled() {
+      // Given
+      final var original = ExpectationContext.defaults();
+
+      // When
+      final var updated = original.withRowOrdering(RowOrdering.UNORDERED);
+
+      // Then
+      assertAll(
+          "updated context",
+          () ->
+              assertEquals(
+                  RowOrdering.UNORDERED, updated.rowOrdering(), "rowOrdering should be UNORDERED"),
+          () ->
+              assertEquals(
+                  RowOrdering.ORDERED,
+                  original.rowOrdering(),
+                  "original rowOrdering should remain ORDERED"));
+    }
+
+    /** Verifies that withOperationDefaults returns new instance with updated defaults. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return new instance with updated operationDefaults")
+    void shouldReturnNewInstance_whenWithOperationDefaultsCalled() {
+      // Given
+      final var original = ExpectationContext.defaults();
+      final var customDefaults = OperationDefaults.builder().floatingPointEpsilon(1e-9).build();
+
+      // When
+      final var updated = original.withOperationDefaults(customDefaults);
+
+      // Then
+      assertAll(
+          "updated context",
+          () ->
+              assertEquals(
+                  customDefaults,
+                  updated.operationDefaults(),
+                  "operationDefaults should be updated"),
+          () ->
+              assertEquals(
+                  OperationDefaults.standard(),
+                  original.operationDefaults(),
+                  "original operationDefaults should remain standard"));
+    }
+  }
+}

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/assertion/ExpectationVerifier.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/assertion/ExpectationVerifier.java
@@ -1,6 +1,7 @@
 package io.github.seijikohara.dbtester.internal.assertion;
 
 import io.github.seijikohara.dbtester.api.config.ColumnStrategyMapping;
+import io.github.seijikohara.dbtester.api.config.ExpectationContext;
 import io.github.seijikohara.dbtester.api.config.OperationDefaults;
 import io.github.seijikohara.dbtester.api.config.RowOrdering;
 import io.github.seijikohara.dbtester.api.dataset.TableSet;
@@ -70,6 +71,86 @@ public final class ExpectationVerifier {
   }
 
   /**
+   * Verifies database state matches expected dataset using the specified context.
+   *
+   * <p>This method accepts an {@link ExpectationContext} parameter object that encapsulates all
+   * optional verification parameters.
+   *
+   * @param expectedTableSet the expected dataset containing expected table data
+   * @param dataSource the database connection source for retrieving actual data
+   * @param context the verification context containing optional parameters
+   * @throws AssertionError if verification fails
+   */
+  public void verifyExpectation(
+      final TableSet expectedTableSet,
+      final DataSource dataSource,
+      final ExpectationContext context) {
+    final var excludeColumns = context.excludeColumns();
+    final var columnStrategies = context.columnStrategies();
+    final var rowOrdering = context.rowOrdering();
+    final var operationDefaults = context.operationDefaults();
+
+    logger.debug(
+        "Verifying expectation for {} tables with {} ordering and epsilon {}",
+        expectedTableSet.getTables().size(),
+        rowOrdering,
+        operationDefaults.floatingPointEpsilon());
+
+    final var normalizedExcludeColumns = normalizeExcludeColumns(excludeColumns);
+    final var effectiveColumnStrategies =
+        columnStrategies.isEmpty() ? Map.<String, ColumnStrategyMapping>of() : columnStrategies;
+
+    if (!normalizedExcludeColumns.isEmpty()) {
+      logger.debug("Excluding columns from verification: {}", normalizedExcludeColumns);
+    }
+
+    if (!effectiveColumnStrategies.isEmpty()) {
+      logger.debug("Using column strategies for: {}", effectiveColumnStrategies.keySet());
+    }
+
+    // Create a comparator with the specified operation defaults if different from instance default
+    final var effectiveComparator =
+        operationDefaults.floatingPointEpsilon() != OperationDefaults.DEFAULT_FLOATING_POINT_EPSILON
+            ? new DataSetComparator(operationDefaults)
+            : comparator;
+
+    expectedTableSet
+        .getTables()
+        .forEach(
+            expectedTable -> {
+              final var tableName = expectedTable.getName().value();
+              final var expectedColumns = expectedTable.getColumns();
+
+              logger.trace(
+                  "Fetching table {} with {} expected columns", tableName, expectedColumns.size());
+
+              final var actualTable =
+                  tableReader.fetchTable(dataSource, tableName, expectedColumns);
+
+              logger.trace(
+                  "Comparing table {}: expected {} rows, actual {} rows ({})",
+                  tableName,
+                  expectedTable.getRowCount(),
+                  actualTable.getRowCount(),
+                  rowOrdering);
+
+              if (normalizedExcludeColumns.isEmpty() && effectiveColumnStrategies.isEmpty()) {
+                effectiveComparator.assertEquals(expectedTable, actualTable, null);
+              } else {
+                effectiveComparator.assertEqualsWithStrategies(
+                    expectedTable,
+                    actualTable,
+                    normalizedExcludeColumns,
+                    effectiveColumnStrategies,
+                    rowOrdering);
+              }
+            });
+
+    logger.debug(
+        "Successfully verified expectation for {} tables", expectedTableSet.getTables().size());
+  }
+
+  /**
    * Verifies database state matches expected dataset.
    *
    * <p>For each table in the expected dataset:
@@ -87,7 +168,7 @@ public final class ExpectationVerifier {
    * @throws AssertionError if verification fails
    */
   public void verifyExpectation(final TableSet expectedTableSet, final DataSource dataSource) {
-    verifyExpectation(expectedTableSet, dataSource, null);
+    verifyExpectation(expectedTableSet, dataSource, (Collection<String>) null);
   }
 
   /**

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/lifecycle/DefaultExpectationSupport.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/lifecycle/DefaultExpectationSupport.java
@@ -1,6 +1,7 @@
 package io.github.seijikohara.dbtester.internal.lifecycle;
 
 import io.github.seijikohara.dbtester.api.annotation.ExpectedDataSet;
+import io.github.seijikohara.dbtester.api.config.ExpectationContext;
 import io.github.seijikohara.dbtester.api.config.RowOrdering;
 import io.github.seijikohara.dbtester.api.context.TestContext;
 import io.github.seijikohara.dbtester.api.dataset.Table;
@@ -217,10 +218,11 @@ public final class DefaultExpectationSupport implements ExpectationSupport {
     }
 
     final var operationDefaults = context.configuration().operations();
+    final var expectationContext =
+        ExpectationContext.of(excludeColumns, columnStrategies, rowOrdering, operationDefaults);
 
     try {
-      expectationProvider.verifyExpectation(
-          tableSet, dataSource, excludeColumns, columnStrategies, rowOrdering, operationDefaults);
+      expectationProvider.verifyExpectation(tableSet, dataSource, expectationContext);
 
       logger.info(
           "Expectation validation completed successfully for {}: {} tables",

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/spi/DefaultExpectationProvider.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/spi/DefaultExpectationProvider.java
@@ -1,6 +1,7 @@
 package io.github.seijikohara.dbtester.internal.spi;
 
 import io.github.seijikohara.dbtester.api.config.ColumnStrategyMapping;
+import io.github.seijikohara.dbtester.api.config.ExpectationContext;
 import io.github.seijikohara.dbtester.api.config.OperationDefaults;
 import io.github.seijikohara.dbtester.api.config.RowOrdering;
 import io.github.seijikohara.dbtester.api.dataset.TableSet;
@@ -46,10 +47,20 @@ public final class DefaultExpectationProvider implements ExpectationProvider {
   public void verifyExpectation(
       final TableSet expectedTableSet,
       final DataSource dataSource,
+      final ExpectationContext context) {
+    expectationVerifier.verifyExpectation(expectedTableSet, dataSource, context);
+  }
+
+  @SuppressWarnings("removal")
+  @Override
+  public void verifyExpectation(
+      final TableSet expectedTableSet,
+      final DataSource dataSource,
       final Collection<String> excludeColumns) {
     expectationVerifier.verifyExpectation(expectedTableSet, dataSource, excludeColumns);
   }
 
+  @SuppressWarnings("removal")
   @Override
   public void verifyExpectation(
       final TableSet expectedTableSet,
@@ -60,6 +71,7 @@ public final class DefaultExpectationProvider implements ExpectationProvider {
         expectedTableSet, dataSource, excludeColumns, columnStrategies);
   }
 
+  @SuppressWarnings("removal")
   @Override
   public void verifyExpectation(
       final TableSet expectedTableSet,
@@ -71,6 +83,7 @@ public final class DefaultExpectationProvider implements ExpectationProvider {
         expectedTableSet, dataSource, excludeColumns, columnStrategies, rowOrdering);
   }
 
+  @SuppressWarnings("removal")
   @Override
   public void verifyExpectation(
       final TableSet expectedTableSet,

--- a/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/lifecycle/DefaultExpectationSupportTest.java
+++ b/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/lifecycle/DefaultExpectationSupportTest.java
@@ -16,6 +16,7 @@ import io.github.seijikohara.dbtester.api.annotation.ExpectedDataSet;
 import io.github.seijikohara.dbtester.api.config.Configuration;
 import io.github.seijikohara.dbtester.api.config.ConventionSettings;
 import io.github.seijikohara.dbtester.api.config.DataSourceRegistry;
+import io.github.seijikohara.dbtester.api.config.ExpectationContext;
 import io.github.seijikohara.dbtester.api.config.OperationDefaults;
 import io.github.seijikohara.dbtester.api.config.RowOrdering;
 import io.github.seijikohara.dbtester.api.context.TestContext;
@@ -126,7 +127,7 @@ class DefaultExpectationSupportTest {
 
       doNothing()
           .when(expectationProvider)
-          .verifyExpectation(any(), any(), any(), any(), any(), any());
+          .verifyExpectation(any(), any(), any(ExpectationContext.class));
 
       // When & Then
       assertDoesNotThrow(
@@ -134,7 +135,7 @@ class DefaultExpectationSupportTest {
           "should not throw when verification succeeds");
 
       verify(expectationProvider, times(1))
-          .verifyExpectation(any(), any(), any(), any(), any(), any());
+          .verifyExpectation(any(), any(), any(ExpectationContext.class));
     }
 
     /** Verifies that verification throws on first failure when retryCount is 0. */
@@ -155,7 +156,7 @@ class DefaultExpectationSupportTest {
 
       doThrow(new ValidationException("Mismatch"))
           .when(expectationProvider)
-          .verifyExpectation(any(), any(), any(), any(), any(), any());
+          .verifyExpectation(any(), any(), any(ExpectationContext.class));
 
       // When & Then
       final var exception =
@@ -170,7 +171,7 @@ class DefaultExpectationSupportTest {
           "exception message should indicate verification failure");
 
       verify(expectationProvider, times(1))
-          .verifyExpectation(any(), any(), any(), any(), any(), any());
+          .verifyExpectation(any(), any(), any(ExpectationContext.class));
     }
 
     /** Verifies that verification succeeds on a retry attempt. */
@@ -194,14 +195,14 @@ class DefaultExpectationSupportTest {
       doThrow(new ValidationException("Mismatch"))
           .doNothing()
           .when(expectationProvider)
-          .verifyExpectation(any(), any(), any(), any(), any(), any());
+          .verifyExpectation(any(), any(), any(ExpectationContext.class));
 
       // When & Then
       assertDoesNotThrow(
           () -> support.verify(context, expectedDataSet), "should not throw when retry succeeds");
 
       verify(expectationProvider, times(2))
-          .verifyExpectation(any(), any(), any(), any(), any(), any());
+          .verifyExpectation(any(), any(), any(ExpectationContext.class));
     }
 
     /** Verifies that all retries are exhausted before throwing. */
@@ -223,7 +224,7 @@ class DefaultExpectationSupportTest {
 
       doThrow(new ValidationException("Persistent mismatch"))
           .when(expectationProvider)
-          .verifyExpectation(any(), any(), any(), any(), any(), any());
+          .verifyExpectation(any(), any(), any(ExpectationContext.class));
 
       // When & Then
       final var exception =
@@ -241,7 +242,7 @@ class DefaultExpectationSupportTest {
                   "exception message should indicate verification failure"),
           () ->
               verify(expectationProvider, times(3))
-                  .verifyExpectation(any(), any(), any(), any(), any(), any()));
+                  .verifyExpectation(any(), any(), any(ExpectationContext.class)));
     }
 
     /** Verifies that no datasets results in early return without verification. */
@@ -258,7 +259,7 @@ class DefaultExpectationSupportTest {
           "should not throw when no datasets found");
 
       verify(expectationProvider, times(0))
-          .verifyExpectation(any(), any(), any(), any(), any(), any());
+          .verifyExpectation(any(), any(), any(ExpectationContext.class));
     }
 
     /** Verifies that annotation retryCount overrides global setting. */
@@ -282,7 +283,7 @@ class DefaultExpectationSupportTest {
 
       doThrow(new ValidationException("Mismatch"))
           .when(expectationProvider)
-          .verifyExpectation(any(), any(), any(), any(), any(), any());
+          .verifyExpectation(any(), any(), any(ExpectationContext.class));
 
       // When & Then
       assertThrows(
@@ -292,7 +293,7 @@ class DefaultExpectationSupportTest {
 
       // Annotation retryCount=1 means 2 total attempts (initial + 1 retry)
       verify(expectationProvider, times(2))
-          .verifyExpectation(any(), any(), any(), any(), any(), any());
+          .verifyExpectation(any(), any(), any(ExpectationContext.class));
     }
 
     /** Verifies that global retryCount is used when annotation value is -1. */
@@ -317,7 +318,7 @@ class DefaultExpectationSupportTest {
 
       doThrow(new ValidationException("Mismatch"))
           .when(expectationProvider)
-          .verifyExpectation(any(), any(), any(), any(), any(), any());
+          .verifyExpectation(any(), any(), any(ExpectationContext.class));
 
       // When & Then
       assertThrows(
@@ -327,7 +328,7 @@ class DefaultExpectationSupportTest {
 
       // Global retryCount=1 means 2 total attempts (initial + 1 retry)
       verify(expectationProvider, times(2))
-          .verifyExpectation(any(), any(), any(), any(), any(), any());
+          .verifyExpectation(any(), any(), any(ExpectationContext.class));
     }
   }
 

--- a/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/spi/DefaultExpectationProviderTest.java
+++ b/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/spi/DefaultExpectationProviderTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import io.github.seijikohara.dbtester.api.config.ColumnStrategyMapping;
+import io.github.seijikohara.dbtester.api.config.ExpectationContext;
 import io.github.seijikohara.dbtester.api.config.OperationDefaults;
 import io.github.seijikohara.dbtester.api.config.RowOrdering;
 import io.github.seijikohara.dbtester.api.dataset.TableSet;
@@ -73,7 +74,7 @@ class DefaultExpectationProviderTest {
     }
   }
 
-  /** Tests for the verifyExpectation() method. */
+  /** Tests for the verifyExpectation(TableSet, DataSource) method. */
   @Nested
   @DisplayName("verifyExpectation(TableSet, DataSource) method")
   class VerifyExpectationMethod {
@@ -101,6 +102,62 @@ class DefaultExpectationProviderTest {
     }
   }
 
+  /** Tests for the verifyExpectation(TableSet, DataSource, ExpectationContext) method. */
+  @Nested
+  @DisplayName("verifyExpectation(TableSet, DataSource, ExpectationContext) method")
+  class VerifyExpectationWithContextMethod {
+
+    /** Tests for the verifyExpectation method with ExpectationContext. */
+    VerifyExpectationWithContextMethod() {}
+
+    /** Verifies that verifyExpectation delegates to expectation verifier with context. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should delegate to expectation verifier when called with context")
+    void shouldDelegateToExpectationVerifier_whenCalledWithContext() {
+      // Given
+      final var expectedDataSet = mock(TableSet.class);
+      final var dataSource = mock(DataSource.class);
+      final var context = ExpectationContext.defaults();
+      doNothing()
+          .when(mockExpectationVerifier)
+          .verifyExpectation(
+              any(TableSet.class), any(DataSource.class), any(ExpectationContext.class));
+
+      // When
+      provider.verifyExpectation(expectedDataSet, dataSource, context);
+
+      // Then
+      verify(mockExpectationVerifier).verifyExpectation(expectedDataSet, dataSource, context);
+    }
+
+    /** Verifies that verifyExpectation passes all context parameters to verifier. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should pass context with all parameters to expectation verifier")
+    void shouldPassContextWithAllParameters_whenCalledWithCustomContext() {
+      // Given
+      final var expectedDataSet = mock(TableSet.class);
+      final var dataSource = mock(DataSource.class);
+      final var context =
+          ExpectationContext.of(
+              List.of("CREATED_AT"),
+              Map.of("EMAIL", ColumnStrategyMapping.caseInsensitive("EMAIL")),
+              RowOrdering.UNORDERED,
+              OperationDefaults.standard());
+      doNothing()
+          .when(mockExpectationVerifier)
+          .verifyExpectation(
+              any(TableSet.class), any(DataSource.class), any(ExpectationContext.class));
+
+      // When
+      provider.verifyExpectation(expectedDataSet, dataSource, context);
+
+      // Then
+      verify(mockExpectationVerifier).verifyExpectation(expectedDataSet, dataSource, context);
+    }
+  }
+
   /**
    * Tests for the verifyExpectation(TableSet, DataSource, Collection, Map, RowOrdering,
    * OperationDefaults) method.
@@ -109,6 +166,7 @@ class DefaultExpectationProviderTest {
   @DisplayName(
       "verifyExpectation(TableSet, DataSource, Collection, Map, RowOrdering, OperationDefaults)"
           + " method")
+  @SuppressWarnings("removal")
   class VerifyExpectationWithOperationDefaultsMethod {
 
     /** Tests for the verifyExpectation method with OperationDefaults. */

--- a/docs/specs/ja/spi.md
+++ b/docs/specs/ja/spi.md
@@ -179,30 +179,12 @@ public interface AssertionProvider {
 
 ```java
 public interface ExpectationProvider {
-    // 基本検証
+    // 基本検証（abstract）
     void verifyExpectation(TableSet expectedTableSet, DataSource dataSource);
 
-    // カラム除外付き
+    // ExpectationContextパラメータオブジェクト付き（default）
     default void verifyExpectation(TableSet expectedTableSet, DataSource dataSource,
-                                   Collection<String> excludeColumns);
-
-    // カラム戦略付き
-    default void verifyExpectation(TableSet expectedTableSet, DataSource dataSource,
-                                   Collection<String> excludeColumns,
-                                   Map<String, ColumnStrategyMapping> columnStrategies);
-
-    // 行順序制御付き
-    default void verifyExpectation(TableSet expectedTableSet, DataSource dataSource,
-                                   Collection<String> excludeColumns,
-                                   Map<String, ColumnStrategyMapping> columnStrategies,
-                                   RowOrdering rowOrdering);
-
-    // 操作デフォルト付き（例: 浮動小数点イプシロン）
-    default void verifyExpectation(TableSet expectedTableSet, DataSource dataSource,
-                                   Collection<String> excludeColumns,
-                                   Map<String, ColumnStrategyMapping> columnStrategies,
-                                   RowOrdering rowOrdering,
-                                   OperationDefaults operationDefaults);
+                                   ExpectationContext context);
 }
 ```
 
@@ -213,26 +195,45 @@ public interface ExpectationProvider {
 | メソッド | 説明 |
 |----------|------|
 | `verifyExpectation(TableSet, DataSource)` | 基本的なデータベース状態検証 |
-| `verifyExpectation(..., excludeColumns)` | 指定カラムを除外して検証 |
-| `verifyExpectation(..., columnStrategies)` | カラム比較戦略付きで検証 |
-| `verifyExpectation(..., rowOrdering)` | 行順序制御付きで検証 |
-| `verifyExpectation(..., operationDefaults)` | 操作デフォルト付きで検証（例: 浮動小数点イプシロン） |
+| `verifyExpectation(TableSet, DataSource, ExpectationContext)` | フルコンテキスト付き検証（除外、戦略、順序、デフォルト） |
 
-**パラメータ**:
+**ExpectationContext** (`io.github.seijikohara.dbtester.api.config.ExpectationContext`):
 
-| パラメータ | 型 | 説明 |
+オプションの検証パラメータをカプセル化するパラメータオブジェクト：
+
+| フィールド | 型 | 説明 |
 |-----------|-----|------|
-| `expectedTableSet` | `TableSet` | 期待テーブルデータを含む期待テーブルセット |
-| `dataSource` | `DataSource` | 実際のデータを取得するためのデータベースコネクションソース |
-| `excludeColumns` | `Collection<String>` | 比較から除外するカラム名（大文字小文字区別なし） |
+| `excludeColumns` | `Set<String>` | 比較から除外するカラム名（大文字小文字区別なし） |
 | `columnStrategies` | `Map<String, ColumnStrategyMapping>` | カラム名でキーイングされたカラム比較戦略 |
 | `rowOrdering` | `RowOrdering` | 行比較戦略（ORDEREDまたはUNORDERED） |
 | `operationDefaults` | `OperationDefaults` | 比較設定を含む操作デフォルト（例: 浮動小数点イプシロン） |
 
+```java
+// デフォルトコンテキスト（除外なし、順序付き、標準デフォルト）
+var context = ExpectationContext.defaults();
+
+// with*()コピーメソッドによるカスタムコンテキスト
+var context = ExpectationContext.defaults()
+    .withExcludeColumns(Set.of("CREATED_AT", "UPDATED_AT"))
+    .withRowOrdering(RowOrdering.UNORDERED);
+
+// 全パラメータ指定のファクトリメソッド
+var context = ExpectationContext.of(
+    excludeColumns, columnStrategies, rowOrdering, operationDefaults);
+```
+
+**非推奨メソッド**（2.0で削除予定）:
+
+旧テレスコーピングオーバーロードは`ExpectationContext`に置き換えられました：
+- `verifyExpectation(TableSet, DataSource, Collection<String>)`
+- `verifyExpectation(TableSet, DataSource, Collection<String>, Map<String, ColumnStrategyMapping>)`
+- `verifyExpectation(TableSet, DataSource, Collection<String>, Map<String, ColumnStrategyMapping>, RowOrdering)`
+- `verifyExpectation(TableSet, DataSource, Collection<String>, Map<String, ColumnStrategyMapping>, RowOrdering, OperationDefaults)`
+
 **プロセス**:
 1. 期待テーブルセット内の各テーブルに対して、データベースから実際のデータを取得
 2. 実際のデータを期待テーブルに存在するカラムのみにフィルタリング
-3. カラム除外と比較戦略を適用
+3. コンテキストからカラム除外と比較戦略を適用
 4. フィルタリングされた実際のデータを期待データと比較
 5. 検証失敗時は`AssertionError`をスロー
 

--- a/docs/specs/public-api.md
+++ b/docs/specs/public-api.md
@@ -17,7 +17,7 @@ Packages intended for test authors writing database tests. These packages form t
 |---------|-------------|
 | `annotation` | Declarative test annotations (`@DataSet`, `@ExpectedDataSet`, `@DataSetSource`) |
 | `assertion` | Programmatic database assertion utilities (`DatabaseAssertion`) |
-| `config` | Configuration types (`Configuration`, `DataSourceRegistry`, `ConventionSettings`) |
+| `config` | Configuration types (`Configuration`, `DataSourceRegistry`, `ConventionSettings`, `ExpectationContext`) |
 | `exception` | Framework exception hierarchy |
 | `export` | Data export API (`DataSetExporter`) |
 | `operation` | Database operation enumerations (`Operation`, `TableOrderingStrategy`) |

--- a/docs/specs/spi.md
+++ b/docs/specs/spi.md
@@ -183,30 +183,12 @@ Verifies database state against expected datasets.
 
 ```java
 public interface ExpectationProvider {
-    // Basic verification
+    // Basic verification (abstract)
     void verifyExpectation(TableSet expectedTableSet, DataSource dataSource);
 
-    // With column exclusion
+    // With ExpectationContext parameter object (default)
     default void verifyExpectation(TableSet expectedTableSet, DataSource dataSource,
-                                   Collection<String> excludeColumns);
-
-    // With column strategies
-    default void verifyExpectation(TableSet expectedTableSet, DataSource dataSource,
-                                   Collection<String> excludeColumns,
-                                   Map<String, ColumnStrategyMapping> columnStrategies);
-
-    // With row ordering
-    default void verifyExpectation(TableSet expectedTableSet, DataSource dataSource,
-                                   Collection<String> excludeColumns,
-                                   Map<String, ColumnStrategyMapping> columnStrategies,
-                                   RowOrdering rowOrdering);
-
-    // With operation defaults (e.g., floating-point epsilon)
-    default void verifyExpectation(TableSet expectedTableSet, DataSource dataSource,
-                                   Collection<String> excludeColumns,
-                                   Map<String, ColumnStrategyMapping> columnStrategies,
-                                   RowOrdering rowOrdering,
-                                   OperationDefaults operationDefaults);
+                                   ExpectationContext context);
 }
 ```
 
@@ -217,26 +199,45 @@ public interface ExpectationProvider {
 | Method | Description |
 |--------|-------------|
 | `verifyExpectation(TableSet, DataSource)` | Basic database state verification |
-| `verifyExpectation(..., excludeColumns)` | Verify excluding specified columns |
-| `verifyExpectation(..., columnStrategies)` | Verify with column comparison strategies |
-| `verifyExpectation(..., rowOrdering)` | Verify with row ordering control |
-| `verifyExpectation(..., operationDefaults)` | Verify with operation defaults (e.g., floating-point epsilon) |
+| `verifyExpectation(TableSet, DataSource, ExpectationContext)` | Verify with full context (exclusions, strategies, ordering, defaults) |
 
-**Parameters**:
+**ExpectationContext** (`io.github.seijikohara.dbtester.api.config.ExpectationContext`):
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `expectedTableSet` | `TableSet` | The expected table set containing expected table data |
-| `dataSource` | `DataSource` | The database connection source for retrieving actual data |
-| `excludeColumns` | `Collection<String>` | Column names to exclude from comparison (case-insensitive) |
+A parameter object that encapsulates all optional verification parameters:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `excludeColumns` | `Set<String>` | Column names to exclude from comparison (case-insensitive) |
 | `columnStrategies` | `Map<String, ColumnStrategyMapping>` | Column comparison strategies keyed by column name |
 | `rowOrdering` | `RowOrdering` | Row comparison strategy (ORDERED or UNORDERED) |
 | `operationDefaults` | `OperationDefaults` | Operation defaults containing comparison settings (e.g., floating-point epsilon) |
 
+```java
+// Default context (no exclusions, ordered, standard defaults)
+var context = ExpectationContext.defaults();
+
+// Custom context using with*() copy methods
+var context = ExpectationContext.defaults()
+    .withExcludeColumns(Set.of("CREATED_AT", "UPDATED_AT"))
+    .withRowOrdering(RowOrdering.UNORDERED);
+
+// Factory method with all parameters
+var context = ExpectationContext.of(
+    excludeColumns, columnStrategies, rowOrdering, operationDefaults);
+```
+
+**Deprecated Methods** (removed in 2.0):
+
+The previous telescoping overloads are deprecated in favor of `ExpectationContext`:
+- `verifyExpectation(TableSet, DataSource, Collection<String>)`
+- `verifyExpectation(TableSet, DataSource, Collection<String>, Map<String, ColumnStrategyMapping>)`
+- `verifyExpectation(TableSet, DataSource, Collection<String>, Map<String, ColumnStrategyMapping>, RowOrdering)`
+- `verifyExpectation(TableSet, DataSource, Collection<String>, Map<String, ColumnStrategyMapping>, RowOrdering, OperationDefaults)`
+
 **Process**:
 1. The provider iterates each table in the expected dataset and fetches actual data from the database.
 2. The provider filters actual data to include only columns present in the expected table.
-3. The provider applies column exclusions and comparison strategies.
+3. The provider applies column exclusions and comparison strategies from the context.
 4. The provider compares filtered actual data against expected data.
 5. The provider throws `AssertionError` if verification fails.
 


### PR DESCRIPTION
## Summary
- Add `ExpectationContext` record in `api/config/` encapsulating all optional verification parameters (excludeColumns, columnStrategies, rowOrdering, operationDefaults)
- Add `verifyExpectation(TableSet, DataSource, ExpectationContext)` default method to `ExpectationProvider`
- Deprecate 4 telescoping overloads with `@Deprecated(since = "1.1", forRemoval = true)`
- Update `DefaultExpectationProvider` and `ExpectationVerifier` to support the new context method
- Update `DefaultExpectationSupport` to construct and pass `ExpectationContext`
- Add comprehensive unit tests for `ExpectationContext`

## Test plan
- [x] `ExpectationContextTest` covers defaults, factory, defensive copies, immutability, and with*() copy methods
- [x] `DefaultExpectationProviderTest` covers new context delegation and deprecated overloads
- [x] `DefaultExpectationSupportTest` updated to use new context-based method
- [x] `./gradlew :db-tester-api:build` passes
- [x] `./gradlew :db-tester-core:build` passes
- [x] `./gradlew :db-tester-junit:build` passes

Closes #172