### PR TITLE
ci: deduplicate and serialize test runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,16 @@ name: Test
 
 on:
   push:
+    branches: [main]
   pull_request:
+    branches: [main]
+
+# Serialize per branch. The integration tests start Oracle, MySQL, PostgreSQL,
+# SQL Server and Neo4j containers per example module, so overlapping runs
+# contend for runner resources and push the Oracle startup past its timeout.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Restrict the `push` trigger to `main` and add a concurrency group, so each pull request runs the test matrix once instead of twice.

## Problem

`test.yml` triggers on `push` with no branch filter and on `pull_request`, so
every pull request ran the `['21', '25']` Java matrix twice against the same
commit — four jobs where two suffice.

That doubling has a real cost here. Each example module
(`db-tester-example-junit`, `-spock`, `-kotest`) starts its own Oracle, MySQL,
PostgreSQL, SQL Server and Neo4j containers, and `org.gradle.parallel=true`
runs them concurrently. Under the doubled load Oracle intermittently missed its
three minute startup timeout:

```
OracleIntegrationSpec > initializationError FAILED
    org.testcontainers.containers.ContainerLaunchException at GenericContainer.java:346
        Caused by: org.rnorth.ducttape.RetryCountExceededException at Unreliables.java:88
            Caused by: org.testcontainers.containers.ContainerLaunchException at LogMessageWaitStrategy.java:47
```

This is demonstrably a resource problem rather than a code problem: on both
#370 and #371 the `push` run and the `pull_request` run of the **same commit**
disagreed, with the push run passing and the pull_request run failing. The
matrix leg that fails also varies between runs (Java 21 on one, Java 25 on the
other), which rules out a JDK-specific cause.

## Changes

### Fixed

- `.github/workflows/test.yml`: `on.push` and `on.pull_request` limited to `main`

### Added

- `.github/workflows/test.yml`: concurrency group keyed on the branch, with `cancel-in-progress`

With the push trigger limited to `main`, the concurrency group cannot collide
across the two event types, so it only supersedes an older run of the same
branch.

## Effect

- CI minutes per pull request are halved
- Container contention drops, reducing the Oracle startup flake

This does not eliminate the flake outright. If it persists, the next step is
raising `withStartupTimeout` on the Oracle containers or serializing the example
module tests.

## Test Plan

- [x] `test.yml` parses as valid YAML; triggers resolve to `{push: {branches: [main]}, pull_request: {branches: [main]}}`
- [ ] CI on this pull request produces exactly one `Test` run with two matrix legs