### PR TITLE
refactor: finalize 1.0-readiness cleanup (accessor naming, explicit API, docs)

### DIFF
--- a/build-logic/src/main/kotlin/dbtester.kotlin-library.gradle.kts
+++ b/build-logic/src/main/kotlin/dbtester.kotlin-library.gradle.kts
@@ -18,6 +18,11 @@ spotless {
     }
 }
 
+// Enforce explicit visibility and return types on the published Kotlin API surface.
+kotlin {
+    explicitApi()
+}
+
 extensions.configure<DokkaExtension> {
     dokkaSourceSets.configureEach {
         reportUndocumented.set(true)

--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/preparation/DatabasePreparation.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/preparation/DatabasePreparation.java
@@ -161,7 +161,7 @@ public final class DatabasePreparation {
             operation,
             tableSet,
             dataSource,
-            config.tableOrderingStrategy(),
+            config.tableOrdering(),
             config.transactionMode(),
             config.queryTimeout(),
             config.batchSize());

--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/preparation/PreparationConfig.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/preparation/PreparationConfig.java
@@ -15,7 +15,7 @@ import org.jspecify.annotations.Nullable;
  * <p>Default values:
  *
  * <ul>
- *   <li>{@code tableOrderingStrategy} = {@link TableOrderingStrategy#AUTO}
+ *   <li>{@code tableOrdering} = {@link TableOrderingStrategy#AUTO}
  *   <li>{@code transactionMode} = {@link TransactionMode#SINGLE_TRANSACTION}
  *   <li>{@code queryTimeout} = {@code null} (no timeout)
  *   <li>{@code batchSize} = {@code 0} (single batch)
@@ -35,7 +35,7 @@ import org.jspecify.annotations.Nullable;
  * DatabasePreparation.execute(dataSource, tableSet, Operation.CLEAN_INSERT, config);
  * }</pre>
  *
- * @param tableOrderingStrategy the strategy for determining table processing order
+ * @param tableOrdering the strategy for determining table processing order
  * @param transactionMode the transaction behavior mode
  * @param queryTimeout the query timeout, or null to use driver default (typically unlimited)
  * @param batchSize the number of rows per INSERT batch; zero means single-batch execution (all rows
@@ -43,7 +43,7 @@ import org.jspecify.annotations.Nullable;
  * @see DatabasePreparation
  */
 public record PreparationConfig(
-    TableOrderingStrategy tableOrderingStrategy,
+    TableOrderingStrategy tableOrdering,
     TransactionMode transactionMode,
     @Nullable Duration queryTimeout,
     int batchSize) {
@@ -76,13 +76,12 @@ public record PreparationConfig(
   /**
    * Returns a new instance with the specified table ordering strategy.
    *
-   * @param tableOrderingStrategy the table ordering strategy
+   * @param tableOrdering the table ordering strategy
    * @return a new instance with the specified strategy
    */
-  public PreparationConfig withTableOrderingStrategy(
-      final TableOrderingStrategy tableOrderingStrategy) {
+  public PreparationConfig withTableOrdering(final TableOrderingStrategy tableOrdering) {
     return new PreparationConfig(
-        tableOrderingStrategy, this.transactionMode, this.queryTimeout, this.batchSize);
+        tableOrdering, this.transactionMode, this.queryTimeout, this.batchSize);
   }
 
   /**
@@ -93,7 +92,7 @@ public record PreparationConfig(
    */
   public PreparationConfig withTransactionMode(final TransactionMode transactionMode) {
     return new PreparationConfig(
-        this.tableOrderingStrategy, transactionMode, this.queryTimeout, this.batchSize);
+        this.tableOrdering, transactionMode, this.queryTimeout, this.batchSize);
   }
 
   /**
@@ -104,7 +103,7 @@ public record PreparationConfig(
    */
   public PreparationConfig withQueryTimeout(final @Nullable Duration queryTimeout) {
     return new PreparationConfig(
-        this.tableOrderingStrategy, this.transactionMode, queryTimeout, this.batchSize);
+        this.tableOrdering, this.transactionMode, queryTimeout, this.batchSize);
   }
 
   /**
@@ -117,6 +116,6 @@ public record PreparationConfig(
    */
   public PreparationConfig withBatchSize(final int batchSize) {
     return new PreparationConfig(
-        this.tableOrderingStrategy, this.transactionMode, this.queryTimeout, batchSize);
+        this.tableOrdering, this.transactionMode, this.queryTimeout, batchSize);
   }
 }

--- a/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/spi/OperationProvider.java
+++ b/db-tester-api/src/main/java/io/github/seijikohara/dbtester/api/spi/OperationProvider.java
@@ -52,7 +52,7 @@ public interface OperationProvider {
    * @param operation the operation to execute
    * @param tableSet the dataset to operate on
    * @param dataSource the data source for database connections
-   * @param tableOrderingStrategy the strategy for determining table processing order
+   * @param tableOrdering the strategy for determining table processing order
    * @param transactionMode the transaction behavior mode
    * @param queryTimeout the query timeout, or null for no timeout
    * @param batchSize the number of rows per INSERT batch, or zero for single-batch execution
@@ -62,7 +62,7 @@ public interface OperationProvider {
       Operation operation,
       TableSet tableSet,
       DataSource dataSource,
-      TableOrderingStrategy tableOrderingStrategy,
+      TableOrderingStrategy tableOrdering,
       TransactionMode transactionMode,
       @Nullable Duration queryTimeout,
       int batchSize);

--- a/db-tester-api/src/test/java/io/github/seijikohara/dbtester/api/preparation/PreparationConfigTest.java
+++ b/db-tester-api/src/test/java/io/github/seijikohara/dbtester/api/preparation/PreparationConfigTest.java
@@ -42,7 +42,7 @@ class PreparationConfigTest {
           () ->
               assertEquals(
                   TableOrderingStrategy.AUTO,
-                  config.tableOrderingStrategy(),
+                  config.tableOrdering(),
                   "should use AUTO table ordering"),
           () ->
               assertEquals(
@@ -82,15 +82,15 @@ class PreparationConfigTest {
     }
   }
 
-  /** Tests for the withTableOrderingStrategy() method. */
+  /** Tests for the withTableOrdering() method. */
   @Nested
-  @DisplayName("withTableOrderingStrategy() method")
+  @DisplayName("withTableOrdering() method")
   class WithTableOrderingStrategyMethod {
 
-    /** Tests for the withTableOrderingStrategy method. */
+    /** Tests for the withTableOrdering method. */
     WithTableOrderingStrategyMethod() {}
 
-    /** Verifies that withTableOrderingStrategy returns new instance with updated strategy. */
+    /** Verifies that withTableOrdering returns new instance with updated strategy. */
     @Test
     @Tag("normal")
     @DisplayName("should return new instance with updated strategy")
@@ -99,7 +99,7 @@ class PreparationConfigTest {
       final var original = PreparationConfig.standard();
 
       // When
-      final var result = original.withTableOrderingStrategy(TableOrderingStrategy.FOREIGN_KEY);
+      final var result = original.withTableOrdering(TableOrderingStrategy.FOREIGN_KEY);
 
       // Then
       assertAll(
@@ -107,7 +107,7 @@ class PreparationConfigTest {
           () ->
               assertEquals(
                   TableOrderingStrategy.FOREIGN_KEY,
-                  result.tableOrderingStrategy(),
+                  result.tableOrdering(),
                   "should use FOREIGN_KEY strategy"),
           () ->
               assertEquals(
@@ -151,8 +151,8 @@ class PreparationConfigTest {
                   "should use AUTO_COMMIT mode"),
           () ->
               assertEquals(
-                  original.tableOrderingStrategy(),
-                  result.tableOrderingStrategy(),
+                  original.tableOrdering(),
+                  result.tableOrdering(),
                   "should preserve table ordering strategy"));
     }
   }

--- a/db-tester-api/src/test/java/io/github/seijikohara/dbtester/api/preparation/TestOperationProvider.java
+++ b/db-tester-api/src/test/java/io/github/seijikohara/dbtester/api/preparation/TestOperationProvider.java
@@ -63,7 +63,7 @@ public final class TestOperationProvider implements OperationProvider {
       final Operation operation,
       final TableSet tableSet,
       final DataSource dataSource,
-      final TableOrderingStrategy tableOrderingStrategy,
+      final TableOrderingStrategy tableOrdering,
       final TransactionMode transactionMode,
       final @Nullable Duration queryTimeout,
       final int batchSize) {
@@ -74,7 +74,7 @@ public final class TestOperationProvider implements OperationProvider {
                 operation,
                 tableSet,
                 dataSource,
-                tableOrderingStrategy,
+                tableOrdering,
                 transactionMode,
                 wrapNullable(queryTimeout),
                 batchSize)));

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/jdbc/write/OperationExecutor.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/jdbc/write/OperationExecutor.java
@@ -114,21 +114,16 @@ public final class OperationExecutor {
    * @param operation the operation to execute
    * @param tableSet the dataset to operate on
    * @param dataSource the data source
-   * @param tableOrderingStrategy the strategy for determining table processing order
+   * @param tableOrdering the strategy for determining table processing order
    * @throws DatabaseTesterException if the operation fails
    */
   public void execute(
       final Operation operation,
       final TableSet tableSet,
       final DataSource dataSource,
-      final TableOrderingStrategy tableOrderingStrategy) {
+      final TableOrderingStrategy tableOrdering) {
     execute(
-        operation,
-        tableSet,
-        dataSource,
-        tableOrderingStrategy,
-        TransactionMode.SINGLE_TRANSACTION,
-        null);
+        operation, tableSet, dataSource, tableOrdering, TransactionMode.SINGLE_TRANSACTION, null);
   }
 
   /**
@@ -137,7 +132,7 @@ public final class OperationExecutor {
    * @param operation the operation to execute
    * @param tableSet the dataset to operate on
    * @param dataSource the data source
-   * @param tableOrderingStrategy the strategy for determining table processing order
+   * @param tableOrdering the strategy for determining table processing order
    * @param transactionMode the transaction behavior mode
    * @param queryTimeout the query timeout, or null for no timeout
    * @throws DatabaseTesterException if the operation fails
@@ -146,11 +141,10 @@ public final class OperationExecutor {
       final Operation operation,
       final TableSet tableSet,
       final DataSource dataSource,
-      final TableOrderingStrategy tableOrderingStrategy,
+      final TableOrderingStrategy tableOrdering,
       final TransactionMode transactionMode,
       final @Nullable Duration queryTimeout) {
-    execute(
-        operation, tableSet, dataSource, tableOrderingStrategy, transactionMode, queryTimeout, 0);
+    execute(operation, tableSet, dataSource, tableOrdering, transactionMode, queryTimeout, 0);
   }
 
   /**
@@ -159,7 +153,7 @@ public final class OperationExecutor {
    * @param operation the operation to execute
    * @param tableSet the dataset to operate on
    * @param dataSource the data source
-   * @param tableOrderingStrategy the strategy for determining table processing order
+   * @param tableOrdering the strategy for determining table processing order
    * @param transactionMode the transaction behavior mode
    * @param queryTimeout the query timeout, or null for no timeout
    * @param batchSize the number of rows per INSERT batch, or zero for single-batch execution
@@ -169,7 +163,7 @@ public final class OperationExecutor {
       final Operation operation,
       final TableSet tableSet,
       final DataSource dataSource,
-      final TableOrderingStrategy tableOrderingStrategy,
+      final TableOrderingStrategy tableOrdering,
       final TransactionMode transactionMode,
       final @Nullable Duration queryTimeout,
       final int batchSize) {
@@ -177,7 +171,7 @@ public final class OperationExecutor {
         "Executing operation {} on dataset with {} tables using strategy {} (transactionMode={}, timeout={}, batchSize={})",
         operation,
         tableSet.tables().size(),
-        tableOrderingStrategy,
+        tableOrdering,
         transactionMode,
         queryTimeout,
         batchSize);
@@ -188,8 +182,7 @@ public final class OperationExecutor {
 
       try {
         configureTransaction(connection, transactionMode);
-        executeOperation(
-            operation, tableSet, connection, tableOrderingStrategy, queryTimeout, batchSize);
+        executeOperation(operation, tableSet, connection, tableOrdering, queryTimeout, batchSize);
         commitIfRequired(connection, transactionMode);
         logger.debug("Successfully executed operation {}", operation);
       } catch (final DatabaseOperationException e) {
@@ -274,15 +267,15 @@ public final class OperationExecutor {
    * @param operation the operation to execute
    * @param tableSet the dataset to operate on
    * @param connection the database connection
-   * @param tableOrderingStrategy the strategy for determining table processing order
+   * @param tableOrdering the strategy for determining table processing order
    * @throws DatabaseOperationException if a database error occurs
    */
   void executeOperation(
       final Operation operation,
       final TableSet tableSet,
       final Connection connection,
-      final TableOrderingStrategy tableOrderingStrategy) {
-    executeOperation(operation, tableSet, connection, tableOrderingStrategy, null);
+      final TableOrderingStrategy tableOrdering) {
+    executeOperation(operation, tableSet, connection, tableOrdering, null);
   }
 
   /**
@@ -291,7 +284,7 @@ public final class OperationExecutor {
    * @param operation the operation to execute
    * @param tableSet the dataset to operate on
    * @param connection the database connection
-   * @param tableOrderingStrategy the strategy for determining table processing order
+   * @param tableOrdering the strategy for determining table processing order
    * @param queryTimeout the query timeout, or null for no timeout
    * @throws DatabaseOperationException if a database error occurs
    */
@@ -299,9 +292,9 @@ public final class OperationExecutor {
       final Operation operation,
       final TableSet tableSet,
       final Connection connection,
-      final TableOrderingStrategy tableOrderingStrategy,
+      final TableOrderingStrategy tableOrdering,
       final @Nullable Duration queryTimeout) {
-    executeOperation(operation, tableSet, connection, tableOrderingStrategy, queryTimeout, 0);
+    executeOperation(operation, tableSet, connection, tableOrdering, queryTimeout, 0);
   }
 
   /**
@@ -310,7 +303,7 @@ public final class OperationExecutor {
    * @param operation the operation to execute
    * @param tableSet the dataset to operate on
    * @param connection the database connection
-   * @param tableOrderingStrategy the strategy for determining table processing order
+   * @param tableOrdering the strategy for determining table processing order
    * @param queryTimeout the query timeout, or null for no timeout
    * @param batchSize the number of rows per INSERT batch, or zero for single-batch execution
    * @throws DatabaseOperationException if a database error occurs
@@ -319,10 +312,10 @@ public final class OperationExecutor {
       final Operation operation,
       final TableSet tableSet,
       final Connection connection,
-      final TableOrderingStrategy tableOrderingStrategy,
+      final TableOrderingStrategy tableOrdering,
       final @Nullable Duration queryTimeout,
       final int batchSize) {
-    final var tables = resolveTableOrder(tableSet.tables(), connection, tableOrderingStrategy);
+    final var tables = resolveTableOrder(tableSet.tables(), connection, tableOrdering);
 
     switch (operation) {
       case NONE -> {

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/lifecycle/DefaultPreparationSupport.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/lifecycle/DefaultPreparationSupport.java
@@ -106,20 +106,14 @@ public final class DefaultPreparationSupport implements PreparationSupport {
       final DataSet dataSet,
       final DataSource dataSource) {
     final var operation = dataSet.operation();
-    final var tableOrderingStrategy = dataSet.tableOrdering();
+    final var tableOrdering = dataSet.tableOrdering();
     final var execution = context.configuration().execution();
     final var transactionMode = execution.transactionMode();
     final var queryTimeout = execution.queryTimeout();
     final var batchSize = resolveBatchSize(dataSet, context);
 
     operationProvider.execute(
-        operation,
-        tableSet,
-        dataSource,
-        tableOrderingStrategy,
-        transactionMode,
-        queryTimeout,
-        batchSize);
+        operation, tableSet, dataSource, tableOrdering, transactionMode, queryTimeout, batchSize);
   }
 
   /**

--- a/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/spi/DefaultOperationProvider.java
+++ b/db-tester-core/src/main/java/io/github/seijikohara/dbtester/internal/spi/DefaultOperationProvider.java
@@ -42,17 +42,11 @@ public final class DefaultOperationProvider implements OperationProvider {
       final Operation operation,
       final TableSet tableSet,
       final DataSource dataSource,
-      final TableOrderingStrategy tableOrderingStrategy,
+      final TableOrderingStrategy tableOrdering,
       final TransactionMode transactionMode,
       final @Nullable Duration queryTimeout,
       final int batchSize) {
     operationExecutor.execute(
-        operation,
-        tableSet,
-        dataSource,
-        tableOrderingStrategy,
-        transactionMode,
-        queryTimeout,
-        batchSize);
+        operation, tableSet, dataSource, tableOrdering, transactionMode, queryTimeout, batchSize);
   }
 }

--- a/db-tester-kotest-spring-boot-starter/src/main/kotlin/io/github/seijikohara/dbtester/kotest/spring/boot/autoconfigure/DbTesterKotestAutoConfiguration.kt
+++ b/db-tester-kotest-spring-boot-starter/src/main/kotlin/io/github/seijikohara/dbtester/kotest/spring/boot/autoconfigure/DbTesterKotestAutoConfiguration.kt
@@ -38,7 +38,7 @@ import javax.sql.DataSource
     matchIfMissing = true,
 )
 @EnableConfigurationProperties(DbTesterProperties::class)
-class DbTesterKotestAutoConfiguration {
+public class DbTesterKotestAutoConfiguration {
     /**
      * Creates a Configuration bean from the DB Tester properties.
      *
@@ -50,7 +50,8 @@ class DbTesterKotestAutoConfiguration {
      */
     @Bean
     @ConditionalOnMissingBean
-    fun dbTesterConfiguration(properties: DbTesterProperties): Configuration = DbTesterConfigurationFactory.toConfiguration(properties)
+    public fun dbTesterConfiguration(properties: DbTesterProperties): Configuration =
+        DbTesterConfigurationFactory.toConfiguration(properties)
 
     /**
      * Creates a [DataSourceRegistrar] bean.
@@ -64,5 +65,5 @@ class DbTesterKotestAutoConfiguration {
      */
     @Bean
     @ConditionalOnMissingBean
-    fun dataSourceRegistrar(properties: DbTesterProperties): DataSourceRegistrar = DataSourceRegistrar(properties)
+    public fun dataSourceRegistrar(properties: DbTesterProperties): DataSourceRegistrar = DataSourceRegistrar(properties)
 }

--- a/db-tester-kotest-spring-boot-starter/src/main/kotlin/io/github/seijikohara/dbtester/kotest/spring/boot/autoconfigure/SpringBootDatabaseTest.kt
+++ b/db-tester-kotest-spring-boot-starter/src/main/kotlin/io/github/seijikohara/dbtester/kotest/spring/boot/autoconfigure/SpringBootDatabaseTest.kt
@@ -40,4 +40,4 @@ import java.lang.annotation.Inherited
 @MustBeDocumented
 @Inherited
 @ApplyExtension(SpringBootDatabaseTestExtension::class)
-annotation class SpringBootDatabaseTest
+public annotation class SpringBootDatabaseTest

--- a/db-tester-kotest-spring-boot-starter/src/main/kotlin/io/github/seijikohara/dbtester/kotest/spring/boot/autoconfigure/SpringBootDatabaseTestExtension.kt
+++ b/db-tester-kotest-spring-boot-starter/src/main/kotlin/io/github/seijikohara/dbtester/kotest/spring/boot/autoconfigure/SpringBootDatabaseTestExtension.kt
@@ -43,11 +43,11 @@ import org.springframework.test.context.TestContextManager
  * @see DataSourceRegistrar
  * @see DbTesterKotestAutoConfiguration
  */
-class SpringBootDatabaseTestExtension :
+public class SpringBootDatabaseTestExtension :
     SpecExtension,
     TestCaseExtension {
     /** Companion object containing class-level logger. */
-    companion object {
+    private companion object {
         private val logger = LoggerFactory.getLogger(SpringBootDatabaseTestExtension::class.java)
     }
 

--- a/db-tester-kotest/src/main/kotlin/io/github/seijikohara/dbtester/kotest/annotation/DatabaseTest.kt
+++ b/db-tester-kotest/src/main/kotlin/io/github/seijikohara/dbtester/kotest/annotation/DatabaseTest.kt
@@ -67,4 +67,4 @@ import java.lang.annotation.Inherited
 @MustBeDocumented
 @Inherited
 @ApplyExtension(DatabaseTestExtension::class)
-annotation class DatabaseTest
+public annotation class DatabaseTest

--- a/db-tester-kotest/src/main/kotlin/io/github/seijikohara/dbtester/kotest/extension/DatabaseTestExtension.kt
+++ b/db-tester-kotest/src/main/kotlin/io/github/seijikohara/dbtester/kotest/extension/DatabaseTestExtension.kt
@@ -80,7 +80,7 @@ import kotlin.reflect.jvm.javaMethod
  * @see DataSet
  * @see ExpectedDataSet
  */
-class DatabaseTestExtension(
+public class DatabaseTestExtension public constructor(
     private val registryProvider: (() -> DataSourceRegistry)? = null,
     private val configurationProvider: (() -> Configuration)? = null,
 ) : TestCaseExtension {
@@ -100,7 +100,7 @@ class DatabaseTestExtension(
     /**
      * Creates an extension with injected lifecycle collaborators.
      *
-     * This constructor exists to supply test doubles for the preparation, verification, and
+     * <p>This constructor exists to supply test doubles for the preparation, verification, and
      * export phases. Production code uses the primary constructor.
      *
      * @param registryProvider optional provider for the [DataSourceRegistry], or null
@@ -122,7 +122,7 @@ class DatabaseTestExtension(
     }
 
     /** Companion object containing class-level constants and logger. */
-    companion object {
+    private companion object {
         private val logger = LoggerFactory.getLogger(DatabaseTestExtension::class.java)
     }
 

--- a/db-tester-kotest/src/main/kotlin/io/github/seijikohara/dbtester/kotest/extension/DatabaseTestSupport.kt
+++ b/db-tester-kotest/src/main/kotlin/io/github/seijikohara/dbtester/kotest/extension/DatabaseTestSupport.kt
@@ -48,14 +48,14 @@ import io.github.seijikohara.dbtester.api.config.DataSourceRegistry
  * @see io.github.seijikohara.dbtester.kotest.annotation.DatabaseTest
  * @see DatabaseTestExtension
  */
-interface DatabaseTestSupport {
+public interface DatabaseTestSupport {
     /**
      * The data source registry for database connections.
      *
      * This property must be implemented by the spec class. Register your
      * [javax.sql.DataSource] instances with this registry before tests run.
      */
-    val dbTesterRegistry: DataSourceRegistry
+    public val dbTesterRegistry: DataSourceRegistry
 
     /**
      * Optional custom configuration for database testing.
@@ -64,6 +64,6 @@ interface DatabaseTestSupport {
      * scenario marker, or operation defaults. When not overridden, returns
      * the default configuration.
      */
-    val dbTesterConfiguration: Configuration
+    public val dbTesterConfiguration: Configuration
         get() = Configuration.defaults()
 }

--- a/db-tester-kotest/src/main/kotlin/io/github/seijikohara/dbtester/kotest/lifecycle/KotestExpectationVerifier.kt
+++ b/db-tester-kotest/src/main/kotlin/io/github/seijikohara/dbtester/kotest/lifecycle/KotestExpectationVerifier.kt
@@ -15,11 +15,11 @@ import java.util.ServiceLoader
  * @see ExpectationSupport
  * @see KotestPreparationExecutor
  */
-class KotestExpectationVerifier internal constructor(
+public class KotestExpectationVerifier internal constructor(
     private val support: ExpectationSupport,
 ) {
     /** Creates a new expectation verifier with a support loaded via ServiceLoader. */
-    constructor() : this(loadExpectationSupport())
+    public constructor() : this(loadExpectationSupport())
 
     /**
      * Verifies the database state against expected datasets.
@@ -32,13 +32,13 @@ class KotestExpectationVerifier internal constructor(
      * @param expectedDataSet the ExpectedDataSet annotation containing row ordering and retry settings
      * @throws AssertionError if the database state does not match the expected state after retries
      */
-    fun verify(
+    public fun verify(
         context: TestContext,
         expectedDataSet: ExpectedDataSet,
     ): Unit = support.verify(context, expectedDataSet)
 
     /** Companion object containing factory methods. */
-    companion object {
+    private companion object {
         private fun loadExpectationSupport(): ExpectationSupport =
             ServiceLoader
                 .load(ExpectationSupport::class.java)

--- a/db-tester-kotest/src/main/kotlin/io/github/seijikohara/dbtester/kotest/lifecycle/KotestExportExecutor.kt
+++ b/db-tester-kotest/src/main/kotlin/io/github/seijikohara/dbtester/kotest/lifecycle/KotestExportExecutor.kt
@@ -16,11 +16,11 @@ import java.util.ServiceLoader
  * @see KotestPreparationExecutor
  * @see KotestExpectationVerifier
  */
-class KotestExportExecutor internal constructor(
+public class KotestExportExecutor internal constructor(
     private val support: ExportSupport,
 ) {
     /** Creates a new export executor with a support loaded via ServiceLoader. */
-    constructor() : this(loadExportSupport())
+    public constructor() : this(loadExportSupport())
 
     /**
      * Exports the current database state to files.
@@ -28,13 +28,13 @@ class KotestExportExecutor internal constructor(
      * @param context the test context containing configuration and registry
      * @param exportDataSet the ExportDataSet annotation containing export settings
      */
-    fun export(
+    public fun export(
         context: TestContext,
         exportDataSet: ExportDataSet,
     ): Unit = support.export(context, exportDataSet)
 
     /** Companion object containing factory methods. */
-    companion object {
+    private companion object {
         private fun loadExportSupport(): ExportSupport =
             ServiceLoader
                 .load(ExportSupport::class.java)

--- a/db-tester-kotest/src/main/kotlin/io/github/seijikohara/dbtester/kotest/lifecycle/KotestPreparationExecutor.kt
+++ b/db-tester-kotest/src/main/kotlin/io/github/seijikohara/dbtester/kotest/lifecycle/KotestPreparationExecutor.kt
@@ -14,11 +14,11 @@ import java.util.ServiceLoader
  * @property support the preparation support
  * @see PreparationSupport
  */
-class KotestPreparationExecutor internal constructor(
+public class KotestPreparationExecutor internal constructor(
     private val support: PreparationSupport,
 ) {
     /** Creates a new preparation executor with a support loaded via ServiceLoader. */
-    constructor() : this(loadPreparationSupport())
+    public constructor() : this(loadPreparationSupport())
 
     /**
      * Executes the preparation phase.
@@ -29,13 +29,13 @@ class KotestPreparationExecutor internal constructor(
      * @param context the test context containing configuration and registry
      * @param dataSet the DataSet annotation specifying the operation to perform
      */
-    fun execute(
+    public fun execute(
         context: TestContext,
         dataSet: DataSet,
     ): Unit = support.execute(context, dataSet)
 
     /** Companion object containing factory methods. */
-    companion object {
+    private companion object {
         private fun loadPreparationSupport(): PreparationSupport =
             ServiceLoader
                 .load(PreparationSupport::class.java)

--- a/db-tester-kotest/src/main/kotlin/io/github/seijikohara/dbtester/kotest/spi/KotestScenarioNameResolver.kt
+++ b/db-tester-kotest/src/main/kotlin/io/github/seijikohara/dbtester/kotest/spi/KotestScenarioNameResolver.kt
@@ -23,9 +23,9 @@ import java.lang.reflect.Method
  * @see ScenarioNameResolver
  * @see AnnotationSpec
  */
-class KotestScenarioNameResolver : ScenarioNameResolver {
+public class KotestScenarioNameResolver : ScenarioNameResolver {
     /** Companion object containing class-level constants. */
-    companion object {
+    private companion object {
         /** Priority for Kotest resolver, higher than default JUnit resolver. */
         private const val KOTEST_PRIORITY = 100
     }

--- a/docs/specs/assertion-api.md
+++ b/docs/specs/assertion-api.md
@@ -313,7 +313,7 @@ then use `with*()` methods to customize.
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
-| `tableOrderingStrategy` | `TableOrderingStrategy` | `AUTO` | Strategy for determining table processing order |
+| `tableOrdering` | `TableOrderingStrategy` | `AUTO` | Strategy for determining table processing order |
 | `transactionMode` | `TransactionMode` | `SINGLE_TRANSACTION` | Transaction behavior mode |
 | `queryTimeout` | `@Nullable Duration` | `null` | Query timeout; null uses driver default |
 | `batchSize` | `int` | `0` | Rows per batch; zero means single-batch execution |
@@ -322,7 +322,7 @@ then use `with*()` methods to customize.
 
 | Method | Description |
 |--------|-------------|
-| `withTableOrderingStrategy(TableOrderingStrategy)` | Returns a new instance with the specified strategy |
+| `withTableOrdering(TableOrderingStrategy)` | Returns a new instance with the specified strategy |
 | `withTransactionMode(TransactionMode)` | Returns a new instance with the specified mode |
 | `withQueryTimeout(@Nullable Duration)` | Returns a new instance with the specified timeout |
 | `withBatchSize(int)` | Returns a new instance with the specified batch size |
@@ -335,7 +335,7 @@ var config = PreparationConfig.standard();
 
 // Custom configuration
 var config = PreparationConfig.standard()
-    .withTableOrderingStrategy(TableOrderingStrategy.FOREIGN_KEY)
+    .withTableOrdering(TableOrderingStrategy.FOREIGN_KEY)
     .withTransactionMode(TransactionMode.AUTO_COMMIT)
     .withBatchSize(500);
 ```

--- a/docs/specs/exceptions.md
+++ b/docs/specs/exceptions.md
@@ -115,7 +115,6 @@ This table lists the default values for all configurable attributes.
 | `@DataSetSource` | `columnStrategies` | `{}` | Default STRICT for all columns |
 | `@ColumnStrategy` | `strategy` | `STRICT` | Exact match |
 | `@ColumnStrategy` | `pattern` | `""` | No pattern |
-| `@ColumnStrategy` | `options` | `""` | No options |
 
 **Magic Value: `-1`**
 

--- a/docs/specs/ja/assertion-api.md
+++ b/docs/specs/ja/assertion-api.md
@@ -301,7 +301,7 @@ DatabasePreparation.execute(dataSource, TableSet.of(users), Operation.CLEAN_INSE
 
 | プロパティ | 型 | デフォルト | 説明 |
 |-----------|-----|----------|------|
-| `tableOrderingStrategy` | `TableOrderingStrategy` | `AUTO` | テーブル処理順序を決定する戦略 |
+| `tableOrdering` | `TableOrderingStrategy` | `AUTO` | テーブル処理順序を決定する戦略 |
 | `transactionMode` | `TransactionMode` | `SINGLE_TRANSACTION` | トランザクション動作モード |
 | `queryTimeout` | `@Nullable Duration` | `null` | クエリタイムアウト。nullの場合はドライバーデフォルトを使用 |
 | `batchSize` | `int` | `0` | バッチあたりの行数。ゼロは単一バッチ実行を意味する |
@@ -310,7 +310,7 @@ DatabasePreparation.execute(dataSource, TableSet.of(users), Operation.CLEAN_INSE
 
 | メソッド | 説明 |
 |----------|------|
-| `withTableOrderingStrategy(TableOrderingStrategy)` | 指定した戦略で新しいインスタンスを返す |
+| `withTableOrdering(TableOrderingStrategy)` | 指定した戦略で新しいインスタンスを返す |
 | `withTransactionMode(TransactionMode)` | 指定したモードで新しいインスタンスを返す |
 | `withQueryTimeout(@Nullable Duration)` | 指定したタイムアウトで新しいインスタンスを返す |
 | `withBatchSize(int)` | 指定したバッチサイズで新しいインスタンスを返す |
@@ -323,7 +323,7 @@ var config = PreparationConfig.standard();
 
 // カスタム設定
 var config = PreparationConfig.standard()
-    .withTableOrderingStrategy(TableOrderingStrategy.FOREIGN_KEY)
+    .withTableOrdering(TableOrderingStrategy.FOREIGN_KEY)
     .withTransactionMode(TransactionMode.AUTO_COMMIT)
     .withBatchSize(500);
 ```

--- a/docs/specs/ja/exceptions.md
+++ b/docs/specs/ja/exceptions.md
@@ -111,7 +111,6 @@ classDiagram
 | `@DataSetSource` | `columnStrategies` | `{}` | 全カラムにデフォルトSTRICT |
 | `@ColumnStrategy` | `strategy` | `STRICT` | 完全一致 |
 | `@ColumnStrategy` | `pattern` | `""` | パターンなし |
-| `@ColumnStrategy` | `options` | `""` | オプションなし |
 
 **マジックバリュー: `-1`**
 

--- a/docs/specs/ja/spi-providers.md
+++ b/docs/specs/ja/spi-providers.md
@@ -39,7 +39,7 @@ public interface OperationProvider {
         Operation operation,
         TableSet tableSet,
         DataSource dataSource,
-        TableOrderingStrategy tableOrderingStrategy,
+        TableOrderingStrategy tableOrdering,
         TransactionMode transactionMode,
         @Nullable Duration queryTimeout,
         int batchSize);
@@ -55,7 +55,7 @@ public interface OperationProvider {
 | `operation` | `Operation` | 実行するデータベース操作 |
 | `tableSet` | `TableSet` | テーブルと行を含むテーブルセット |
 | `dataSource` | `DataSource` | コネクション用のJDBCデータソース |
-| `tableOrderingStrategy` | `TableOrderingStrategy` | テーブル処理順序の戦略 |
+| `tableOrdering` | `TableOrderingStrategy` | テーブル処理順序の戦略 |
 | `transactionMode` | `TransactionMode` | トランザクション動作モード |
 | `queryTimeout` | `@Nullable Duration` | クエリタイムアウト、またはタイムアウトなしの場合はnull |
 | `batchSize` | `int` | INSERTバッチあたりの行数（0 = 単一バッチ） |

--- a/docs/specs/spi-providers.md
+++ b/docs/specs/spi-providers.md
@@ -39,7 +39,7 @@ public interface OperationProvider {
         Operation operation,
         TableSet tableSet,
         DataSource dataSource,
-        TableOrderingStrategy tableOrderingStrategy,
+        TableOrderingStrategy tableOrdering,
         TransactionMode transactionMode,
         @Nullable Duration queryTimeout,
         int batchSize);
@@ -55,7 +55,7 @@ public interface OperationProvider {
 | `operation` | `Operation` | The database operation to execute |
 | `tableSet` | `TableSet` | The table set containing tables and rows |
 | `dataSource` | `DataSource` | The JDBC data source for connections |
-| `tableOrderingStrategy` | `TableOrderingStrategy` | Strategy for table processing order |
+| `tableOrdering` | `TableOrderingStrategy` | Strategy for table processing order |
 | `transactionMode` | `TransactionMode` | Transaction behavior mode |
 | `queryTimeout` | `@Nullable Duration` | Query timeout, or null for no timeout |
 | `batchSize` | `int` | Rows per INSERT batch (0 = single batch) |

--- a/examples/db-tester-example-junit/src/test/java/example/feature/ProgrammaticPreparationApiTest.java
+++ b/examples/db-tester-example-junit/src/test/java/example/feature/ProgrammaticPreparationApiTest.java
@@ -260,7 +260,7 @@ final class ProgrammaticPreparationApiTest {
           PreparationConfig.standard()
               .withBatchSize(2)
               .withTransactionMode(TransactionMode.AUTO_COMMIT)
-              .withTableOrderingStrategy(TableOrderingStrategy.FOREIGN_KEY);
+              .withTableOrdering(TableOrderingStrategy.FOREIGN_KEY);
 
       // When
       DatabasePreparation.cleanInsert(dataSource, tableSet, config);
@@ -372,7 +372,7 @@ final class ProgrammaticPreparationApiTest {
       final var config =
           PreparationConfig.standard()
               .withTransactionMode(TransactionMode.AUTO_COMMIT)
-              .withTableOrderingStrategy(TableOrderingStrategy.FOREIGN_KEY);
+              .withTableOrdering(TableOrderingStrategy.FOREIGN_KEY);
 
       // When
       DatabasePreparation.execute(dataSource, tableSet, Operation.CLEAN_INSERT, config);

--- a/examples/db-tester-example-kotest/src/test/kotlin/example/feature/ProgrammaticPreparationApiSpec.kt
+++ b/examples/db-tester-example-kotest/src/test/kotlin/example/feature/ProgrammaticPreparationApiSpec.kt
@@ -210,7 +210,7 @@ class ProgrammaticPreparationApiSpec :
                 .standard()
                 .withBatchSize(2)
                 .withTransactionMode(TransactionMode.AUTO_COMMIT)
-                .withTableOrderingStrategy(TableOrderingStrategy.FOREIGN_KEY)
+                .withTableOrdering(TableOrderingStrategy.FOREIGN_KEY)
 
         // When
         DatabasePreparation.cleanInsert(dataSource, tableSet, config)
@@ -308,7 +308,7 @@ class ProgrammaticPreparationApiSpec :
             PreparationConfig
                 .standard()
                 .withTransactionMode(TransactionMode.AUTO_COMMIT)
-                .withTableOrderingStrategy(TableOrderingStrategy.FOREIGN_KEY)
+                .withTableOrdering(TableOrderingStrategy.FOREIGN_KEY)
 
         // When
         DatabasePreparation.execute(dataSource, tableSet, Operation.CLEAN_INSERT, config)

--- a/examples/db-tester-example-spock/src/test/groovy/example/feature/ProgrammaticPreparationApiSpec.groovy
+++ b/examples/db-tester-example-spock/src/test/groovy/example/feature/ProgrammaticPreparationApiSpec.groovy
@@ -179,7 +179,7 @@ class ProgrammaticPreparationApiSpec extends Specification implements DatabaseTe
 		def config = PreparationConfig.standard()
 				.withBatchSize(2)
 				.withTransactionMode(TransactionMode.AUTO_COMMIT)
-				.withTableOrderingStrategy(TableOrderingStrategy.FOREIGN_KEY)
+				.withTableOrdering(TableOrderingStrategy.FOREIGN_KEY)
 
 		when: 'executing cleanInsert with custom configuration'
 		DatabasePreparation.cleanInsert(dataSource, tableSet, config)
@@ -254,7 +254,7 @@ class ProgrammaticPreparationApiSpec extends Specification implements DatabaseTe
 
 		def config = PreparationConfig.standard()
 				.withTransactionMode(TransactionMode.AUTO_COMMIT)
-				.withTableOrderingStrategy(TableOrderingStrategy.FOREIGN_KEY)
+				.withTableOrdering(TableOrderingStrategy.FOREIGN_KEY)
 
 		when: 'executing CLEAN_INSERT with explicit configuration'
 		DatabasePreparation.execute(dataSource, tableSet, Operation.CLEAN_INSERT, config)


### PR DESCRIPTION
## Summary

Closes three gaps surfaced by the adversarial verification of the v1.0-readiness
cleanup that were neither done nor explicitly deferred.

## Changes

- **API naming (breaking)**: unify the table-ordering accessor on `tableOrdering`.
  `PreparationConfig.tableOrderingStrategy()` → `tableOrdering()` and
  `withTableOrderingStrategy(...)` → `withTableOrdering(...)`, matching the
  annotations (`@DataSet`/`@ExpectedDataSet`) and `ExpectationContext`. The
  `OperationProvider` SPI parameter and internal call sites are renamed for
  consistency. Docs (`assertion-api`, `spi-providers`, EN+JA) updated.
- **Explicit API mode**: enable Kotlin `explicitApi()` in the kotlin-library
  convention plugin and make the published Kotest API surface explicit
  (`public` on classes/members; `private companion object` where the companion
  held only private members).
- **Docs leftover**: drop the removed `@ColumnStrategy` `options` attribute from
  the exception default-value tables (EN+JA).

The release-gate gap (maven-central required reviewer) was intentionally left out
of scope per maintainer decision; it requires repository environment settings.

## Verification

All 10 published modules build green (`build` for each), including Error Prone,
NullAway, Checkstyle, CodeNarc, Spotless/ktlint, JaCoCo, Dokka/Groovydoc, and
verifyNullMarkedPackages. The three example modules' test sources compile against
the renamed API.