### PR TITLE
fix(core): read query results by column label to honor SQL aliases

### DIFF
--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/jdbc/read/TableReader.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/jdbc/read/TableReader.java
@@ -195,10 +195,14 @@ public final class TableReader {
                 .mapToObj(
                     i -> {
                       try {
-                        return new ColumnName(metaData.getColumnName(i));
+                        // Use the column label so SQL aliases (SELECT col AS alias) and computed
+                        // columns (SELECT SUM(x) AS total) match the expected dataset. For a plain
+                        // SELECT * the label defaults to the physical column name, so full-table
+                        // reads keep their previous behavior.
+                        return new ColumnName(metaData.getColumnLabel(i));
                       } catch (final SQLException e) {
                         throw new DatabaseTesterException(
-                            String.format("Failed to retrieve column name at index: %d", i), e);
+                            String.format("Failed to retrieve column label at index: %d", i), e);
                       }
                     })
                 .toList();

--- a/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/jdbc/read/TableReaderTest.java
+++ b/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/jdbc/read/TableReaderTest.java
@@ -133,8 +133,8 @@ class TableReaderTest {
     void shouldReturnTableWithData_whenRowsExist() throws SQLException {
       // Given
       when(metaData.getColumnCount()).thenReturn(2);
-      when(metaData.getColumnName(1)).thenReturn("ID");
-      when(metaData.getColumnName(2)).thenReturn("NAME");
+      when(metaData.getColumnLabel(1)).thenReturn("ID");
+      when(metaData.getColumnLabel(2)).thenReturn("NAME");
       when(resultSet.next()).thenReturn(true, false);
       when(resultSet.getObject(1)).thenReturn(1);
       when(resultSet.getObject(2)).thenReturn("John");
@@ -164,8 +164,8 @@ class TableReaderTest {
     void shouldReturnEmptyTable_whenNoRowsExist() throws SQLException {
       // Given
       when(metaData.getColumnCount()).thenReturn(2);
-      when(metaData.getColumnName(1)).thenReturn("ID");
-      when(metaData.getColumnName(2)).thenReturn("NAME");
+      when(metaData.getColumnLabel(1)).thenReturn("ID");
+      when(metaData.getColumnLabel(2)).thenReturn("NAME");
       when(resultSet.next()).thenReturn(false);
 
       // When
@@ -191,8 +191,8 @@ class TableReaderTest {
     void shouldHandleNullValues_whenColumnValueIsNull() throws SQLException {
       // Given
       when(metaData.getColumnCount()).thenReturn(2);
-      when(metaData.getColumnName(1)).thenReturn("ID");
-      when(metaData.getColumnName(2)).thenReturn("NAME");
+      when(metaData.getColumnLabel(1)).thenReturn("ID");
+      when(metaData.getColumnLabel(2)).thenReturn("NAME");
       when(resultSet.next()).thenReturn(true, false);
       when(resultSet.getObject(1)).thenReturn(1);
       when(resultSet.getObject(2)).thenReturn(null);
@@ -255,7 +255,7 @@ class TableReaderTest {
     void shouldUseCorrectSql_whenFetchingTable() throws SQLException {
       // Given
       when(metaData.getColumnCount()).thenReturn(1);
-      when(metaData.getColumnName(1)).thenReturn("ID");
+      when(metaData.getColumnLabel(1)).thenReturn("ID");
       when(resultSet.next()).thenReturn(false);
 
       // When
@@ -285,8 +285,8 @@ class TableReaderTest {
     void shouldUseCorrectSql_whenColumnsSpecified() throws SQLException {
       // Given
       when(metaData.getColumnCount()).thenReturn(2);
-      when(metaData.getColumnName(1)).thenReturn("ID");
-      when(metaData.getColumnName(2)).thenReturn("NAME");
+      when(metaData.getColumnLabel(1)).thenReturn("ID");
+      when(metaData.getColumnLabel(2)).thenReturn("NAME");
       when(resultSet.next()).thenReturn(false);
 
       final var columns = List.of(new ColumnName("ID"), new ColumnName("NAME"));
@@ -309,7 +309,7 @@ class TableReaderTest {
     void shouldUseSelectAll_whenColumnsEmpty() throws SQLException {
       // Given
       when(metaData.getColumnCount()).thenReturn(1);
-      when(metaData.getColumnName(1)).thenReturn("ID");
+      when(metaData.getColumnLabel(1)).thenReturn("ID");
       when(resultSet.next()).thenReturn(false);
 
       // When
@@ -339,7 +339,7 @@ class TableReaderTest {
     void shouldReturnDataSet_whenMultipleTablesProvided() throws SQLException {
       // Given
       when(metaData.getColumnCount()).thenReturn(1);
-      when(metaData.getColumnName(1)).thenReturn("ID");
+      when(metaData.getColumnLabel(1)).thenReturn("ID");
       when(resultSet.next()).thenReturn(false);
 
       // When
@@ -375,7 +375,7 @@ class TableReaderTest {
     void shouldHandleMultipleRows_whenResultSetHasMultipleRows() throws SQLException {
       // Given
       when(metaData.getColumnCount()).thenReturn(1);
-      when(metaData.getColumnName(1)).thenReturn("ID");
+      when(metaData.getColumnLabel(1)).thenReturn("ID");
       when(resultSet.next()).thenReturn(true, true, true, false);
       when(resultSet.getObject(1)).thenReturn(1, 2, 3);
       when(typeConverter.convert(1)).thenReturn(1);
@@ -390,17 +390,17 @@ class TableReaderTest {
     }
 
     /**
-     * Verifies that executeQuery throws exception on column name retrieval failure.
+     * Verifies that executeQuery throws exception on column label retrieval failure.
      *
      * @throws SQLException if a database error occurs
      */
     @Test
     @Tag("error")
-    @DisplayName("should throw exception when column name retrieval fails")
-    void shouldThrowException_whenColumnNameRetrievalFails() throws SQLException {
+    @DisplayName("should throw exception when column label retrieval fails")
+    void shouldThrowException_whenColumnLabelRetrievalFails() throws SQLException {
       // Given
       when(metaData.getColumnCount()).thenReturn(1);
-      when(metaData.getColumnName(1)).thenThrow(new SQLException("Column name error"));
+      when(metaData.getColumnLabel(1)).thenThrow(new SQLException("Column label error"));
 
       // When & Then
       final var exception =
@@ -410,12 +410,12 @@ class TableReaderTest {
               "should throw DatabaseTesterException");
       final var message = exception.getMessage();
       assertAll(
-          "column name retrieval exception",
+          "column label retrieval exception",
           () -> assertNotNull(message, "exception message should not be null"),
           () ->
               assertTrue(
-                  message != null && message.contains("Failed to retrieve column name"),
-                  "exception message should indicate column name failure"));
+                  message != null && message.contains("Failed to retrieve column label"),
+                  "exception message should indicate column label failure"));
     }
 
     /**
@@ -429,7 +429,7 @@ class TableReaderTest {
     void shouldThrowException_whenColumnReadFails() throws SQLException {
       // Given
       when(metaData.getColumnCount()).thenReturn(1);
-      when(metaData.getColumnName(1)).thenReturn("ID");
+      when(metaData.getColumnLabel(1)).thenReturn("ID");
       when(resultSet.next()).thenReturn(true);
       when(resultSet.getObject(1)).thenThrow(new SQLException("Read error"));
 
@@ -460,7 +460,7 @@ class TableReaderTest {
     void shouldConvertLobValues_whenLobColumnExists() throws SQLException {
       // Given
       when(metaData.getColumnCount()).thenReturn(1);
-      when(metaData.getColumnName(1)).thenReturn("DATA");
+      when(metaData.getColumnLabel(1)).thenReturn("DATA");
       when(resultSet.next()).thenReturn(true, false);
       final var mockBlob = new byte[] {1, 2, 3};
       when(resultSet.getObject(1)).thenReturn(mockBlob);
@@ -597,7 +597,7 @@ class TableReaderTest {
     void shouldThrowException_whenResultSetNextFails() throws SQLException {
       // Given
       when(metaData.getColumnCount()).thenReturn(1);
-      when(metaData.getColumnName(1)).thenReturn("ID");
+      when(metaData.getColumnLabel(1)).thenReturn("ID");
       when(resultSet.next()).thenThrow(new SQLException("Cursor error"));
 
       // When & Then

--- a/examples/db-tester-example-junit/src/test/java/example/feature/CustomQueryValidationTest.java
+++ b/examples/db-tester-example-junit/src/test/java/example/feature/CustomQueryValidationTest.java
@@ -223,14 +223,13 @@ final class CustomQueryValidationTest {
         VALUES (4, 1, '2024-01-25', 500.00, 'West')
         """);
 
-    // Note: TableReader currently uses ResultSetMetaData#getColumnName, which returns the
-    // original column name for plain columns and ignores SQL aliases like `AS CATEGORY_ID`.
-    // Aggregate expressions still resolve to their alias, so plain columns are projected
-    // without an alias here. See follow-up task on switching TableReader to getColumnLabel.
+    // The expected column names use the SQL aliases, including the alias on the plain COLUMN1
+    // reference. TableReader reads column labels, so an alias on any projected column resolves to
+    // that alias in the result.
     final var expected =
         createTable(
             "CATEGORY_TOTALS",
-            List.of("COLUMN1", "TOTAL_AMOUNT", "RECORD_COUNT"),
+            List.of("CATEGORY_ID", "TOTAL_AMOUNT", "RECORD_COUNT"),
             List.of(
                 List.of(1, new BigDecimal("1700.00"), 3L),
                 List.of(2, new BigDecimal("300.00"), 1L)));
@@ -240,7 +239,7 @@ final class CustomQueryValidationTest {
         expected,
         dataSource,
         "CATEGORY_TOTALS",
-        "SELECT COLUMN1,"
+        "SELECT COLUMN1 AS CATEGORY_ID,"
             + " SUM(COLUMN3) AS TOTAL_AMOUNT,"
             + " COUNT(*) AS RECORD_COUNT"
             + " FROM TABLE1 GROUP BY COLUMN1 ORDER BY COLUMN1");
@@ -267,13 +266,13 @@ final class CustomQueryValidationTest {
         VALUES (4, 1, '2024-02-01', 600.00, 'North')
         """);
 
-    // Note: TableReader currently uses ResultSetMetaData#getColumnName, which returns the
-    // original column name and ignores SQL aliases. The columns are projected without aliases
-    // so the expected column names mirror the underlying table columns.
+    // The expected column names use the SQL aliases applied to the joined columns. TableReader
+    // reads column labels, so CATEGORY_NAME and SALE_AMOUNT resolve to the aliases rather than the
+    // underlying table column names.
     final var expected =
         createTable(
             "SALES_WITH_CATEGORY",
-            List.of("ID", "NAME", "COLUMN3"),
+            List.of("ID", "CATEGORY_NAME", "SALE_AMOUNT"),
             List.of(
                 List.of(1, "Premium", new BigDecimal("500.00")),
                 List.of(2, "Standard", new BigDecimal("300.00")),
@@ -285,7 +284,7 @@ final class CustomQueryValidationTest {
         expected,
         dataSource,
         "SALES_WITH_CATEGORY",
-        "SELECT s.ID, c.NAME, s.COLUMN3"
+        "SELECT s.ID, c.NAME AS CATEGORY_NAME, s.COLUMN3 AS SALE_AMOUNT"
             + " FROM TABLE1 s INNER JOIN CATEGORIES c ON s.COLUMN1 = c.ID"
             + " ORDER BY s.ID");
     logger.info("INNER JOIN query validation completed");

--- a/examples/db-tester-example-kotest/src/test/kotlin/example/feature/CustomQueryValidationSpec.kt
+++ b/examples/db-tester-example-kotest/src/test/kotlin/example/feature/CustomQueryValidationSpec.kt
@@ -154,9 +154,9 @@ class CustomQueryValidationSpec :
     /**
      * Verifies that a GROUP BY aggregation returns the expected per-category totals.
      *
-     * TableReader currently uses ResultSetMetaData#getColumnName, which ignores SQL aliases on
-     * plain column references. Plain columns are projected without an alias so the expected
-     * column name matches the underlying table column.
+     * The expected column names use the SQL aliases, including the alias on the plain COLUMN1
+     * reference. TableReader reads column labels, so an alias on any projected column resolves to
+     * that alias in the result.
      */
     @Test
     @DataSet
@@ -170,7 +170,7 @@ class CustomQueryValidationSpec :
         val expected =
             createTable(
                 "CATEGORY_TOTALS",
-                listOf("COLUMN1", "TOTAL_AMOUNT", "RECORD_COUNT"),
+                listOf("CATEGORY_ID", "TOTAL_AMOUNT", "RECORD_COUNT"),
                 listOf(
                     listOf(1, BigDecimal("1700.00"), 3L),
                     listOf(2, BigDecimal("300.00"), 1L),
@@ -181,7 +181,7 @@ class CustomQueryValidationSpec :
             expected,
             dataSource,
             "CATEGORY_TOTALS",
-            "SELECT COLUMN1, SUM(COLUMN3) AS TOTAL_AMOUNT, COUNT(*) AS RECORD_COUNT" +
+            "SELECT COLUMN1 AS CATEGORY_ID, SUM(COLUMN3) AS TOTAL_AMOUNT, COUNT(*) AS RECORD_COUNT" +
                 " FROM TABLE1 GROUP BY COLUMN1 ORDER BY COLUMN1",
         )
     }
@@ -189,9 +189,9 @@ class CustomQueryValidationSpec :
     /**
      * Verifies that an INNER JOIN between sales and categories returns labeled rows.
      *
-     * TableReader currently uses ResultSetMetaData#getColumnName, which ignores SQL aliases on
-     * plain column references. Columns are projected without aliases so the expected column
-     * names mirror the underlying table columns.
+     * The expected column names use the SQL aliases applied to the joined columns. TableReader
+     * reads column labels, so CATEGORY_NAME and SALE_AMOUNT resolve to the aliases rather than the
+     * underlying table column names.
      */
     @Test
     @DataSet
@@ -205,7 +205,7 @@ class CustomQueryValidationSpec :
         val expected =
             createTable(
                 "SALES_WITH_CATEGORY",
-                listOf("ID", "NAME", "COLUMN3"),
+                listOf("ID", "CATEGORY_NAME", "SALE_AMOUNT"),
                 listOf(
                     listOf(1, "Premium", BigDecimal("500.00")),
                     listOf(2, "Standard", BigDecimal("300.00")),
@@ -218,7 +218,7 @@ class CustomQueryValidationSpec :
             expected,
             dataSource,
             "SALES_WITH_CATEGORY",
-            "SELECT s.ID, c.NAME, s.COLUMN3" +
+            "SELECT s.ID, c.NAME AS CATEGORY_NAME, s.COLUMN3 AS SALE_AMOUNT" +
                 " FROM TABLE1 s INNER JOIN CATEGORIES c ON s.COLUMN1 = c.ID" +
                 " ORDER BY s.ID",
         )

--- a/examples/db-tester-example-spock/src/test/groovy/example/feature/CustomQueryValidationSpec.groovy
+++ b/examples/db-tester-example-spock/src/test/groovy/example/feature/CustomQueryValidationSpec.groovy
@@ -149,12 +149,12 @@ class CustomQueryValidationSpec extends Specification implements DatabaseTestSup
 			VALUES (4, 1, '2024-01-25', 500.00, 'West')
 		''')
 
-		// Note: TableReader currently uses ResultSetMetaData#getColumnName, which ignores SQL
-		// aliases on plain column references. Plain columns are projected without an alias here
-		// so the expected column name matches the underlying table column.
+		// The expected column names use the SQL aliases, including the alias on the plain COLUMN1
+		// reference. TableReader reads column labels, so an alias on any projected column resolves
+		// to that alias in the result.
 		and: 'expected aggregates summarize per-category total and record count'
 		def expected = createTable('CATEGORY_TOTALS',
-				['COLUMN1', 'TOTAL_AMOUNT', 'RECORD_COUNT'],
+				['CATEGORY_ID', 'TOTAL_AMOUNT', 'RECORD_COUNT'],
 				[
 					[1, new BigDecimal('1700.00'), 3L],
 					[2, new BigDecimal('300.00'), 1L]
@@ -165,7 +165,7 @@ class CustomQueryValidationSpec extends Specification implements DatabaseTestSup
 				expected,
 				dataSource,
 				'CATEGORY_TOTALS',
-				'SELECT COLUMN1, SUM(COLUMN3) AS TOTAL_AMOUNT, COUNT(*) AS RECORD_COUNT' +
+				'SELECT COLUMN1 AS CATEGORY_ID, SUM(COLUMN3) AS TOTAL_AMOUNT, COUNT(*) AS RECORD_COUNT' +
 				' FROM TABLE1 GROUP BY COLUMN1 ORDER BY COLUMN1')
 	}
 
@@ -177,12 +177,12 @@ class CustomQueryValidationSpec extends Specification implements DatabaseTestSup
 			VALUES (4, 1, '2024-02-01', 600.00, 'North')
 		''')
 
-		// Note: TableReader currently uses ResultSetMetaData#getColumnName, which ignores SQL
-		// aliases on plain column references. Columns are projected without aliases so the
-		// expected column names mirror the underlying table columns.
+		// The expected column names use the SQL aliases applied to the joined columns. TableReader
+		// reads column labels, so CATEGORY_NAME and SALE_AMOUNT resolve to the aliases rather than
+		// the underlying table column names.
 		and: 'expected rows pair each sale with the category name'
 		def expected = createTable('SALES_WITH_CATEGORY',
-				['ID', 'NAME', 'COLUMN3'],
+				['ID', 'CATEGORY_NAME', 'SALE_AMOUNT'],
 				[
 					[1, 'Premium', new BigDecimal('500.00')],
 					[2, 'Standard', new BigDecimal('300.00')],
@@ -195,7 +195,7 @@ class CustomQueryValidationSpec extends Specification implements DatabaseTestSup
 				expected,
 				dataSource,
 				'SALES_WITH_CATEGORY',
-				'SELECT s.ID, c.NAME, s.COLUMN3' +
+				'SELECT s.ID, c.NAME AS CATEGORY_NAME, s.COLUMN3 AS SALE_AMOUNT' +
 				' FROM TABLE1 s INNER JOIN CATEGORIES c ON s.COLUMN1 = c.ID' +
 				' ORDER BY s.ID')
 	}


### PR DESCRIPTION
## Summary

`TableReader` read result-set column names through `ResultSetMetaData.getColumnName`, which returns the underlying physical column name and ignores SQL aliases. A query such as `SELECT col AS alias` or `SELECT SUM(x) AS total` could not be validated through `DatabaseQueryAssertion.assertEqualsByQuery`, because the expected dataset had no way to name the projected column. This is a bug: when an alias appears in the query, the expected dataset should match on that alias.

## Fix

Read column labels through `ResultSetMetaData.getColumnLabel`. The JDBC contract defines the label as the alias when one is present, and the physical column name otherwise. A plain `SELECT *` therefore keeps its previous behavior, so full-table reads (used by `@ExpectedDataSet`) are unaffected.

The change is one call site in `TableReader`; it is the only place that read column metadata for query results.

## Tests

- Update `TableReaderTest` mocks to stub `getColumnLabel`, and rename the metadata-failure test accordingly.
- Update the `CustomQueryValidation` integration tests for JUnit, Spock, and Kotest to name projected columns by their aliases (`CATEGORY_ID`, `CATEGORY_NAME`, `SALE_AMOUNT`). These tests previously projected columns without aliases to work around the bug; the work-around comments are removed. The tests now both demonstrate and guard the fix.

## Compatibility

Backward compatible. `getColumnLabel` falls back to the column name when no alias is present, so existing alias-free queries and full-table reads return identical results.

## Verification

- `db-tester-core` builds green (tests, Checkstyle, Error Prone, NullAway).
- The `CustomQueryValidation` integration tests pass on all three frameworks (H2 only).