### PR TITLE
fix(ci): correct Codecov path fixes and badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DB Tester
 
 [![Test](https://github.com/seijikohara/db-tester/actions/workflows/test.yml/badge.svg)](https://github.com/seijikohara/db-tester/actions/workflows/test.yml)
-[![codecov](https://codecov.io/gh/seijikohara/db-tester/graph/badge.svg)](https://codecov.io/gh/seijikohara)
+[![codecov](https://codecov.io/gh/seijikohara/db-tester/graph/badge.svg)](https://codecov.io/gh/seijikohara/db-tester)
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.seijikohara/db-tester-bom.svg)](https://search.maven.org/artifact/io.github.seijikohara/db-tester-bom)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Docs](https://img.shields.io/badge/Docs-VitePress-646cff.svg)](https://seijikohara.github.io/db-tester/)

--- a/codecov.yml
+++ b/codecov.yml
@@ -16,12 +16,13 @@ coverage:
 fixes:
   - "io/github/seijikohara/dbtester/api/::db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/"
   - "io/github/seijikohara/dbtester/internal/::db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/"
+  - "io/github/seijikohara/dbtester/spring/support/::db-tester-spring-support/src/main/java/io/github/seijikohara/dbtester/spring/support/"
+  - "io/github/seijikohara/dbtester/junit/spring/boot/autoconfigure/::db-tester-junit-spring-boot-starter/src/main/java/io/github/seijikohara/dbtester/junit/spring/boot/autoconfigure/"
   - "io/github/seijikohara/dbtester/junit/::db-tester-junit/src/main/java/io/github/seijikohara/dbtester/junit/"
+  - "io/github/seijikohara/dbtester/spock/spring/boot/autoconfigure/::db-tester-spock-spring-boot-starter/src/main/groovy/io/github/seijikohara/dbtester/spock/spring/boot/autoconfigure/"
   - "io/github/seijikohara/dbtester/spock/::db-tester-spock/src/main/groovy/io/github/seijikohara/dbtester/spock/"
+  - "io/github/seijikohara/dbtester/kotest/spring/boot/autoconfigure/::db-tester-kotest-spring-boot-starter/src/main/kotlin/io/github/seijikohara/dbtester/kotest/spring/boot/autoconfigure/"
   - "io/github/seijikohara/dbtester/kotest/::db-tester-kotest/src/main/kotlin/io/github/seijikohara/dbtester/kotest/"
-  - "io/github/seijikohara/dbtester/spring/autoconfigure/junit/::db-tester-junit-spring-boot-starter/src/main/java/io/github/seijikohara/dbtester/spring/autoconfigure/junit/"
-  - "io/github/seijikohara/dbtester/spring/autoconfigure/spock/::db-tester-spock-spring-boot-starter/src/main/groovy/io/github/seijikohara/dbtester/spring/autoconfigure/spock/"
-  - "io/github/seijikohara/dbtester/spring/autoconfigure/kotest/::db-tester-kotest-spring-boot-starter/src/main/kotlin/io/github/seijikohara/dbtester/spring/autoconfigure/kotest/"
 
 # Ignore example modules from coverage
 ignore:


### PR DESCRIPTION
## Summary
- Fix `codecov.yml` path fixes to match actual package structure (spring-boot-starter modules had incorrect paths, spring-support module was missing)
- Order specific paths before general paths to prevent prefix mismatch
- Fix Codecov badge link in `README.md` to include repository name

## Test plan
- [ ] CI passes
- [ ] Codecov receives coverage data and shows non-zero coverage