### PR TITLE
ci(deps): keep tag-style references for GitHub Actions in Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,7 +9,6 @@
     ":enableVulnerabilityAlertsWithLabel(security)",
     "group:monorepos",
     "group:recommended",
-    "helpers:pinGitHubActionDigests",
   ],
 
   timezone: "Asia/Tokyo",
@@ -39,6 +38,8 @@
     {
       matchManagers: ["github-actions"],
       labels: ["dependencies", "github-actions"],
+      // Keep tag-style references (e.g. `@v4`) instead of pinning to commit SHAs.
+      pinDigests: false,
     },
     {
       matchManagers: ["gradle", "gradle-wrapper"],


### PR DESCRIPTION
## Summary

- Drop the `helpers:pinGitHubActionDigests` preset that rewrites action references from `@v4`-style tags to commit SHAs.
- Set `pinDigests: false` for the `github-actions` manager to make the intent explicit and resilient to upstream preset changes.

## Why

The previous Dependabot setup and the existing workflows use tag-style references (e.g. `actions/checkout@v6`). Pinning to SHAs changes the diff style and makes workflow files harder to read. Maintain the existing convention.

## Test plan

- [ ] After merge, confirm the next Renovate update PR for any GitHub Action keeps the `@vN` style instead of switching to a SHA.