### PR TITLE
ci(deps): complete Renovate migration and enable transitive remediation

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,6 +23,10 @@
   // Use platform-native auto-merge so branch protection and required checks are honored.
   platformAutomerge: true,
 
+  // Remediate transitive (indirect) dependency vulnerabilities via lockfile updates,
+  // preserving the coverage previously provided by Dependabot security updates (now disabled).
+  transitiveRemediation: true,
+
   packageRules: [
     {
       // Auto-merge low-risk updates. Major updates require manual review.


### PR DESCRIPTION
## Summary

Complete the Dependabot → Renovate migration. The migration commit (`52a4c8e`) removed `.github/dependabot.yml` (Dependabot version updates) but did not disable **Dependabot security updates**, which run from a repository Settings toggle independent of the config file. As a result Dependabot kept opening security PRs that duplicated Renovate's vulnerability handling — e.g. mermaid 11.15.0 appeared as both Dependabot #291 and Renovate #292 (the latter merged, marked `[security]`).

## Actions taken (outside this PR)

- Disabled **Dependabot security updates** (`automated-security-fixes`); **Dependabot alerts** remain enabled so Renovate can read them via its `vulnerabilityAlerts` integration.
- Closed the stale Dependabot PRs #291, #299, #300, #301 and deleted their branches.

## This PR

Enables `transitiveRemediation` in `renovate.json5`. Dependabot security updates remediated **transitive (indirect)** npm vulnerabilities via lockfile updates; Renovate does not do this by default. This setting preserves that coverage so indirect npm vulnerabilities are still fixed automatically.

## Result

Renovate is now the sole dependency-update tool, covering Gradle, GitHub Actions, and npm version updates plus direct and transitive vulnerability remediation. Dependabot alerts feed Renovate; Dependabot no longer opens PRs.
