### PR TITLE
refactor(api)!: collapse SPI telescoping overloads to canonical methods

### DIFF
--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/config/ExpectationContext.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/config/ExpectationContext.java
@@ -79,32 +79,6 @@ public record ExpectationContext(
    * Creates a new ExpectationContext from the provided parameters.
    *
    * <p>This factory method accepts {@link Collection} for exclude columns and converts it to an
-   * immutable {@link Set} internally. The table ordering strategy defaults to {@link
-   * TableOrderingStrategy#AUTO}.
-   *
-   * @param excludeColumns column names to exclude from comparison
-   * @param columnStrategies column comparison strategies keyed by uppercase column name
-   * @param rowOrdering the row comparison strategy
-   * @param operationDefaults the operation defaults containing comparison settings
-   * @return a new ExpectationContext
-   */
-  public static ExpectationContext of(
-      final Collection<String> excludeColumns,
-      final Map<String, ColumnStrategyMapping> columnStrategies,
-      final RowOrdering rowOrdering,
-      final OperationDefaults operationDefaults) {
-    return new ExpectationContext(
-        Set.copyOf(excludeColumns),
-        columnStrategies,
-        rowOrdering,
-        operationDefaults,
-        TableOrderingStrategy.AUTO);
-  }
-
-  /**
-   * Creates a new ExpectationContext from the provided parameters.
-   *
-   * <p>This factory method accepts {@link Collection} for exclude columns and converts it to an
    * immutable {@link Set} internally.
    *
    * @param excludeColumns column names to exclude from comparison

--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/spi/ExpectationProvider.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/spi/ExpectationProvider.java
@@ -1,11 +1,8 @@
 package io.github.seijikohara.dbtester.api.spi;
 
 import io.github.seijikohara.dbtester.api.config.ExpectationContext;
-import io.github.seijikohara.dbtester.api.config.OperationDefaults;
-import io.github.seijikohara.dbtester.api.config.RowOrdering;
 import io.github.seijikohara.dbtester.api.dataset.TableSet;
 import javax.sql.DataSource;
-import org.slf4j.LoggerFactory;
 
 /**
  * Service Provider Interface for verifying database state against expected datasets.
@@ -34,77 +31,21 @@ import org.slf4j.LoggerFactory;
 public interface ExpectationProvider {
 
   /**
-   * Logs a warning message about unsupported features.
-   *
-   * @param message the warning message to log
-   * @param args the message arguments
-   */
-  private static void logWarning(final String message, final Object... args) {
-    LoggerFactory.getLogger(ExpectationProvider.class).warn(message, args);
-  }
-
-  /**
-   * Verifies that the database state matches the expected dataset.
+   * Verifies that the database state matches the expected dataset using the specified context.
    *
    * <p>For each table in the expected dataset, fetches actual data from the database and compares
    * it with the expected data. Only columns present in the expected table are included in the
-   * comparison.
-   *
-   * @param expectedTableSet the expected dataset containing expected table data
-   * @param dataSource the database connection source for retrieving actual data
-   * @throws AssertionError if verification fails (row count mismatch, column value mismatch, or
-   *     table structure mismatch)
-   */
-  void verifyExpectation(TableSet expectedTableSet, DataSource dataSource);
-
-  /**
-   * Verifies that the database state matches the expected dataset using the specified context.
-   *
-   * <p>This method accepts an {@link ExpectationContext} parameter object that encapsulates all
-   * optional verification parameters (column exclusions, column strategies, row ordering, and
-   * operation defaults). This replaces the telescoping overload pattern.
-   *
-   * <p>The default implementation logs warnings for non-default context values and delegates to
-   * {@link #verifyExpectation(TableSet, DataSource)}. Implementations should override this method
-   * to support the full set of verification parameters.
+   * comparison. The {@link ExpectationContext} parameter object encapsulates all optional
+   * verification parameters (column exclusions, column strategies, row ordering, and operation
+   * defaults).
    *
    * @param expectedTableSet the expected dataset containing expected table data
    * @param dataSource the database connection source for retrieving actual data
    * @param context the verification context containing optional parameters
-   * @throws AssertionError if verification fails
+   * @throws AssertionError if verification fails (row count mismatch, column value mismatch, or
+   *     table structure mismatch)
    * @see ExpectationContext
    */
-  default void verifyExpectation(
-      final TableSet expectedTableSet,
-      final DataSource dataSource,
-      final ExpectationContext context) {
-    if (!context.excludeColumns().isEmpty()) {
-      logWarning(
-          "Column exclusions specified but current ExpectationProvider does not support them. "
-              + "Exclusions will be ignored: {}. Override verifyExpectation(TableSet, DataSource, "
-              + "ExpectationContext) to support column exclusion.",
-          context.excludeColumns());
-    }
-    if (!context.columnStrategies().isEmpty()) {
-      logWarning(
-          "Column strategies specified but current ExpectationProvider does not support them. "
-              + "Strategies will be ignored: {}. Override verifyExpectation(TableSet, DataSource, "
-              + "ExpectationContext) to support column strategies.",
-          context.columnStrategies().keySet());
-    }
-    if (context.rowOrdering() == RowOrdering.UNORDERED) {
-      logWarning(
-          "Unordered row comparison requested but current ExpectationProvider does not support it. "
-              + "Falling back to ordered comparison. Override verifyExpectation(TableSet, "
-              + "DataSource, ExpectationContext) to support unordered comparison.");
-    }
-    if (context.operationDefaults().floatingPointEpsilon()
-        != OperationDefaults.DEFAULT_FLOATING_POINT_EPSILON) {
-      logWarning(
-          "Custom floating-point epsilon specified but current ExpectationProvider does not "
-              + "support it. Using default epsilon. Override verifyExpectation(TableSet, "
-              + "DataSource, ExpectationContext) to support custom epsilon.");
-    }
-    verifyExpectation(expectedTableSet, dataSource);
-  }
+  void verifyExpectation(
+      TableSet expectedTableSet, DataSource dataSource, ExpectationContext context);
 }

--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/spi/OperationProvider.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/spi/OperationProvider.java
@@ -46,32 +46,8 @@ public interface OperationProvider {
    * TransactionMode#SINGLE_TRANSACTION}, changes are committed on success or rolled back on
    * failure.
    *
-   * @param operation the operation to execute
-   * @param tableSet the dataset to operate on
-   * @param dataSource the data source for database connections
-   * @param tableOrderingStrategy the strategy for determining table processing order
-   * @param transactionMode the transaction behavior mode
-   * @param queryTimeout the query timeout, or null for no timeout
-   * @throws DatabaseTesterException if the operation fails
-   */
-  void execute(
-      Operation operation,
-      TableSet tableSet,
-      DataSource dataSource,
-      TableOrderingStrategy tableOrderingStrategy,
-      TransactionMode transactionMode,
-      @Nullable Duration queryTimeout);
-
-  /**
-   * Executes a database operation on the given dataset with batch size control.
-   *
-   * <p>This method extends the base {@link #execute} method with an additional batch size parameter
-   * for controlling INSERT batch flushing. A batch size of zero means all rows are added to a
-   * single batch (default behavior). A positive value causes the executor to flush the batch every
-   * N rows.
-   *
-   * <p>The default implementation ignores the batch size and delegates to the base {@link #execute}
-   * method, maintaining backward compatibility for existing providers.
+   * <p>The batch size controls INSERT batch flushing. A batch size of zero adds all rows to a
+   * single batch. A positive value flushes the batch every N rows.
    *
    * @param operation the operation to execute
    * @param tableSet the dataset to operate on
@@ -82,14 +58,12 @@ public interface OperationProvider {
    * @param batchSize the number of rows per INSERT batch, or zero for single-batch execution
    * @throws DatabaseTesterException if the operation fails
    */
-  default void execute(
+  void execute(
       Operation operation,
       TableSet tableSet,
       DataSource dataSource,
       TableOrderingStrategy tableOrderingStrategy,
       TransactionMode transactionMode,
       @Nullable Duration queryTimeout,
-      int batchSize) {
-    execute(operation, tableSet, dataSource, tableOrderingStrategy, transactionMode, queryTimeout);
-  }
+      int batchSize);
 }

--- a/db-tester-api/src/test/java/io/github/seijikohara/dbtester/api/config/ExpectationContextTest.java
+++ b/db-tester-api/src/test/java/io/github/seijikohara/dbtester/api/config/ExpectationContextTest.java
@@ -80,7 +80,12 @@ class ExpectationContextTest {
 
       // When
       final var context =
-          ExpectationContext.of(excludeColumns, columnStrategies, rowOrdering, operationDefaults);
+          ExpectationContext.of(
+              excludeColumns,
+              columnStrategies,
+              rowOrdering,
+              operationDefaults,
+              TableOrderingStrategy.AUTO);
 
       // Then
       assertAll(
@@ -120,7 +125,11 @@ class ExpectationContextTest {
       final var mutableList = new ArrayList<>(List.of("COL1", "COL2"));
       final var context =
           ExpectationContext.of(
-              mutableList, Map.of(), RowOrdering.ORDERED, OperationDefaults.standard());
+              mutableList,
+              Map.of(),
+              RowOrdering.ORDERED,
+              OperationDefaults.standard(),
+              TableOrderingStrategy.AUTO);
 
       // When
       mutableList.add("COL3");
@@ -139,7 +148,11 @@ class ExpectationContextTest {
           new HashMap<>(Map.of("EMAIL", ColumnStrategyMapping.caseInsensitive("EMAIL")));
       final var context =
           ExpectationContext.of(
-              List.of(), mutableMap, RowOrdering.ORDERED, OperationDefaults.standard());
+              List.of(),
+              mutableMap,
+              RowOrdering.ORDERED,
+              OperationDefaults.standard(),
+              TableOrderingStrategy.AUTO);
 
       // When
       mutableMap.put("NAME", ColumnStrategyMapping.strict("NAME"));
@@ -156,7 +169,11 @@ class ExpectationContextTest {
       // Given
       final var context =
           ExpectationContext.of(
-              List.of("COL1"), Map.of(), RowOrdering.ORDERED, OperationDefaults.standard());
+              List.of("COL1"),
+              Map.of(),
+              RowOrdering.ORDERED,
+              OperationDefaults.standard(),
+              TableOrderingStrategy.AUTO);
 
       // When & Then
       assertThrows(
@@ -176,7 +193,8 @@ class ExpectationContextTest {
               List.of(),
               Map.of("EMAIL", ColumnStrategyMapping.caseInsensitive("EMAIL")),
               RowOrdering.ORDERED,
-              OperationDefaults.standard());
+              OperationDefaults.standard(),
+              TableOrderingStrategy.AUTO);
 
       // When & Then
       assertThrows(

--- a/db-tester-api/src/test/java/io/github/seijikohara/dbtester/api/preparation/TestOperationProvider.java
+++ b/db-tester-api/src/test/java/io/github/seijikohara/dbtester/api/preparation/TestOperationProvider.java
@@ -65,26 +65,6 @@ public final class TestOperationProvider implements OperationProvider {
       final DataSource dataSource,
       final TableOrderingStrategy tableOrderingStrategy,
       final TransactionMode transactionMode,
-      final @Nullable Duration queryTimeout) {
-    INVOCATIONS.add(
-        new Invocation(
-            "execute(6-arg)",
-            List.of(
-                operation,
-                tableSet,
-                dataSource,
-                tableOrderingStrategy,
-                transactionMode,
-                wrapNullable(queryTimeout))));
-  }
-
-  @Override
-  public void execute(
-      final Operation operation,
-      final TableSet tableSet,
-      final DataSource dataSource,
-      final TableOrderingStrategy tableOrderingStrategy,
-      final TransactionMode transactionMode,
       final @Nullable Duration queryTimeout,
       final int batchSize) {
     INVOCATIONS.add(

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/spi/DefaultExpectationProvider.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/spi/DefaultExpectationProvider.java
@@ -34,11 +34,6 @@ public final class DefaultExpectationProvider implements ExpectationProvider {
   }
 
   @Override
-  public void verifyExpectation(final TableSet expectedTableSet, final DataSource dataSource) {
-    expectationVerifier.verifyExpectation(expectedTableSet, dataSource);
-  }
-
-  @Override
   public void verifyExpectation(
       final TableSet expectedTableSet,
       final DataSource dataSource,

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/spi/DefaultOperationProvider.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/spi/DefaultOperationProvider.java
@@ -44,18 +44,6 @@ public final class DefaultOperationProvider implements OperationProvider {
       final DataSource dataSource,
       final TableOrderingStrategy tableOrderingStrategy,
       final TransactionMode transactionMode,
-      final @Nullable Duration queryTimeout) {
-    operationExecutor.execute(
-        operation, tableSet, dataSource, tableOrderingStrategy, transactionMode, queryTimeout);
-  }
-
-  @Override
-  public void execute(
-      final Operation operation,
-      final TableSet tableSet,
-      final DataSource dataSource,
-      final TableOrderingStrategy tableOrderingStrategy,
-      final TransactionMode transactionMode,
       final @Nullable Duration queryTimeout,
       final int batchSize) {
     operationExecutor.execute(

--- a/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/spi/DefaultExpectationProviderTest.java
+++ b/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/spi/DefaultExpectationProviderTest.java
@@ -11,6 +11,7 @@ import io.github.seijikohara.dbtester.api.config.ExpectationContext;
 import io.github.seijikohara.dbtester.api.config.OperationDefaults;
 import io.github.seijikohara.dbtester.api.config.RowOrdering;
 import io.github.seijikohara.dbtester.api.dataset.TableSet;
+import io.github.seijikohara.dbtester.api.operation.TableOrderingStrategy;
 import io.github.seijikohara.dbtester.internal.assertion.ExpectationVerifier;
 import java.util.List;
 import java.util.Map;
@@ -74,34 +75,6 @@ class DefaultExpectationProviderTest {
     }
   }
 
-  /** Tests for the verifyExpectation(TableSet, DataSource) method. */
-  @Nested
-  @DisplayName("verifyExpectation(TableSet, DataSource) method")
-  class VerifyExpectationMethod {
-
-    /** Tests for the verifyExpectation method. */
-    VerifyExpectationMethod() {}
-
-    /** Verifies that verifyExpectation delegates to expectation verifier. */
-    @Test
-    @Tag("normal")
-    @DisplayName("should delegate to expectation verifier when called")
-    void shouldDelegateToExpectationVerifier_whenCalled() {
-      // Given
-      final var expectedDataSet = mock(TableSet.class);
-      final var dataSource = mock(DataSource.class);
-      doNothing()
-          .when(mockExpectationVerifier)
-          .verifyExpectation(any(TableSet.class), any(DataSource.class));
-
-      // When
-      provider.verifyExpectation(expectedDataSet, dataSource);
-
-      // Then
-      verify(mockExpectationVerifier).verifyExpectation(expectedDataSet, dataSource);
-    }
-  }
-
   /** Tests for the verifyExpectation(TableSet, DataSource, ExpectationContext) method. */
   @Nested
   @DisplayName("verifyExpectation(TableSet, DataSource, ExpectationContext) method")
@@ -144,7 +117,8 @@ class DefaultExpectationProviderTest {
               List.of("CREATED_AT"),
               Map.of("EMAIL", ColumnStrategyMapping.caseInsensitive("EMAIL")),
               RowOrdering.UNORDERED,
-              OperationDefaults.standard());
+              OperationDefaults.standard(),
+              TableOrderingStrategy.AUTO);
       doNothing()
           .when(mockExpectationVerifier)
           .verifyExpectation(

--- a/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/spi/DefaultOperationProviderTest.java
+++ b/db-tester-core/src/test/java/io/github/seijikohara/dbtester/internal/spi/DefaultOperationProviderTest.java
@@ -2,6 +2,7 @@ package io.github.seijikohara.dbtester.internal.spi;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
@@ -103,14 +104,15 @@ class DefaultOperationProviderTest {
               any(DataSource.class),
               any(TableOrderingStrategy.class),
               any(TransactionMode.class),
-              isNull());
+              isNull(),
+              anyInt());
 
       // When
-      provider.execute(operation, dataSet, dataSource, strategy, transactionMode, queryTimeout);
+      provider.execute(operation, dataSet, dataSource, strategy, transactionMode, queryTimeout, 0);
 
       // Then
       verify(mockOperationExecutor)
-          .execute(operation, dataSet, dataSource, strategy, transactionMode, queryTimeout);
+          .execute(operation, dataSet, dataSource, strategy, transactionMode, queryTimeout, 0);
     }
 
     /** Verifies that execute handles INSERT operation. */
@@ -133,14 +135,15 @@ class DefaultOperationProviderTest {
               any(DataSource.class),
               any(TableOrderingStrategy.class),
               any(TransactionMode.class),
-              isNull());
+              isNull(),
+              anyInt());
 
       // When
-      provider.execute(operation, dataSet, dataSource, strategy, transactionMode, queryTimeout);
+      provider.execute(operation, dataSet, dataSource, strategy, transactionMode, queryTimeout, 0);
 
       // Then
       verify(mockOperationExecutor)
-          .execute(operation, dataSet, dataSource, strategy, transactionMode, queryTimeout);
+          .execute(operation, dataSet, dataSource, strategy, transactionMode, queryTimeout, 0);
     }
 
     /** Verifies that execute handles DELETE_ALL operation. */
@@ -163,14 +166,15 @@ class DefaultOperationProviderTest {
               any(DataSource.class),
               any(TableOrderingStrategy.class),
               any(TransactionMode.class),
-              isNull());
+              isNull(),
+              anyInt());
 
       // When
-      provider.execute(operation, dataSet, dataSource, strategy, transactionMode, queryTimeout);
+      provider.execute(operation, dataSet, dataSource, strategy, transactionMode, queryTimeout, 0);
 
       // Then
       verify(mockOperationExecutor)
-          .execute(operation, dataSet, dataSource, strategy, transactionMode, queryTimeout);
+          .execute(operation, dataSet, dataSource, strategy, transactionMode, queryTimeout, 0);
     }
 
     /** Verifies that execute handles TRUNCATE_TABLE operation. */
@@ -193,14 +197,15 @@ class DefaultOperationProviderTest {
               any(DataSource.class),
               any(TableOrderingStrategy.class),
               any(TransactionMode.class),
-              isNull());
+              isNull(),
+              anyInt());
 
       // When
-      provider.execute(operation, dataSet, dataSource, strategy, transactionMode, queryTimeout);
+      provider.execute(operation, dataSet, dataSource, strategy, transactionMode, queryTimeout, 0);
 
       // Then
       verify(mockOperationExecutor)
-          .execute(operation, dataSet, dataSource, strategy, transactionMode, queryTimeout);
+          .execute(operation, dataSet, dataSource, strategy, transactionMode, queryTimeout, 0);
     }
 
     /** Verifies that execute passes query timeout to operation executor. */
@@ -223,14 +228,15 @@ class DefaultOperationProviderTest {
               any(DataSource.class),
               any(TableOrderingStrategy.class),
               any(TransactionMode.class),
-              any(Duration.class));
+              any(Duration.class),
+              anyInt());
 
       // When
-      provider.execute(operation, dataSet, dataSource, strategy, transactionMode, queryTimeout);
+      provider.execute(operation, dataSet, dataSource, strategy, transactionMode, queryTimeout, 0);
 
       // Then
       verify(mockOperationExecutor)
-          .execute(operation, dataSet, dataSource, strategy, transactionMode, queryTimeout);
+          .execute(operation, dataSet, dataSource, strategy, transactionMode, queryTimeout, 0);
     }
 
     /** Verifies that execute handles NONE transaction mode. */
@@ -253,14 +259,15 @@ class DefaultOperationProviderTest {
               any(DataSource.class),
               any(TableOrderingStrategy.class),
               any(TransactionMode.class),
-              isNull());
+              isNull(),
+              anyInt());
 
       // When
-      provider.execute(operation, dataSet, dataSource, strategy, transactionMode, queryTimeout);
+      provider.execute(operation, dataSet, dataSource, strategy, transactionMode, queryTimeout, 0);
 
       // Then
       verify(mockOperationExecutor)
-          .execute(operation, dataSet, dataSource, strategy, transactionMode, queryTimeout);
+          .execute(operation, dataSet, dataSource, strategy, transactionMode, queryTimeout, 0);
     }
   }
 }

--- a/docs/specs/ja/spi-providers.md
+++ b/docs/specs/ja/spi-providers.md
@@ -41,15 +41,6 @@ public interface OperationProvider {
         DataSource dataSource,
         TableOrderingStrategy tableOrderingStrategy,
         TransactionMode transactionMode,
-        @Nullable Duration queryTimeout);
-
-    // バッチサイズ制御付き（デフォルトではベースのexecuteに委譲）
-    default void execute(
-        Operation operation,
-        TableSet tableSet,
-        DataSource dataSource,
-        TableOrderingStrategy tableOrderingStrategy,
-        TransactionMode transactionMode,
         @Nullable Duration queryTimeout,
         int batchSize);
 }
@@ -67,7 +58,7 @@ public interface OperationProvider {
 | `tableOrderingStrategy` | `TableOrderingStrategy` | テーブル処理順序の戦略 |
 | `transactionMode` | `TransactionMode` | トランザクション動作モード |
 | `queryTimeout` | `@Nullable Duration` | クエリタイムアウト、またはタイムアウトなしの場合はnull |
-| `batchSize` | `int` | INSERTバッチあたりの行数（0 = 単一バッチ）、バッチオーバーロードで使用 |
+| `batchSize` | `int` | INSERTバッチあたりの行数（0 = 単一バッチ） |
 
 **操作**:
 
@@ -143,12 +134,8 @@ public interface AssertionProvider {
 
 ```java
 public interface ExpectationProvider {
-    // 基本検証（abstract）
-    void verifyExpectation(TableSet expectedTableSet, DataSource dataSource);
-
-    // ExpectationContextパラメータオブジェクト付き（default）
-    default void verifyExpectation(TableSet expectedTableSet, DataSource dataSource,
-                                   ExpectationContext context);
+    void verifyExpectation(TableSet expectedTableSet, DataSource dataSource,
+                           ExpectationContext context);
 }
 ```
 
@@ -158,7 +145,6 @@ public interface ExpectationProvider {
 
 | メソッド | 説明 |
 |----------|------|
-| `verifyExpectation(TableSet, DataSource)` | 基本的なデータベース状態検証 |
 | `verifyExpectation(TableSet, DataSource, ExpectationContext)` | フルコンテキスト付き検証（除外、戦略、順序、デフォルト） |
 
 **ExpectationContext** (`io.github.seijikohara.dbtester.api.config.ExpectationContext`):
@@ -183,11 +169,7 @@ var context = ExpectationContext.defaults()
     .withRowOrdering(RowOrdering.UNORDERED)
     .withTableOrdering(TableOrderingStrategy.FOREIGN_KEY);
 
-// 4パラメータのファクトリメソッド（テーブル順序はAUTOがデフォルト）
-var context = ExpectationContext.of(
-    excludeColumns, columnStrategies, rowOrdering, operationDefaults);
-
-// 5パラメータのファクトリメソッド（テーブル順序を明示指定）
+// 全パラメータのファクトリメソッド
 var context = ExpectationContext.of(
     excludeColumns, columnStrategies, rowOrdering, operationDefaults,
     TableOrderingStrategy.FOREIGN_KEY);

--- a/docs/specs/spi-providers.md
+++ b/docs/specs/spi-providers.md
@@ -41,15 +41,6 @@ public interface OperationProvider {
         DataSource dataSource,
         TableOrderingStrategy tableOrderingStrategy,
         TransactionMode transactionMode,
-        @Nullable Duration queryTimeout);
-
-    // With batch size control (default delegates to base execute)
-    default void execute(
-        Operation operation,
-        TableSet tableSet,
-        DataSource dataSource,
-        TableOrderingStrategy tableOrderingStrategy,
-        TransactionMode transactionMode,
         @Nullable Duration queryTimeout,
         int batchSize);
 }
@@ -67,7 +58,7 @@ public interface OperationProvider {
 | `tableOrderingStrategy` | `TableOrderingStrategy` | Strategy for table processing order |
 | `transactionMode` | `TransactionMode` | Transaction behavior mode |
 | `queryTimeout` | `@Nullable Duration` | Query timeout, or null for no timeout |
-| `batchSize` | `int` | Rows per INSERT batch (0 = single batch), used by the batch overload |
+| `batchSize` | `int` | Rows per INSERT batch (0 = single batch) |
 
 **Operations**:
 
@@ -143,12 +134,8 @@ Verifies database state against expected datasets.
 
 ```java
 public interface ExpectationProvider {
-    // Basic verification (abstract)
-    void verifyExpectation(TableSet expectedTableSet, DataSource dataSource);
-
-    // With ExpectationContext parameter object (default)
-    default void verifyExpectation(TableSet expectedTableSet, DataSource dataSource,
-                                   ExpectationContext context);
+    void verifyExpectation(TableSet expectedTableSet, DataSource dataSource,
+                           ExpectationContext context);
 }
 ```
 
@@ -158,7 +145,6 @@ public interface ExpectationProvider {
 
 | Method | Description |
 |--------|-------------|
-| `verifyExpectation(TableSet, DataSource)` | Basic database state verification |
 | `verifyExpectation(TableSet, DataSource, ExpectationContext)` | Verify with full context (exclusions, strategies, ordering, defaults) |
 
 **ExpectationContext** (`io.github.seijikohara.dbtester.api.config.ExpectationContext`):
@@ -183,11 +169,7 @@ var context = ExpectationContext.defaults()
     .withRowOrdering(RowOrdering.UNORDERED)
     .withTableOrdering(TableOrderingStrategy.FOREIGN_KEY);
 
-// Factory method with 4 parameters (table ordering defaults to AUTO)
-var context = ExpectationContext.of(
-    excludeColumns, columnStrategies, rowOrdering, operationDefaults);
-
-// Factory method with 5 parameters (explicit table ordering)
+// Factory method with all parameters
 var context = ExpectationContext.of(
     excludeColumns, columnStrategies, rowOrdering, operationDefaults,
     TableOrderingStrategy.FOREIGN_KEY);


### PR DESCRIPTION
## Summary

Part of the 0.x hardening program (drives **API design consistency** and **API surface** dimensions). Removes the backward-compatibility scaffolding from the operation and expectation SPIs — the default warning-shims and now-dead abstract base methods that existed only to avoid breaking hypothetical external providers. The framework already invokes the feature-rich variants exclusively, so the thin methods were dead in production.

- `OperationProvider`: single abstract `execute(..., int batchSize)`; the parameterless-batch base + delegating default removed.
- `ExpectationProvider`: single abstract `verifyExpectation(TableSet, DataSource, ExpectationContext)`; the two-arg base + warning-logging default shim removed.
- `DefaultOperationProvider` / `DefaultExpectationProvider`: one override each.
- `ExpectationContext.of`: the 4-arg overload (hardcoding `tableOrdering=AUTO`) merged into the canonical 5-arg factory.
- SPI tests and `docs/specs/spi-providers.md` (+ Japanese mirror) updated.

`DataSetLoader`'s base + `loadExpectationDataSetsWithExclusions` pair is intentionally **kept** — it is the documented minimal-override contract backing a real feature, not dead compat.

## Breaking changes

- `OperationProvider.execute(...)` without `batchSize` removed.
- `ExpectationProvider.verifyExpectation(TableSet, DataSource)` removed.
- 4-arg `ExpectationContext.of(...)` removed.

Acceptable under 0.x SemVer.

## Verification

- 6 published modules: BUILD SUCCESSFUL (Checkstyle, Error Prone, NullAway, DocLint, tests, JaCoCo).
- H2 ITs `AnnotationConfigurationTest`, `ProgrammaticAssertionApiTest` pass.

## Note

Stacked on #312 (base branch `refactor/comparison-strategy-redesign`); GitHub retargets to `main` once that merges.