### PR TITLE
test(spring): improve Spring Boot starter test coverage

### DIFF
--- a/db-tester-junit-spring-boot-starter/src/test/java/io/github/seijikohara/dbtester/junit/spring/boot/autoconfigure/DbTesterJUnitAutoConfigurationTest.java
+++ b/db-tester-junit-spring-boot-starter/src/test/java/io/github/seijikohara/dbtester/junit/spring/boot/autoconfigure/DbTesterJUnitAutoConfigurationTest.java
@@ -1,11 +1,21 @@
 package io.github.seijikohara.dbtester.junit.spring.boot.autoconfigure;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.github.seijikohara.dbtester.api.config.DataFormat;
+import io.github.seijikohara.dbtester.api.config.RowOrdering;
+import io.github.seijikohara.dbtester.api.config.TableMergeStrategy;
+import io.github.seijikohara.dbtester.api.config.TransactionMode;
+import io.github.seijikohara.dbtester.api.operation.Operation;
+import java.time.Duration;
+import java.util.Set;
 import java.util.stream.Stream;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.BeforeEach;
@@ -98,6 +108,195 @@ class DbTesterJUnitAutoConfigurationTest {
 
       // Then
       assertNotNull(config.operations(), "operations should not be null");
+    }
+
+    /** Verifies that Configuration has verification settings. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return Configuration with verification settings")
+    void should_return_configuration_with_verification() {
+      // Given & When
+      final var config = autoConfiguration.dbTesterConfiguration(properties);
+
+      // Then
+      assertNotNull(config.verification(), "verification should not be null");
+    }
+
+    /** Verifies that Configuration has execution settings. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return Configuration with execution settings")
+    void should_return_configuration_with_execution() {
+      // Given & When
+      final var config = autoConfiguration.dbTesterConfiguration(properties);
+
+      // Then
+      assertNotNull(config.execution(), "execution should not be null");
+    }
+
+    /** Verifies that Configuration has loader. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should return Configuration with loader")
+    void should_return_configuration_with_loader() {
+      // Given & When
+      final var config = autoConfiguration.dbTesterConfiguration(properties);
+
+      // Then
+      assertNotNull(config.loader(), "loader should not be null");
+    }
+
+    /** Verifies that custom convention properties are mapped to Configuration. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should map custom convention properties to Configuration")
+    void should_map_custom_convention_properties() {
+      // Given
+      properties.getConvention().setBaseDirectory("/custom/base");
+      properties.getConvention().setExpectationSuffix("/verify");
+      properties.getConvention().setScenarioMarker("[TestCase]");
+      properties.getConvention().setDataFormat(DataFormat.TSV);
+      properties.getConvention().setTableMergeStrategy(TableMergeStrategy.FIRST);
+      properties.getConvention().setLoadOrderFileName("custom-order.txt");
+
+      // When
+      final var config = autoConfiguration.dbTesterConfiguration(properties);
+
+      // Then
+      final var conventions = config.conventions();
+      assertAll(
+          "convention properties should be mapped",
+          () -> assertEquals("/custom/base", conventions.baseDirectory(), "baseDirectory mismatch"),
+          () ->
+              assertEquals(
+                  "/verify", conventions.expectationSuffix(), "expectationSuffix mismatch"),
+          () -> assertEquals("[TestCase]", conventions.scenarioMarker(), "scenarioMarker mismatch"),
+          () -> assertEquals(DataFormat.TSV, conventions.dataFormat(), "dataFormat mismatch"),
+          () ->
+              assertEquals(
+                  TableMergeStrategy.FIRST,
+                  conventions.tableMergeStrategy(),
+                  "tableMergeStrategy mismatch"),
+          () ->
+              assertEquals(
+                  "custom-order.txt",
+                  conventions.loadOrderFileName(),
+                  "loadOrderFileName mismatch"));
+    }
+
+    /** Verifies that custom verification properties are mapped to Configuration. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should map custom verification properties to Configuration")
+    void should_map_custom_verification_properties() {
+      // Given
+      properties.getVerification().setGlobalExcludeColumns(Set.of("created_at", "updated_at"));
+      properties.getVerification().setRowOrdering(RowOrdering.UNORDERED);
+      properties.getVerification().setRetryCount(3);
+      properties.getVerification().setRetryDelay(Duration.ofSeconds(2));
+
+      // When
+      final var config = autoConfiguration.dbTesterConfiguration(properties);
+
+      // Then
+      final var verification = config.verification();
+      assertAll(
+          "verification properties should be mapped",
+          () ->
+              assertEquals(
+                  Set.of("created_at", "updated_at"),
+                  verification.globalExcludeColumns(),
+                  "globalExcludeColumns mismatch"),
+          () ->
+              assertEquals(
+                  RowOrdering.UNORDERED, verification.rowOrdering(), "rowOrdering mismatch"),
+          () -> assertEquals(3, verification.retryCount(), "retryCount mismatch"),
+          () ->
+              assertEquals(
+                  Duration.ofSeconds(2), verification.retryDelay(), "retryDelay mismatch"));
+    }
+
+    /** Verifies that custom execution properties are mapped to Configuration. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should map custom execution properties to Configuration")
+    void should_map_custom_execution_properties() {
+      // Given
+      properties.getExecution().setQueryTimeout(Duration.ofSeconds(30));
+      properties.getExecution().setTransactionMode(TransactionMode.AUTO_COMMIT);
+
+      // When
+      final var config = autoConfiguration.dbTesterConfiguration(properties);
+
+      // Then
+      final var execution = config.execution();
+      assertAll(
+          "execution properties should be mapped",
+          () ->
+              assertEquals(
+                  Duration.ofSeconds(30), execution.queryTimeout(), "queryTimeout mismatch"),
+          () ->
+              assertEquals(
+                  TransactionMode.AUTO_COMMIT,
+                  execution.transactionMode(),
+                  "transactionMode mismatch"));
+    }
+
+    /** Verifies that custom operation properties are mapped to Configuration. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should map custom operation properties to Configuration")
+    void should_map_custom_operation_properties() {
+      // Given
+      properties.getOperation().setPreparation(Operation.INSERT);
+      properties.getOperation().setExpectation(Operation.DELETE_ALL);
+
+      // When
+      final var config = autoConfiguration.dbTesterConfiguration(properties);
+
+      // Then
+      final var operations = config.operations();
+      assertAll(
+          "operation properties should be mapped",
+          () -> assertEquals(Operation.INSERT, operations.preparation(), "preparation mismatch"),
+          () ->
+              assertEquals(Operation.DELETE_ALL, operations.expectation(), "expectation mismatch"));
+    }
+
+    /** Verifies that default properties produce default Configuration values. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should produce default values for all Configuration sections")
+    void should_produce_default_values_for_all_sections() {
+      // Given - default properties
+
+      // When
+      final var config = autoConfiguration.dbTesterConfiguration(properties);
+
+      // Then
+      assertAll(
+          "default Configuration values should be correct",
+          () -> assertNull(config.conventions().baseDirectory(), "baseDirectory should be null"),
+          () ->
+              assertEquals(
+                  RowOrdering.ORDERED,
+                  config.verification().rowOrdering(),
+                  "rowOrdering should be ORDERED"),
+          () -> assertEquals(0, config.verification().retryCount(), "retryCount should be 0"),
+          () -> assertNull(config.execution().queryTimeout(), "queryTimeout should be null"),
+          () ->
+              assertEquals(
+                  TransactionMode.SINGLE_TRANSACTION,
+                  config.execution().transactionMode(),
+                  "transactionMode should be SINGLE_TRANSACTION"),
+          () ->
+              assertEquals(
+                  Operation.CLEAN_INSERT,
+                  config.operations().preparation(),
+                  "preparation should be CLEAN_INSERT"),
+          () ->
+              assertEquals(
+                  Operation.NONE, config.operations().expectation(), "expectation should be NONE"));
     }
   }
 

--- a/db-tester-junit-spring-boot-starter/src/test/java/io/github/seijikohara/dbtester/junit/spring/boot/autoconfigure/DbTesterPropertiesTest.java
+++ b/db-tester-junit-spring-boot-starter/src/test/java/io/github/seijikohara/dbtester/junit/spring/boot/autoconfigure/DbTesterPropertiesTest.java
@@ -9,8 +9,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.seijikohara.dbtester.api.config.ConventionSettings;
 import io.github.seijikohara.dbtester.api.config.DataFormat;
+import io.github.seijikohara.dbtester.api.config.RowOrdering;
 import io.github.seijikohara.dbtester.api.config.TableMergeStrategy;
+import io.github.seijikohara.dbtester.api.config.TransactionMode;
 import io.github.seijikohara.dbtester.api.operation.Operation;
+import java.time.Duration;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -340,6 +344,182 @@ class DbTesterPropertiesTest {
           Operation.TRUNCATE_INSERT,
           properties.getOperation().getPreparation(),
           "preparation mismatch");
+    }
+  }
+
+  /** Tests for the verification property. */
+  @Nested
+  @DisplayName("verification property")
+  class VerificationProperty {
+
+    /** Tests for the verification property. */
+    VerificationProperty() {}
+
+    /** Verifies that verification has correct default values. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should have correct default values")
+    void should_have_correct_default_values() {
+      // Given & When
+      final var verification = properties.getVerification();
+
+      // Then
+      assertAll(
+          "verification default values should be correct",
+          () -> assertNotNull(verification, "verification should not be null"),
+          () ->
+              assertTrue(
+                  verification.getGlobalExcludeColumns().isEmpty(),
+                  "globalExcludeColumns should default to empty"),
+          () ->
+              assertEquals(
+                  RowOrdering.ORDERED,
+                  verification.getRowOrdering(),
+                  "rowOrdering should default to ORDERED"),
+          () -> assertEquals(0, verification.getRetryCount(), "retryCount should default to 0"),
+          () ->
+              assertEquals(
+                  Duration.ofMillis(100),
+                  verification.getRetryDelay(),
+                  "retryDelay should default to 100ms"));
+    }
+
+    /** Verifies that verification properties can be modified. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should allow modifying verification properties")
+    void should_allow_modifying_verification_properties() {
+      // Given
+      final var verification = properties.getVerification();
+
+      // When
+      verification.setGlobalExcludeColumns(Set.of("created_at", "updated_at"));
+      verification.setRowOrdering(RowOrdering.UNORDERED);
+      verification.setRetryCount(3);
+      verification.setRetryDelay(Duration.ofSeconds(1));
+
+      // Then
+      assertAll(
+          "verification modified values should be correct",
+          () ->
+              assertEquals(
+                  Set.of("created_at", "updated_at"),
+                  verification.getGlobalExcludeColumns(),
+                  "globalExcludeColumns mismatch"),
+          () ->
+              assertEquals(
+                  RowOrdering.UNORDERED, verification.getRowOrdering(), "rowOrdering mismatch"),
+          () -> assertEquals(3, verification.getRetryCount(), "retryCount mismatch"),
+          () ->
+              assertEquals(
+                  Duration.ofSeconds(1), verification.getRetryDelay(), "retryDelay mismatch"));
+    }
+
+    /** Verifies that verification can be replaced. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should allow replacing verification")
+    void should_allow_replacing_verification() {
+      // Given
+      final var newVerification = new DbTesterProperties.VerificationProperties();
+      newVerification.setRowOrdering(RowOrdering.UNORDERED);
+      newVerification.setRetryCount(5);
+
+      // When
+      properties.setVerification(newVerification);
+
+      // Then
+      assertAll(
+          "replaced verification should be correct",
+          () ->
+              assertEquals(
+                  RowOrdering.UNORDERED,
+                  properties.getVerification().getRowOrdering(),
+                  "rowOrdering mismatch"),
+          () ->
+              assertEquals(5, properties.getVerification().getRetryCount(), "retryCount mismatch"));
+    }
+  }
+
+  /** Tests for the execution property. */
+  @Nested
+  @DisplayName("execution property")
+  class ExecutionProperty {
+
+    /** Tests for the execution property. */
+    ExecutionProperty() {}
+
+    /** Verifies that execution has correct default values. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should have correct default values")
+    void should_have_correct_default_values() {
+      // Given & When
+      final var execution = properties.getExecution();
+
+      // Then
+      assertAll(
+          "execution default values should be correct",
+          () -> assertNotNull(execution, "execution should not be null"),
+          () -> assertNull(execution.getQueryTimeout(), "queryTimeout should default to null"),
+          () ->
+              assertEquals(
+                  TransactionMode.SINGLE_TRANSACTION,
+                  execution.getTransactionMode(),
+                  "transactionMode should default to SINGLE_TRANSACTION"));
+    }
+
+    /** Verifies that execution properties can be modified. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should allow modifying execution properties")
+    void should_allow_modifying_execution_properties() {
+      // Given
+      final var execution = properties.getExecution();
+
+      // When
+      execution.setQueryTimeout(Duration.ofSeconds(30));
+      execution.setTransactionMode(TransactionMode.AUTO_COMMIT);
+
+      // Then
+      assertAll(
+          "execution modified values should be correct",
+          () ->
+              assertEquals(
+                  Duration.ofSeconds(30), execution.getQueryTimeout(), "queryTimeout mismatch"),
+          () ->
+              assertEquals(
+                  TransactionMode.AUTO_COMMIT,
+                  execution.getTransactionMode(),
+                  "transactionMode mismatch"));
+    }
+
+    /** Verifies that execution can be replaced. */
+    @Test
+    @Tag("normal")
+    @DisplayName("should allow replacing execution")
+    void should_allow_replacing_execution() {
+      // Given
+      final var newExecution = new DbTesterProperties.ExecutionProperties();
+      newExecution.setQueryTimeout(Duration.ofMinutes(1));
+      newExecution.setTransactionMode(TransactionMode.AUTO_COMMIT);
+
+      // When
+      properties.setExecution(newExecution);
+
+      // Then
+      assertAll(
+          "replaced execution should be correct",
+          () ->
+              assertEquals(
+                  Duration.ofMinutes(1),
+                  properties.getExecution().getQueryTimeout(),
+                  "queryTimeout mismatch"),
+          () ->
+              assertEquals(
+                  TransactionMode.AUTO_COMMIT,
+                  properties.getExecution().getTransactionMode(),
+                  "transactionMode mismatch"));
     }
   }
 }

--- a/db-tester-kotest-spring-boot-starter/src/test/kotlin/io/github/seijikohara/dbtester/kotest/spring/boot/autoconfigure/DbTesterKotestAutoConfigurationSpec.kt
+++ b/db-tester-kotest-spring-boot-starter/src/test/kotlin/io/github/seijikohara/dbtester/kotest/spring/boot/autoconfigure/DbTesterKotestAutoConfigurationSpec.kt
@@ -1,13 +1,19 @@
 package io.github.seijikohara.dbtester.kotest.spring.boot.autoconfigure
 
 import io.github.seijikohara.dbtester.api.config.Configuration
+import io.github.seijikohara.dbtester.api.config.DataFormat
 import io.github.seijikohara.dbtester.api.config.DataSourceRegistry
+import io.github.seijikohara.dbtester.api.config.RowOrdering
+import io.github.seijikohara.dbtester.api.config.TableMergeStrategy
+import io.github.seijikohara.dbtester.api.config.TransactionMode
+import io.github.seijikohara.dbtester.api.operation.Operation
 import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.mockk.every
 import io.mockk.mockk
 import org.springframework.beans.factory.ObjectProvider
+import java.time.Duration
 import java.util.stream.Stream
 import javax.sql.DataSource
 
@@ -131,4 +137,106 @@ class DbTesterKotestAutoConfigurationSpec : AnnotationSpec() {
                     }
                 }
             }
+
+    /** Verifies that the Configuration bean includes verification settings. */
+    @Test
+    fun `should create Configuration with verification settings`(): Unit =
+        autoConfiguration.dbTesterConfiguration(properties).let { configuration ->
+            configuration.verification() shouldNotBe null
+        }
+
+    /** Verifies that the Configuration bean includes execution settings. */
+    @Test
+    fun `should create Configuration with execution settings`(): Unit =
+        autoConfiguration.dbTesterConfiguration(properties).let { configuration ->
+            configuration.execution() shouldNotBe null
+        }
+
+    /** Verifies that custom convention properties are correctly mapped to Configuration. */
+    @Test
+    fun `should map custom convention properties to Configuration`(): Unit =
+        DbTesterProperties()
+            .also { customProperties ->
+                customProperties.convention.baseDirectory = "custom/path"
+                customProperties.convention.expectationSuffix = "-verify"
+                customProperties.convention.scenarioMarker = "[Test]"
+                customProperties.convention.dataFormat = DataFormat.TSV
+                customProperties.convention.tableMergeStrategy = TableMergeStrategy.FIRST
+                customProperties.convention.loadOrderFileName = "custom-order.txt"
+            }.let { customProperties ->
+                autoConfiguration.dbTesterConfiguration(customProperties).let { configuration ->
+                    configuration.conventions().baseDirectory() shouldBe "custom/path"
+                    configuration.conventions().expectationSuffix() shouldBe "-verify"
+                    configuration.conventions().scenarioMarker() shouldBe "[Test]"
+                    configuration.conventions().dataFormat() shouldBe DataFormat.TSV
+                    configuration.conventions().tableMergeStrategy() shouldBe TableMergeStrategy.FIRST
+                    configuration.conventions().loadOrderFileName() shouldBe "custom-order.txt"
+                }
+            }
+
+    /** Verifies that custom verification properties are correctly mapped to Configuration. */
+    @Test
+    fun `should map custom verification properties to Configuration`(): Unit =
+        DbTesterProperties()
+            .also { customProperties ->
+                customProperties.verification.globalExcludeColumns = setOf("created_at", "updated_at")
+                customProperties.verification.rowOrdering = RowOrdering.UNORDERED
+                customProperties.verification.retryCount = 3
+                customProperties.verification.retryDelay = Duration.ofSeconds(2)
+            }.let { customProperties ->
+                autoConfiguration.dbTesterConfiguration(customProperties).let { configuration ->
+                    configuration.verification().globalExcludeColumns() shouldBe setOf("created_at", "updated_at")
+                    configuration.verification().rowOrdering() shouldBe RowOrdering.UNORDERED
+                    configuration.verification().retryCount() shouldBe 3
+                    configuration.verification().retryDelay() shouldBe Duration.ofSeconds(2)
+                }
+            }
+
+    /** Verifies that custom execution properties are correctly mapped to Configuration. */
+    @Test
+    fun `should map custom execution properties to Configuration`(): Unit =
+        DbTesterProperties()
+            .also { customProperties ->
+                customProperties.execution.queryTimeout = Duration.ofSeconds(30)
+                customProperties.execution.transactionMode = TransactionMode.AUTO_COMMIT
+            }.let { customProperties ->
+                autoConfiguration.dbTesterConfiguration(customProperties).let { configuration ->
+                    configuration.execution().queryTimeout() shouldBe Duration.ofSeconds(30)
+                    configuration.execution().transactionMode() shouldBe TransactionMode.AUTO_COMMIT
+                }
+            }
+
+    /** Verifies that custom operation properties are correctly mapped to Configuration. */
+    @Test
+    fun `should map custom operation properties to Configuration`(): Unit =
+        DbTesterProperties()
+            .also { customProperties ->
+                customProperties.operation.preparation = Operation.INSERT
+                customProperties.operation.expectation = Operation.DELETE_ALL
+            }.let { customProperties ->
+                autoConfiguration.dbTesterConfiguration(customProperties).let { configuration ->
+                    configuration.operations().preparation() shouldBe Operation.INSERT
+                    configuration.operations().expectation() shouldBe Operation.DELETE_ALL
+                }
+            }
+
+    /** Verifies that default properties produce correct default values for all Configuration sections. */
+    @Test
+    fun `should produce default values for all Configuration sections`(): Unit =
+        autoConfiguration.dbTesterConfiguration(DbTesterProperties()).let { configuration ->
+            configuration.conventions() shouldNotBe null
+            configuration.conventions().baseDirectory() shouldBe null
+            configuration.conventions().dataFormat() shouldBe DataFormat.AUTO
+            configuration.verification() shouldNotBe null
+            configuration.verification().globalExcludeColumns() shouldBe emptySet()
+            configuration.verification().rowOrdering() shouldBe RowOrdering.ORDERED
+            configuration.verification().retryCount() shouldBe 0
+            configuration.verification().retryDelay() shouldBe Duration.ofMillis(100)
+            configuration.execution() shouldNotBe null
+            configuration.execution().queryTimeout() shouldBe null
+            configuration.execution().transactionMode() shouldBe TransactionMode.SINGLE_TRANSACTION
+            configuration.operations() shouldNotBe null
+            configuration.operations().preparation() shouldBe Operation.CLEAN_INSERT
+            configuration.operations().expectation() shouldBe Operation.NONE
+        }
 }

--- a/db-tester-kotest-spring-boot-starter/src/test/kotlin/io/github/seijikohara/dbtester/kotest/spring/boot/autoconfigure/DbTesterPropertiesSpec.kt
+++ b/db-tester-kotest-spring-boot-starter/src/test/kotlin/io/github/seijikohara/dbtester/kotest/spring/boot/autoconfigure/DbTesterPropertiesSpec.kt
@@ -2,11 +2,14 @@ package io.github.seijikohara.dbtester.kotest.spring.boot.autoconfigure
 
 import io.github.seijikohara.dbtester.api.config.ConventionSettings
 import io.github.seijikohara.dbtester.api.config.DataFormat
+import io.github.seijikohara.dbtester.api.config.RowOrdering
 import io.github.seijikohara.dbtester.api.config.TableMergeStrategy
+import io.github.seijikohara.dbtester.api.config.TransactionMode
 import io.github.seijikohara.dbtester.api.operation.Operation
 import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import java.time.Duration
 
 /**
  * Unit tests for [DbTesterProperties].
@@ -134,5 +137,79 @@ class DbTesterPropertiesSpec : AnnotationSpec() {
                 properties.operation = newOperation
                 properties.operation.preparation shouldBe Operation.DELETE_ALL
                 properties.operation.expectation shouldBe Operation.INSERT
+            }
+
+    /** Verifies that the verification property has correct default values. */
+    @Test
+    fun `should have verification property with defaults`(): Unit =
+        properties.verification.let { verification ->
+            verification shouldNotBe null
+            verification.globalExcludeColumns shouldBe emptySet()
+            verification.rowOrdering shouldBe RowOrdering.ORDERED
+            verification.retryCount shouldBe 0
+            verification.retryDelay shouldBe Duration.ofMillis(100)
+        }
+
+    /** Verifies that verification properties can be changed individually. */
+    @Test
+    fun `should allow changing verification properties`(): Unit =
+        properties.verification.let { verification ->
+            verification.globalExcludeColumns = setOf("created_at", "updated_at")
+            verification.rowOrdering = RowOrdering.UNORDERED
+            verification.retryCount = 3
+            verification.retryDelay = Duration.ofSeconds(1)
+
+            verification.globalExcludeColumns shouldBe setOf("created_at", "updated_at")
+            verification.rowOrdering shouldBe RowOrdering.UNORDERED
+            verification.retryCount shouldBe 3
+            verification.retryDelay shouldBe Duration.ofSeconds(1)
+        }
+
+    /** Verifies that the verification object can be replaced entirely. */
+    @Test
+    fun `should allow replacing verification object`(): Unit =
+        DbTesterProperties
+            .VerificationProperties()
+            .also { newVerification ->
+                newVerification.rowOrdering = RowOrdering.UNORDERED
+                newVerification.retryCount = 5
+            }.let { newVerification ->
+                properties.verification = newVerification
+                properties.verification.rowOrdering shouldBe RowOrdering.UNORDERED
+                properties.verification.retryCount shouldBe 5
+            }
+
+    /** Verifies that the execution property has correct default values. */
+    @Test
+    fun `should have execution property with defaults`(): Unit =
+        properties.execution.let { execution ->
+            execution shouldNotBe null
+            execution.queryTimeout shouldBe null
+            execution.transactionMode shouldBe TransactionMode.SINGLE_TRANSACTION
+        }
+
+    /** Verifies that execution properties can be changed individually. */
+    @Test
+    fun `should allow changing execution properties`(): Unit =
+        properties.execution.let { execution ->
+            execution.queryTimeout = Duration.ofSeconds(30)
+            execution.transactionMode = TransactionMode.AUTO_COMMIT
+
+            execution.queryTimeout shouldBe Duration.ofSeconds(30)
+            execution.transactionMode shouldBe TransactionMode.AUTO_COMMIT
+        }
+
+    /** Verifies that the execution object can be replaced entirely. */
+    @Test
+    fun `should allow replacing execution object`(): Unit =
+        DbTesterProperties
+            .ExecutionProperties()
+            .also { newExecution ->
+                newExecution.queryTimeout = Duration.ofSeconds(30)
+                newExecution.transactionMode = TransactionMode.AUTO_COMMIT
+            }.let { newExecution ->
+                properties.execution = newExecution
+                properties.execution.queryTimeout shouldBe Duration.ofSeconds(30)
+                properties.execution.transactionMode shouldBe TransactionMode.AUTO_COMMIT
             }
 }

--- a/db-tester-spock-spring-boot-starter/src/test/groovy/io/github/seijikohara/dbtester/spock/spring/boot/autoconfigure/DbTesterPropertiesSpec.groovy
+++ b/db-tester-spock-spring-boot-starter/src/test/groovy/io/github/seijikohara/dbtester/spock/spring/boot/autoconfigure/DbTesterPropertiesSpec.groovy
@@ -1,8 +1,11 @@
 package io.github.seijikohara.dbtester.spock.spring.boot.autoconfigure
 
 import io.github.seijikohara.dbtester.api.config.DataFormat
+import io.github.seijikohara.dbtester.api.config.RowOrdering
 import io.github.seijikohara.dbtester.api.config.TableMergeStrategy
+import io.github.seijikohara.dbtester.api.config.TransactionMode
 import io.github.seijikohara.dbtester.api.operation.Operation
+import java.time.Duration
 import spock.lang.Specification
 
 /**
@@ -162,5 +165,87 @@ class DbTesterPropertiesSpec extends Specification {
 
 		then: 'operation is replaced'
 		properties.operation.preparation == Operation.TRUNCATE_INSERT
+	}
+
+	/** Verifies that verification property has correct default values. */
+	def 'should have verification property with correct defaults'() {
+		expect: 'verification defaults are correct'
+		verifyAll {
+			properties.verification != null
+			properties.verification.globalExcludeColumns.isEmpty()
+			properties.verification.rowOrdering == RowOrdering.ORDERED
+			properties.verification.retryCount == 0
+			properties.verification.retryDelay == Duration.ofMillis(100)
+		}
+	}
+
+	/** Verifies that verification properties can be modified. */
+	def 'should allow modifying verification properties'() {
+		when: 'modifying verification properties'
+		properties.verification.globalExcludeColumns = ['created_at', 'updated_at'] as Set
+		properties.verification.rowOrdering = RowOrdering.UNORDERED
+		properties.verification.retryCount = 3
+		properties.verification.retryDelay = Duration.ofSeconds(1)
+
+		then: 'verification properties are modified'
+		verifyAll {
+			properties.verification.globalExcludeColumns == ['created_at', 'updated_at'] as Set
+			properties.verification.rowOrdering == RowOrdering.UNORDERED
+			properties.verification.retryCount == 3
+			properties.verification.retryDelay == Duration.ofSeconds(1)
+		}
+	}
+
+	/** Verifies that verification can be replaced with a new instance. */
+	def 'should allow replacing verification'() {
+		given: 'a new verification instance'
+		def newVerification = new DbTesterProperties.VerificationProperties()
+		newVerification.rowOrdering = RowOrdering.UNORDERED
+
+		when: 'replacing verification'
+		properties.verification = newVerification
+
+		then: 'verification is replaced'
+		properties.verification.rowOrdering == RowOrdering.UNORDERED
+	}
+
+	/** Verifies that execution property has correct default values. */
+	def 'should have execution property with correct defaults'() {
+		expect: 'execution defaults are correct'
+		verifyAll {
+			properties.execution != null
+			properties.execution.queryTimeout == null
+			properties.execution.transactionMode == TransactionMode.SINGLE_TRANSACTION
+		}
+	}
+
+	/** Verifies that execution properties can be modified. */
+	def 'should allow modifying execution properties'() {
+		when: 'modifying execution properties'
+		properties.execution.queryTimeout = Duration.ofSeconds(30)
+		properties.execution.transactionMode = TransactionMode.AUTO_COMMIT
+
+		then: 'execution properties are modified'
+		verifyAll {
+			properties.execution.queryTimeout == Duration.ofSeconds(30)
+			properties.execution.transactionMode == TransactionMode.AUTO_COMMIT
+		}
+	}
+
+	/** Verifies that execution can be replaced with a new instance. */
+	def 'should allow replacing execution'() {
+		given: 'a new execution instance'
+		def newExecution = new DbTesterProperties.ExecutionProperties()
+		newExecution.queryTimeout = Duration.ofMinutes(1)
+		newExecution.transactionMode = TransactionMode.AUTO_COMMIT
+
+		when: 'replacing execution'
+		properties.execution = newExecution
+
+		then: 'execution is replaced'
+		verifyAll {
+			properties.execution.queryTimeout == Duration.ofMinutes(1)
+			properties.execution.transactionMode == TransactionMode.AUTO_COMMIT
+		}
 	}
 }

--- a/db-tester-spock-spring-boot-starter/src/test/groovy/io/github/seijikohara/dbtester/spock/spring/boot/autoconfigure/DbTesterSpockAutoConfigurationSpec.groovy
+++ b/db-tester-spock-spring-boot-starter/src/test/groovy/io/github/seijikohara/dbtester/spock/spring/boot/autoconfigure/DbTesterSpockAutoConfigurationSpec.groovy
@@ -1,7 +1,13 @@
 package io.github.seijikohara.dbtester.spock.spring.boot.autoconfigure
 
 import io.github.seijikohara.dbtester.api.config.Configuration
+import io.github.seijikohara.dbtester.api.config.DataFormat
 import io.github.seijikohara.dbtester.api.config.DataSourceRegistry
+import io.github.seijikohara.dbtester.api.config.RowOrdering
+import io.github.seijikohara.dbtester.api.config.TableMergeStrategy
+import io.github.seijikohara.dbtester.api.config.TransactionMode
+import io.github.seijikohara.dbtester.api.operation.Operation
+import java.time.Duration
 import spock.lang.Specification
 
 /**
@@ -130,5 +136,120 @@ class DbTesterSpockAutoConfigurationSpec extends Specification {
 		config != null
 		registry != null
 		registrar != null
+	}
+
+	/** Verifies that Configuration has verification settings. */
+	def 'should return Configuration with verification settings'() {
+		when: 'getting dbTesterConfiguration'
+		def config = autoConfiguration.dbTesterConfiguration(properties)
+
+		then: 'configuration has verification'
+		config.verification() != null
+	}
+
+	/** Verifies that Configuration has execution settings. */
+	def 'should return Configuration with execution settings'() {
+		when: 'getting dbTesterConfiguration'
+		def config = autoConfiguration.dbTesterConfiguration(properties)
+
+		then: 'configuration has execution'
+		config.execution() != null
+	}
+
+	/** Verifies that custom convention properties are mapped to Configuration. */
+	def 'should map custom convention properties to Configuration'() {
+		given: 'custom convention properties'
+		properties.convention.baseDirectory = '/custom/base'
+		properties.convention.expectationSuffix = '/verify'
+		properties.convention.scenarioMarker = '[TestCase]'
+		properties.convention.dataFormat = DataFormat.TSV
+		properties.convention.tableMergeStrategy = TableMergeStrategy.FIRST
+		properties.convention.loadOrderFileName = 'custom-order.txt'
+
+		when: 'getting dbTesterConfiguration'
+		def config = autoConfiguration.dbTesterConfiguration(properties)
+
+		then: 'convention properties are mapped'
+		def conventions = config.conventions()
+		verifyAll {
+			conventions.baseDirectory() == '/custom/base'
+			conventions.expectationSuffix() == '/verify'
+			conventions.scenarioMarker() == '[TestCase]'
+			conventions.dataFormat() == DataFormat.TSV
+			conventions.tableMergeStrategy() == TableMergeStrategy.FIRST
+			conventions.loadOrderFileName() == 'custom-order.txt'
+		}
+	}
+
+	/** Verifies that custom verification properties are mapped to Configuration. */
+	def 'should map custom verification properties to Configuration'() {
+		given: 'custom verification properties'
+		properties.verification.globalExcludeColumns = ['created_at', 'updated_at'] as Set
+		properties.verification.rowOrdering = RowOrdering.UNORDERED
+		properties.verification.retryCount = 3
+		properties.verification.retryDelay = Duration.ofSeconds(2)
+
+		when: 'getting dbTesterConfiguration'
+		def config = autoConfiguration.dbTesterConfiguration(properties)
+
+		then: 'verification properties are mapped'
+		def verification = config.verification()
+		verifyAll {
+			verification.globalExcludeColumns() == ['created_at', 'updated_at'] as Set
+			verification.rowOrdering() == RowOrdering.UNORDERED
+			verification.retryCount() == 3
+			verification.retryDelay() == Duration.ofSeconds(2)
+		}
+	}
+
+	/** Verifies that custom execution properties are mapped to Configuration. */
+	def 'should map custom execution properties to Configuration'() {
+		given: 'custom execution properties'
+		properties.execution.queryTimeout = Duration.ofSeconds(30)
+		properties.execution.transactionMode = TransactionMode.AUTO_COMMIT
+
+		when: 'getting dbTesterConfiguration'
+		def config = autoConfiguration.dbTesterConfiguration(properties)
+
+		then: 'execution properties are mapped'
+		def execution = config.execution()
+		verifyAll {
+			execution.queryTimeout() == Duration.ofSeconds(30)
+			execution.transactionMode() == TransactionMode.AUTO_COMMIT
+		}
+	}
+
+	/** Verifies that custom operation properties are mapped to Configuration. */
+	def 'should map custom operation properties to Configuration'() {
+		given: 'custom operation properties'
+		properties.operation.preparation = Operation.INSERT
+		properties.operation.expectation = Operation.DELETE_ALL
+
+		when: 'getting dbTesterConfiguration'
+		def config = autoConfiguration.dbTesterConfiguration(properties)
+
+		then: 'operation properties are mapped'
+		def operations = config.operations()
+		verifyAll {
+			operations.preparation() == Operation.INSERT
+			operations.expectation() == Operation.DELETE_ALL
+		}
+	}
+
+	/** Verifies that default properties produce default Configuration values. */
+	def 'should produce default values for all Configuration sections'() {
+		when: 'getting dbTesterConfiguration with default properties'
+		def config = autoConfiguration.dbTesterConfiguration(properties)
+
+		then: 'all default values are correct'
+		verifyAll {
+			config.conventions().baseDirectory() == null
+			config.verification().rowOrdering() == RowOrdering.ORDERED
+			config.verification().retryCount() == 0
+			config.execution().queryTimeout() == null
+			config.execution().transactionMode() == TransactionMode.SINGLE_TRANSACTION
+			config.operations().preparation() == Operation.CLEAN_INSERT
+			config.operations().expectation() == Operation.NONE
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add verification and execution property tests to all three Spring Boot starters (JUnit, Spock, Kotest)
- Add tests verifying custom property values are correctly mapped through auto-configuration to Configuration
- Add tests for default Configuration values across all sections (conventions, verification, execution, operations)

## Test plan
- [x] JUnit starter: `DbTesterPropertiesTest` — verification property defaults, modification, replacement; execution property defaults, modification, replacement
- [x] JUnit starter: `DbTesterJUnitAutoConfigurationTest` — custom convention/verification/execution/operation property mapping; default values for all sections; verification/execution/loader presence
- [x] Spock starter: `DbTesterPropertiesSpec` — verification and execution property tests (6 new tests)
- [x] Spock starter: `DbTesterSpockAutoConfigurationSpec` — custom property mapping and default verification (7 new tests)
- [x] Kotest starter: `DbTesterPropertiesSpec` — verification and execution property tests (6 new tests)
- [x] Kotest starter: `DbTesterKotestAutoConfigurationSpec` — custom property mapping and default verification (7 new tests)
- [x] All 3 starter builds pass

Closes #180